### PR TITLE
Remove the hidden string in secret field

### DIFF
--- a/kit/score/parse.go
+++ b/kit/score/parse.go
@@ -17,9 +17,6 @@ var (
 	ErrSuppressedSecret = errors.New("Error suppressed to avoid revealing secret")
 )
 
-// hiddenSecret is used to replace the global secret when parsing.
-const hiddenSecret = "hidden"
-
 // Parse returns a score object for the provided JSON string s
 // which contains secret.
 func Parse(s, secret string) (*Score, error) {
@@ -44,7 +41,7 @@ func Parse(s, secret string) (*Score, error) {
 // IsValid returns an error if the score object is invalid.
 // Otherwise, nil is returned.
 // If the given secret matches the score's secret value,
-// the Secret field is overwritten with the string "hidden".
+// the Secret field is redacted with the empty string "".
 func (sc *Score) IsValid(secret string) error {
 	tName := sc.GetTestName()
 	if tName == "" {
@@ -62,7 +59,7 @@ func (sc *Score) IsValid(secret string) error {
 	if sc.Secret != secret {
 		return errMsg(tName, ErrSecret.Error())
 	}
-	sc.Secret = hiddenSecret // overwrite secret
+	sc.Secret = "" // redact the secret session key
 	return nil
 }
 

--- a/kit/score/parse_test.go
+++ b/kit/score/parse_test.go
@@ -135,7 +135,8 @@ var scoreValidTests = []struct {
 func TestScoreIsValid(t *testing.T) {
 	for _, test := range scoreValidTests {
 		t.Run(test.name, func(t *testing.T) {
-			for _, sc := range test.in {
+			// clone the test.in scores to allow repeatable tests
+			for _, sc := range clone(test.in) {
 				err := sc.IsValid(theSecret)
 				if err != nil {
 					if !strings.Contains(err.Error(), test.want.Error()) {
@@ -147,4 +148,24 @@ func TestScoreIsValid(t *testing.T) {
 			}
 		})
 	}
+}
+
+// clone returns a copy of the src slice pointing to different score objects.
+// This only necessary for testing purposes, when we want to run tests repeatedly
+// with the -count argument to check for non-deterministic behavior.
+func clone(src []*score.Score) []*score.Score {
+	dst := make([]*score.Score, len(src))
+	for i, sc := range src {
+		if sc == nil {
+			continue
+		}
+		dst[i] = &score.Score{
+			Secret:   sc.Secret,
+			TestName: sc.TestName,
+			Score:    sc.Score,
+			MaxScore: sc.MaxScore,
+			Weight:   sc.Weight,
+		}
+	}
+	return dst
 }

--- a/kit/score/registry_example_test.go
+++ b/kit/score/registry_example_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/autograde/quickfeed/kit/score"
@@ -71,7 +72,16 @@ func TestFibonacciMax(t *testing.T) {
 	}
 }
 
+var (
+	once sync.Once
+	ran  bool
+)
+
 func TestFibonacciMin(t *testing.T) {
+	if ran {
+		// This test cannot be run more than once
+		t.SkipNow()
+	}
 	sc := scoreRegistry.Min()
 	for _, ft := range fibonacciTests {
 		out := fibonacci(ft.in)
@@ -85,6 +95,7 @@ func TestFibonacciMin(t *testing.T) {
 	if sc.TestName != t.Name() {
 		t.Errorf("TestName=%s, expected %s", sc.TestName, t.Name())
 	}
+	once.Do(func() { ran = true })
 }
 
 func TestFibonacciSubTest(t *testing.T) {


### PR DESCRIPTION
This removes the 'hidden' string used to redact the secret replacing it with the empty string.

This commit also adds more tests that appeared to give only 99 % score.
But this could not be reproduced with the input added in this test.

Fixes #547

