### PR TITLE
Support scoring Benchmark functions

### DIFF
--- a/kit/score/registry_bench_test.go
+++ b/kit/score/registry_bench_test.go
@@ -1,0 +1,59 @@
+package score_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+func fibonacciIter(n uint) uint {
+	a, b := uint(0), uint(1)
+	// Iterate until desired position in sequence.
+	for i := 0; i < int(n); i++ {
+		temp := a
+		a = b
+		b = temp + a
+	}
+	return a
+}
+
+func init() {
+	scoreRegistry.Add(BenchmarkFibonacci, len(fibonacciTests), 20)
+	// scoreRegistry.Add(TestFibonacciMin, len(fibonacciTests), 20)
+	// for _, ft := range fibonacciTests {
+	// 	scoreRegistry.AddSub(TestFibonacciSubTest, subTestName("Max", ft.in), 1, 1)
+	// }
+	// for _, ft := range fibonacciTests {
+	// 	scoreRegistry.AddSub(TestFibonacciSubTest, subTestName("Min", ft.in), 1, 1)
+	// }
+}
+
+// Q for slack or golang nuts:
+// Is there a way to access testing.BenchmarkResult after a benchmark has been executed (from within code)
+//
+// Not clear how to make further progress on this at the moment.
+// Seems like the best approach is to shell out a go test -bench command and parse the benchmark results
+// 
+
+func BenchmarkFibonacci(b *testing.B) {
+	sc := scoreRegistry.Max()
+	for _, ft := range fibonacciTests {
+		b.Run(fmt.Sprintf("iterative/n=%d", ft.in), func(b *testing.B) {
+			var out uint
+			for i := 0; i < b.N; i++ {
+				out = fibonacciIter(ft.in)
+			}
+			if out != ft.want {
+				sc.Dec()
+			}
+		})
+		b.Run(fmt.Sprintf("recursive/n=%d", ft.in), func(b *testing.B) {
+			var out uint
+			for i := 0; i < b.N; i++ {
+				out = fibonacci(ft.in)
+			}
+			if out != ft.want {
+				sc.Dec()
+			}
+		})
+	}
+}

--- a/kit/score/registry_bench_test.go
+++ b/kit/score/registry_bench_test.go
@@ -32,7 +32,7 @@ func init() {
 //
 // Not clear how to make further progress on this at the moment.
 // Seems like the best approach is to shell out a go test -bench command and parse the benchmark results
-// 
+//
 
 func BenchmarkFibonacci(b *testing.B) {
 	sc := scoreRegistry.Max()

--- a/kit/score/registry_test.go
+++ b/kit/score/registry_test.go
@@ -13,8 +13,8 @@ func fib() {}
 func TestTestNamePanic(t *testing.T) {
 	const (
 		notFunc     = "not a function: "
-		notTestFunc = "not a test function: "
-		missingT    = "test function missing *testing.T argument: "
+		notTestFunc = "not a test or benchmark function: "
+		missingT    = "function missing *testing.T or *testing.B argument: "
 	)
 	tests := []struct {
 		typ    string

--- a/kit/score/score.go
+++ b/kit/score/score.go
@@ -77,7 +77,7 @@ func (s *Score) RelativeScore() string {
 // Note that, if subtests are used, each subtest must defer call the PanicHandler method
 // to ensure that panics are caught and handled appropriately.
 // The msg parameter is optional, and will be printed in case of a panic.
-func (s *Score) Print(t *testing.T, msg ...string) {
+func (s *Score) Print(t testing.TB, msg ...string) {
 	if r := recover(); r != nil {
 		s.fail(t)
 		printPanicMessage(s.TestName, msg[0], r)
@@ -96,7 +96,7 @@ func (s *Score) Print(t *testing.T, msg ...string) {
 //   defer s.PanicHandler(t)
 //
 // The msg parameter is optional, and will be printed in case of a panic.
-func (s *Score) PanicHandler(t *testing.T, msg ...string) {
+func (s *Score) PanicHandler(t testing.TB, msg ...string) {
 	if r := recover(); r != nil {
 		s.fail(t)
 		printPanicMessage(t.Name(), msg[0], r)
@@ -104,7 +104,7 @@ func (s *Score) PanicHandler(t *testing.T, msg ...string) {
 }
 
 // fail resets the score to zero and fails the provided test.
-func (s *Score) fail(t *testing.T) {
+func (s *Score) fail(t testing.TB) {
 	// reset score for panicked test functions
 	s.Score = 0
 	// fail the test


### PR DESCRIPTION
- Allow testing.TB instead of testing.T in Score API
- Allow also testing.B in Add and AddSub methods

Fixes #553.

