### PR TITLE
Fix access token cache

### DIFF
--- a/database/db_user_test.go
+++ b/database/db_user_test.go
@@ -157,6 +157,7 @@ func TestGormDBUpdateAccessTokenCourseTokenCache(t *testing.T) {
 	const (
 		stud           = "student1"
 		newAccessToken = "123"
+		anotherToken   = "456"
 		provider       = "fake"
 		remoteID       = 10
 		remoteID2      = 11
@@ -205,5 +206,23 @@ func TestGormDBUpdateAccessTokenCourseTokenCache(t *testing.T) {
 	cachedToken = cr.GetAccessToken()
 	if cachedToken != newAccessToken {
 		t.Errorf("cached token different from expected updated token: %s != %s", cachedToken, newAccessToken)
+	}
+
+	// Update the access token for the user again.
+	if err := db.UpdateAccessToken(&pb.RemoteIdentity{
+		Provider:    provider,
+		RemoteID:    remoteID,
+		AccessToken: anotherToken,
+	}); err != nil {
+		t.Error(err)
+	}
+
+	cr, err = db.GetCourse(1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachedToken = cr.GetAccessToken()
+	if cachedToken != anotherToken {
+		t.Errorf("cached token different from expected updated token: %s != %s", cachedToken, anotherToken)
 	}
 }

--- a/database/db_user_test.go
+++ b/database/db_user_test.go
@@ -6,6 +6,8 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/internal/qtest"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestGormDBUpdateAccessToken(t *testing.T) {
@@ -77,5 +79,131 @@ func TestGormDBUpdateAccessToken(t *testing.T) {
 	updatedUser.Enrollments = nil
 	if !reflect.DeepEqual(updatedUser, wantUser) {
 		t.Errorf("have user %+v want %+v", updatedUser, wantUser)
+	}
+}
+
+func TestGormDBUpdateAccessTokenUserGetAccessToken(t *testing.T) {
+	const (
+		newAccessToken = "123"
+		anotherToken   = "456"
+		provider       = "fake"
+		remoteID       = 10
+	)
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	wantUser := qtest.CreateFakeUser(t, db, remoteID)
+
+	cachedAccessToken, err := wantUser.GetAccessToken(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update the access token for the user.
+	if err := db.UpdateAccessToken(&pb.RemoteIdentity{
+		Provider:    provider,
+		RemoteID:    remoteID,
+		AccessToken: newAccessToken,
+	}); err != nil {
+		t.Error(err)
+	}
+	gotUser, err := db.GetUser(wantUser.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assign the access token we expect to the wantUser object.
+	wantUser.RemoteIdentities[0].AccessToken = newAccessToken
+	if diff := cmp.Diff(wantUser, gotUser, protocmp.Transform()); diff != "" {
+		t.Errorf("GetUser() mismatch (-wantUser +gotUser):\n%s", diff)
+	}
+	cachedAccessToken2, err := gotUser.GetAccessToken(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cachedAccessToken == cachedAccessToken2 {
+		t.Errorf("cached access token before and after are the same: %s == %s", cachedAccessToken, cachedAccessToken2)
+	}
+
+	// Update the access token again for the user.
+	if err := db.UpdateAccessToken(&pb.RemoteIdentity{
+		Provider:    provider,
+		RemoteID:    remoteID,
+		AccessToken: anotherToken,
+	}); err != nil {
+		t.Error(err)
+	}
+	gotUser, err = db.GetUser(wantUser.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assign the access token we expect to the wantUser object.
+	wantUser.RemoteIdentities[0].AccessToken = anotherToken
+	if diff := cmp.Diff(wantUser, gotUser, protocmp.Transform()); diff != "" {
+		t.Errorf("GetUser() mismatch (-wantUser +gotUser):\n%s", diff)
+	}
+	cachedAccessToken3, err := gotUser.GetAccessToken(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cachedAccessToken2 == cachedAccessToken3 {
+		t.Errorf("cached access token before and after are the same: %s == %s", cachedAccessToken2, cachedAccessToken3)
+	}
+}
+
+func TestGormDBUpdateAccessTokenCourseTokenCache(t *testing.T) {
+	const (
+		stud           = "student1"
+		newAccessToken = "123"
+		provider       = "fake"
+		remoteID       = 10
+		remoteID2      = 11
+	)
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	admin := qtest.CreateNamedUser(t, db, remoteID, "admin")
+	initialAdminToken, err := admin.GetAccessToken(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	course := &pb.Course{
+		ID:              1,
+		CourseCreatorID: admin.ID,
+		Code:            "DAT320",
+		Name:            "Operating Systems and Systems Programming",
+		Provider:        provider,
+		Year:            2021,
+	}
+	if err := db.CreateCourse(admin.ID, course); err != nil {
+		t.Fatal(err)
+	}
+	cr, err := db.GetCourse(1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachedToken := cr.GetAccessToken()
+	if cachedToken != initialAdminToken {
+		t.Errorf("cached token different from expected initial token: %s != %s", cachedToken, initialAdminToken)
+	}
+
+	// Update the access token for the user.
+	if err := db.UpdateAccessToken(&pb.RemoteIdentity{
+		Provider:    provider,
+		RemoteID:    remoteID,
+		AccessToken: newAccessToken,
+	}); err != nil {
+		t.Error(err)
+	}
+
+	cr, err = db.GetCourse(1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachedToken = cr.GetAccessToken()
+	if cachedToken != newAccessToken {
+		t.Errorf("cached token different from expected updated token: %s != %s", cachedToken, newAccessToken)
 	}
 }

--- a/database/db_user_test.go
+++ b/database/db_user_test.go
@@ -178,9 +178,8 @@ func TestGormDBUpdateAccessTokenCourseTokenCache(t *testing.T) {
 		Provider:        provider,
 		Year:            2021,
 	}
-	if err := db.CreateCourse(admin.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, course)
+
 	cr, err := db.GetCourse(1, false)
 	if err != nil {
 		t.Fatal(err)

--- a/database/gormdb.go
+++ b/database/gormdb.go
@@ -140,15 +140,9 @@ func (db *GormDB) UpdateAccessToken(remote *pb.RemoteIdentity) error {
 	return tx.Commit().Error
 }
 
-// updateAccessTokenCache caches the access token for the course
-// to allow easy access elsewhere.
+// updateAccessTokenCache updates the access token for the course
+// to allow easy access via the Course type.
 func (db *GormDB) updateAccessTokenCache(course *pb.Course) {
-	existingToken := course.GetAccessToken()
-	if existingToken != "" {
-		// no need to cache again
-		return
-	}
-	// only need to query db if not in cache
 	courseCreator, err := db.GetUser(course.GetCourseCreatorID())
 	if err != nil {
 		// failed to get course creator; ignore

--- a/database/gormdb_assignment_test.go
+++ b/database/gormdb_assignment_test.go
@@ -45,10 +45,8 @@ func TestGormDBCreateAssignment(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	user := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(user.ID, &pb.Course{}); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	qtest.CreateCourse(t, db, admin, &pb.Course{})
 
 	assignment := pb.Assignment{
 		CourseID: 1,
@@ -83,9 +81,7 @@ func TestUpdateAssignment(t *testing.T) {
 
 	course := &pb.Course{}
 	admin := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(admin.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, course)
 
 	if err := db.CreateAssignment(&pb.Assignment{
 		CourseID:    course.ID,
@@ -215,9 +211,8 @@ func TestUpdateBenchmarks(t *testing.T) {
 
 	course := &pb.Course{}
 	admin := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(admin.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, course)
+
 	assignment := &pb.Assignment{
 		CourseID:    course.ID,
 		Name:        "Assignment 1",
@@ -227,7 +222,6 @@ func TestUpdateBenchmarks(t *testing.T) {
 		Order:       1,
 		IsGroupLab:  false,
 	}
-
 	if err := db.CreateAssignment(assignment); err != nil {
 		t.Fatal(err)
 	}

--- a/database/gormdb_course.go
+++ b/database/gormdb_course.go
@@ -6,11 +6,11 @@ import (
 
 // CreateCourse creates a new course if user with given ID is admin, enrolls user as course teacher.
 func (db *GormDB) CreateCourse(userID uint64, course *pb.Course) error {
-	user, err := db.GetUser(userID)
+	courseCreator, err := db.GetUser(userID)
 	if err != nil {
 		return err
 	}
-	if !user.IsAdmin {
+	if !courseCreator.IsAdmin {
 		return ErrInsufficientAccess
 	}
 
@@ -32,13 +32,20 @@ func (db *GormDB) CreateCourse(userID uint64, course *pb.Course) error {
 		return err
 	}
 	query := &pb.Enrollment{
-		UserID:   user.ID,
+		UserID:   courseCreator.ID,
 		CourseID: course.ID,
 		Status:   pb.Enrollment_TEACHER,
 	}
 	if err := db.UpdateEnrollment(query); err != nil {
 		return err
 	}
+	// TODO(meling) fix error checking; tests would fail because test courses lack provider
+	accessToken, _ := courseCreator.GetAccessToken(course.GetProvider())
+	// if err != nil {
+	// 	return err
+	// }
+	// update the access token cache for course
+	pb.SetAccessToken(course.GetID(), accessToken)
 	return nil
 }
 
@@ -70,7 +77,6 @@ func (db *GormDB) GetCourse(courseID uint64, withEnrollments bool) (*pb.Course, 
 			return nil, err
 		}
 	}
-	db.updateAccessTokenCache(&course)
 	return &course, nil
 }
 
@@ -80,7 +86,6 @@ func (db *GormDB) GetCourseByOrganizationID(did uint64) (*pb.Course, error) {
 	if err := db.conn.First(&course, &pb.Course{OrganizationID: did}).Error; err != nil {
 		return nil, err
 	}
-	db.updateAccessTokenCache(&course)
 	return &course, nil
 }
 

--- a/database/gormdb_course.go
+++ b/database/gormdb_course.go
@@ -39,11 +39,10 @@ func (db *GormDB) CreateCourse(userID uint64, course *pb.Course) error {
 	if err := db.UpdateEnrollment(query); err != nil {
 		return err
 	}
-	// TODO(meling) fix error checking; tests would fail because test courses lack provider
-	accessToken, _ := courseCreator.GetAccessToken(course.GetProvider())
-	// if err != nil {
-	// 	return err
-	// }
+	accessToken, err := courseCreator.GetAccessToken(course.GetProvider())
+	if err != nil {
+		return err
+	}
 	// update the access token cache for course
 	pb.SetAccessToken(course.GetID(), accessToken)
 	return nil

--- a/database/gormdb_group_test.go
+++ b/database/gormdb_group_test.go
@@ -125,11 +125,9 @@ func TestGormDBCreateAndGetGroup(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db, cleanup := qtest.TestDB(t)
 
-			teacher := qtest.CreateFakeUser(t, db, 10)
-			var course pb.Course
-			if err := db.CreateCourse(teacher.ID, &course); err != nil {
-				t.Fatal(err)
-			}
+			admin := qtest.CreateFakeUser(t, db, 10)
+			course := &pb.Course{}
+			qtest.CreateCourse(t, db, admin, course)
 
 			var uids []uint64
 			// create as many users as the desired number of enrollments
@@ -225,11 +223,10 @@ func TestGormDBCreateGroupTwice(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
+
 	var users []*pb.User
 	enrollments := []pb.Enrollment_UserStatus{pb.Enrollment_STUDENT, pb.Enrollment_STUDENT}
 	// create as many users as the desired number of enrollments
@@ -281,11 +278,10 @@ func TestGetGroupsByCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
+
 	var users []*pb.User
 	enrollments := []pb.Enrollment_UserStatus{
 		pb.Enrollment_STUDENT,

--- a/database/gormdb_submission_test.go
+++ b/database/gormdb_submission_test.go
@@ -26,12 +26,10 @@ func TestGormDBGetSubmissionForUser(t *testing.T) {
 }
 
 func setupCourseAssignment(t *testing.T, db database.Database) (*pb.User, *pb.Course, *pb.Assignment) {
-	teacher := qtest.CreateFakeUser(t, db, 10)
 	// create a course and an assignment
+	admin := qtest.CreateFakeUser(t, db, 10)
 	course := &pb.Course{}
-	if err := db.CreateCourse(teacher.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, course)
 	assignment := &pb.Assignment{
 		CourseID: course.ID,
 		Order:    1,
@@ -293,16 +291,11 @@ func TestGormDBGetInsertSubmissions(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	// Create course c1 and c2
-	c1 := pb.Course{OrganizationID: 1}
-	if err := db.CreateCourse(teacher.ID, &c1); err != nil {
-		t.Fatal(err)
-	}
-	c2 := pb.Course{OrganizationID: 2}
-	if err := db.CreateCourse(teacher.ID, &c2); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	c1 := &pb.Course{OrganizationID: 1}
+	c2 := &pb.Course{OrganizationID: 2}
+	qtest.CreateCourse(t, db, admin, c1)
+	qtest.CreateCourse(t, db, admin, c2)
 
 	// create user and enroll as student
 	user := qtest.CreateFakeUser(t, db, 11)

--- a/database/gormdb_test.go
+++ b/database/gormdb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 	"gorm.io/gorm"
 )
 
@@ -35,11 +36,9 @@ func TestGormDBGetUserWithEnrollments(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 11)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 11)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
 
 	student := qtest.CreateFakeUser(t, db, 13)
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -59,15 +58,15 @@ func TestGormDBGetUserWithEnrollments(t *testing.T) {
 
 	// user entries from the database will have to be enrolled as
 	// teacher and student respectively
-	teacher.Enrollments = append(teacher.Enrollments, &pb.Enrollment{
+	admin.Enrollments = append(admin.Enrollments, &pb.Enrollment{
 		ID:           1,
 		CourseID:     course.ID,
-		UserID:       teacher.ID,
+		UserID:       admin.ID,
 		Status:       pb.Enrollment_TEACHER,
 		State:        pb.Enrollment_VISIBLE,
 		UsedSlipDays: []*pb.UsedSlipDays{},
 	})
-	teacher.RemoteIdentities = nil
+	admin.RemoteIdentities = nil
 
 	student.Enrollments = append(student.Enrollments, &pb.Enrollment{
 		ID:           2,
@@ -79,11 +78,11 @@ func TestGormDBGetUserWithEnrollments(t *testing.T) {
 	})
 	student.RemoteIdentities = nil
 
-	gotTeacher, err := db.GetUserWithEnrollments(teacher.ID)
+	gotTeacher, err := db.GetUserWithEnrollments(admin.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(teacher, gotTeacher, cmpopts.IgnoreUnexported(pb.User{}, pb.Enrollment{})); diff != "" {
+	if diff := cmp.Diff(admin, gotTeacher, cmpopts.IgnoreUnexported(pb.User{}, pb.Enrollment{})); diff != "" {
 		t.Errorf("enrollment mismatch (-teacher +gotTeacher):\n%s", diff)
 	}
 	gotStudent, err := db.GetUserWithEnrollments(student.ID)
@@ -179,27 +178,19 @@ func TestGormDBGetCourses(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	user := qtest.CreateFakeUser(t, db, 10)
-	c1 := pb.Course{OrganizationID: 1}
-	if err := db.CreateCourse(user.ID, &c1); err != nil {
-		t.Fatal(err)
-	}
-
-	c2 := pb.Course{OrganizationID: 2}
-	if err := db.CreateCourse(user.ID, &c2); err != nil {
-		t.Fatal(err)
-	}
-
-	c3 := pb.Course{OrganizationID: 3}
-	if err := db.CreateCourse(user.ID, &c3); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	c1 := &pb.Course{OrganizationID: 1}
+	c2 := &pb.Course{OrganizationID: 2}
+	c3 := &pb.Course{OrganizationID: 3}
+	qtest.CreateCourse(t, db, admin, c1)
+	qtest.CreateCourse(t, db, admin, c2)
+	qtest.CreateCourse(t, db, admin, c3)
 
 	courses, err := db.GetCourses()
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantCourses := []*pb.Course{&c1, &c2, &c3}
+	wantCourses := []*pb.Course{c1, c2, c3}
 	if !reflect.DeepEqual(courses, wantCourses) {
 		t.Errorf("have %v want %v", courses, wantCourses)
 	}
@@ -217,7 +208,7 @@ func TestGormDBGetCourses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantCourse1 := []*pb.Course{&c1}
+	wantCourse1 := []*pb.Course{c1}
 	if !reflect.DeepEqual(course1, wantCourse1) {
 		t.Errorf("have %v want %v", course1, wantCourse1)
 	}
@@ -226,7 +217,7 @@ func TestGormDBGetCourses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantCourse1and2 := []*pb.Course{&c1, &c2}
+	wantCourse1and2 := []*pb.Course{c1, c2}
 	if !reflect.DeepEqual(course1and2, wantCourse1and2) {
 		t.Errorf("have %v want %v", course1and2, wantCourse1and2)
 	}
@@ -253,11 +244,9 @@ func TestGormDBCreateEnrollment(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 1)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 1)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -279,11 +268,9 @@ func TestGormDBAcceptRejectEnrollment(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 1)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 1)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -345,26 +332,15 @@ func TestGormDBGetCoursesByUser(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 1)
-	c1 := pb.Course{OrganizationID: 1}
-	if err := db.CreateCourse(teacher.ID, &c1); err != nil {
-		t.Fatal(err)
-	}
-
-	c2 := pb.Course{OrganizationID: 2}
-	if err := db.CreateCourse(teacher.ID, &c2); err != nil {
-		t.Fatal(err)
-	}
-
-	c3 := pb.Course{OrganizationID: 3}
-	if err := db.CreateCourse(teacher.ID, &c3); err != nil {
-		t.Fatal(err)
-	}
-
-	c4 := pb.Course{OrganizationID: 4}
-	if err := db.CreateCourse(teacher.ID, &c4); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 1)
+	c1 := &pb.Course{OrganizationID: 1}
+	c2 := &pb.Course{OrganizationID: 2}
+	c3 := &pb.Course{OrganizationID: 3}
+	c4 := &pb.Course{OrganizationID: 4}
+	qtest.CreateCourse(t, db, admin, c1)
+	qtest.CreateCourse(t, db, admin, c2)
+	qtest.CreateCourse(t, db, admin, c3)
+	qtest.CreateCourse(t, db, admin, c4)
 
 	user := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -403,13 +379,13 @@ func TestGormDBGetCoursesByUser(t *testing.T) {
 	}
 
 	wantCourses := []*pb.Course{
-		{ID: c1.ID, OrganizationID: 1, Enrolled: pb.Enrollment_PENDING},
-		{ID: c2.ID, OrganizationID: 2, Enrolled: pb.Enrollment_NONE},
-		{ID: c3.ID, OrganizationID: 3, Enrolled: pb.Enrollment_STUDENT},
-		{ID: c4.ID, OrganizationID: 4, Enrolled: pb.Enrollment_NONE},
+		{ID: c1.ID, OrganizationID: 1, Provider: "fake", Enrolled: pb.Enrollment_PENDING},
+		{ID: c2.ID, OrganizationID: 2, Provider: "fake", Enrolled: pb.Enrollment_NONE},
+		{ID: c3.ID, OrganizationID: 3, Provider: "fake", Enrolled: pb.Enrollment_STUDENT},
+		{ID: c4.ID, OrganizationID: 4, Provider: "fake", Enrolled: pb.Enrollment_NONE},
 	}
-	if !reflect.DeepEqual(courses, wantCourses) {
-		t.Errorf("have course %+v want %+v", courses, wantCourses)
+	if diff := cmp.Diff(wantCourses, courses, protocmp.Transform()); diff != "" {
+		t.Errorf("courses mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -597,20 +573,18 @@ func TestGormDBCreateCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	course := pb.Course{
-		Name: "name",
-		Code: "code",
-		Year: 2017,
-		Tag:  "tag",
-
+	course := &pb.Course{
+		Name:           "name",
+		Code:           "code",
+		Year:           2017,
+		Tag:            "tag",
 		Provider:       "github",
 		OrganizationID: 1,
 	}
 
-	admin := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(admin.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 	if course.ID == 0 {
 		t.Error("expected id to be set")
 	}
@@ -659,9 +633,8 @@ func TestGormDBCreateCourseNonAdmin(t *testing.T) {
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(admin.ID, &pb.Course{}); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, &pb.Course{})
+
 	nonAdmin := qtest.CreateFakeUser(t, db, 11)
 	// the following should fail to create a course
 	if err := db.CreateCourse(nonAdmin.ID, &pb.Course{}); err == nil {
@@ -682,10 +655,9 @@ func TestGormDBGetCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	user := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(user.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	// Get the created course.
 	createdCourse, err := db.GetCourse(course.ID, false)
@@ -711,10 +683,9 @@ func TestGormDBGetCourseByOrganization(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	user := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(user.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	// Get the created course.
 	createdCourse, err := db.GetCourseByOrganizationID(course.OrganizationID)
@@ -757,10 +728,9 @@ func TestGormDBUpdateCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(admin.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	updates.ID = course.ID
 	if err := db.UpdateCourse(updates); err != nil {
@@ -855,15 +825,11 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	course := pb.Course{OrganizationID: 1}
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
-	courseTwo := pb.Course{OrganizationID: 2}
-	if err := db.CreateCourse(teacher.ID, &courseTwo); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	c1 := &pb.Course{OrganizationID: 1}
+	c2 := &pb.Course{OrganizationID: 2}
+	qtest.CreateCourse(t, db, admin, c1)
+	qtest.CreateCourse(t, db, admin, c2)
 
 	var users []*pb.User
 	enrollments := []pb.Enrollment_UserStatus{pb.Enrollment_STUDENT, pb.Enrollment_STUDENT}
@@ -878,7 +844,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 			continue
 		}
 		if err := db.CreateEnrollment(&pb.Enrollment{
-			CourseID: course.ID,
+			CourseID: c1.ID,
 			UserID:   users[i].ID,
 		}); err != nil {
 			t.Fatal(err)
@@ -888,7 +854,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 		case pb.Enrollment_STUDENT:
 			query := &pb.Enrollment{
 				UserID:   users[i].ID,
-				CourseID: course.ID,
+				CourseID: c1.ID,
 				Status:   pb.Enrollment_STUDENT,
 			}
 			err = db.UpdateEnrollment(query)
@@ -901,7 +867,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	// Creating Group
 	group := &pb.Group{
 		Name:     "SameNameGroup",
-		CourseID: course.ID,
+		CourseID: c1.ID,
 		Users:    users,
 	}
 	if err := db.CreateGroup(group); err != nil {
@@ -911,7 +877,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	// Create Assignments
 	assignment1 := pb.Assignment{
 		Order:      1,
-		CourseID:   course.ID,
+		CourseID:   c1.ID,
 		IsGroupLab: true,
 	}
 	if err := db.CreateAssignment(&assignment1); err != nil {
@@ -919,7 +885,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	}
 	assignment2 := pb.Assignment{
 		Order:      2,
-		CourseID:   course.ID,
+		CourseID:   c1.ID,
 		IsGroupLab: true,
 	}
 	if err := db.CreateAssignment(&assignment2); err != nil {
@@ -927,7 +893,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	}
 	assignment3 := pb.Assignment{
 		Order:      1,
-		CourseID:   courseTwo.ID,
+		CourseID:   c2.ID,
 		IsGroupLab: false,
 	}
 	if err := db.CreateAssignment(&assignment3); err != nil {
@@ -974,7 +940,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 
 	// Even if there is three submission, only the latest for each assignment should be returned
 
-	submissions, err := db.GetLastSubmissions(course.ID, &pb.Submission{GroupID: group.ID})
+	submissions, err := db.GetLastSubmissions(c1.ID, &pb.Submission{GroupID: group.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -982,14 +948,14 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 	if diff := cmp.Diff(submissions, want, cmpopts.IgnoreUnexported(pb.Submission{})); diff != "" {
 		t.Errorf("Expected same submissions, but got (-sub +want):\n%s", diff)
 	}
-	data, err := db.GetLastSubmissions(course.ID, &pb.Submission{GroupID: group.ID})
+	data, err := db.GetLastSubmissions(c1.ID, &pb.Submission{GroupID: group.ID})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(data) != 2 {
 		t.Errorf("Expected '%v' elements in the array, got '%v'", 2, len(data))
 	}
 	// Since there is no submissions, but the course and user exist, an empty array should be returned
-	data, err = db.GetLastSubmissions(courseTwo.ID, &pb.Submission{GroupID: group.ID})
+	data, err = db.GetLastSubmissions(c2.ID, &pb.Submission{GroupID: group.ID})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(data) != 0 {
@@ -1009,11 +975,9 @@ func TestGetRepositoriesByOrganization(t *testing.T) {
 		Provider:       "github",
 		OrganizationID: 1234,
 	}
-
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(teacher.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateFakeUser(t, db, 11)
 
@@ -1064,11 +1028,10 @@ func TestDeleteGroup(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	var course pb.Course
-	if err := db.CreateCourse(teacher.ID, &course); err != nil {
-		t.Fatal(err)
-	}
+	admin := qtest.CreateFakeUser(t, db, 10)
+	course := &pb.Course{}
+	qtest.CreateCourse(t, db, admin, course)
+
 	var users []*pb.User
 	enrollments := []pb.Enrollment_UserStatus{pb.Enrollment_STUDENT, pb.Enrollment_STUDENT}
 	// create as many users as the desired number of enrollments
@@ -1134,13 +1097,11 @@ func TestGetRepositoriesByCourseIdAndType(t *testing.T) {
 		Tag:            "Spring",
 		Provider:       "github",
 		OrganizationID: 1234,
-		ID:             1,
 	}
 
-	teacher := qtest.CreateFakeUser(t, db, 10)
-	if err := db.CreateCourse(teacher.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateFakeUser(t, db, 11)
 
@@ -1198,10 +1159,9 @@ func TestGetRepoByCourseIdUserIdAndType(t *testing.T) {
 		OrganizationID: 120,
 	}
 
-	teacher := qtest.CreateFakeUser(t, db, 1)
-	if err := db.CreateCourse(teacher.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateFakeUser(t, db, 10)
 	userTwo := qtest.CreateFakeUser(t, db, 11)
@@ -1276,7 +1236,6 @@ func TestGetRepositoryByCourseUser(t *testing.T) {
 	defer cleanup()
 
 	course := &pb.Course{
-		ID:             1234,
 		Name:           "Test Course",
 		Code:           "DAT100",
 		Year:           2017,
@@ -1285,10 +1244,10 @@ func TestGetRepositoryByCourseUser(t *testing.T) {
 		OrganizationID: 120,
 	}
 
-	teacher := qtest.CreateFakeUser(t, db, 1)
-	if err := db.CreateCourse(teacher.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	remoteID := &pb.RemoteIdentity{Provider: course.Provider, RemoteID: 1, AccessToken: "token"}
+	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	qtest.CreateCourse(t, db, admin, course)
+
 	user := qtest.CreateFakeUser(t, db, 10)
 	userTwo := qtest.CreateFakeUser(t, db, 11)
 

--- a/database/gormdb_user_test.go
+++ b/database/gormdb_user_test.go
@@ -20,9 +20,7 @@ func TestGetUserByCourse(t *testing.T) {
 		Name:            "Operating Systems and Systems Programming",
 		Year:            2021,
 	}
-	if err := db.CreateCourse(admin.ID, course); err != nil {
-		t.Fatal(err)
-	}
+	qtest.CreateCourse(t, db, admin, course)
 
 	user := qtest.CreateUser(t, db, 2, &pb.User{Login: username})
 	qtest.EnrollStudent(t, db, user, course)

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -60,6 +60,15 @@ func CreateFakeUser(t *testing.T, db database.Database, remoteID uint64) *pb.Use
 	return &user
 }
 
+func CreateUserFromRemoteIdentity(t *testing.T, db database.Database, remoteID *pb.RemoteIdentity) *pb.User {
+	t.Helper()
+	var user pb.User
+	if err := db.CreateUserFromRemoteIdentity(&user, remoteID); err != nil {
+		t.Fatal(err)
+	}
+	return &user
+}
+
 func CreateNamedUser(t *testing.T, db database.Database, remoteID uint64, name string) *pb.User {
 	t.Helper()
 	user := &pb.User{Name: name}
@@ -87,6 +96,20 @@ func CreateUser(t *testing.T, db database.Database, remoteID uint64, user *pb.Us
 		t.Fatal(err)
 	}
 	return user
+}
+
+func CreateCourse(t *testing.T, db database.Database, user *pb.User, course *pb.Course) {
+	t.Helper()
+	if course.Provider == "" {
+		for _, rid := range user.RemoteIdentities {
+			if rid.Provider != "" {
+				course.Provider = rid.Provider
+			}
+		}
+	}
+	if err := db.CreateCourse(user.ID, course); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func EnrollStudent(t *testing.T, db database.Database, student *pb.User, course *pb.Course) {

--- a/web/grpc_auth_test.go
+++ b/web/grpc_auth_test.go
@@ -78,16 +78,14 @@ func fillDatabase(t *testing.T, db database.Database) {
 	if checkCookie != botUserID {
 		t.Errorf("Expected %v, got %v\n", botUserID, checkCookie)
 	}
-	admin := qtest.CreateUser(t, db, 1, &pb.User{Login: "admin"})
+	admin := qtest.CreateFakeUser(t, db, 1)
+	// admin := qtest.CreateUser(t, db, 1, &pb.User{Login: "admin"})
 	course := &pb.Course{
-		ID:              1,
-		CourseCreatorID: uint64(admin.ID),
-		Code:            "DAT320",
-		Name:            "Operating Systems and Systems Programming",
-		Year:            2021,
+		Code: "DAT320",
+		Name: "Operating Systems and Systems Programming",
+		Year: 2021,
 	}
-	err := db.CreateCourse(admin.ID, course)
-	check(t, err)
+	qtest.CreateCourse(t, db, admin, course)
 
 	user = qtest.CreateUser(t, db, 11, &pb.User{Login: userName})
 	qtest.EnrollStudent(t, db, user, course)


### PR DESCRIPTION
- Added test to show bug in access token course cache
- Fixed course access token cache issue
- Implemented improved token cache for courses
- Fixed error handling and added qtest.CreateCourse()
- Fixed CreateCourse to run as transaction

Fixes #574

