### PR TITLE
Refactored CI RunTests and RecordResults

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
-          skip-go-installation: true
+          # skip-go-installation: true
           skip-pkg-cache: true
           skip-build-cache: true
           args: --disable errcheck --timeout 5m

--- a/ag/assignment.go
+++ b/ag/assignment.go
@@ -1,6 +1,7 @@
 package ag
 
 import (
+	context "context"
 	"time"
 )
 
@@ -19,6 +20,17 @@ func (a *Assignment) SinceDeadline(now time.Time) (time.Duration, error) {
 		return zero, err
 	}
 	return now.Sub(deadline), nil
+}
+
+// WithTimeout returns a context with an execution timeout set to the assignment's specified
+// container timeout. If the assignment has no container timeout, the provided timeout value
+// is used instead.
+func (a *Assignment) WithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := a.GetContainerTimeout()
+	if t > 0 {
+		timeout = time.Duration(t) * time.Minute
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 // IsApproved returns an approved submission status if this assignment is already approved

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -21,10 +21,10 @@ import (
 )
 
 var (
-	ContainerTimeout = time.Duration(10 * time.Minute)
-	maxToScan        = 1_000_000 // bytes
-	maxLogSize       = 30_000    // bytes
-	lastSegmentSize  = 1_000     // bytes
+	DefaultContainerTimeout = time.Duration(10 * time.Minute)
+	maxToScan               = 1_000_000 // bytes
+	maxLogSize              = 30_000    // bytes
+	lastSegmentSize         = 1_000     // bytes
 )
 
 // Docker is an implementation of the CI interface using Docker.

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -125,7 +125,7 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.Containe
 				return nil, err
 			}
 		} else {
-			d.logger.Infof("Trying to pulling image: '%s' from docker.io", job.Image)
+			d.logger.Infof("Trying to pull image: '%s' from docker.io", job.Image)
 			if err := d.pullImage(ctx, job.Image); err != nil {
 				return nil, err
 			}
@@ -165,8 +165,8 @@ func (d *Docker) waitForContainer(ctx context.Context, job *Job, respID string) 
 	return "", nil
 }
 
-// pullImage pulls an image from docker hub; this can be slow and should be
-// avoided if possible.
+// pullImage pulls an image from docker hub.
+// This can be slow and should be avoided if possible.
 func (d *Docker) pullImage(ctx context.Context, image string) error {
 	progress, err := d.client.ImagePull(ctx, "docker.io/library/"+image, types.ImagePullOptions{})
 	if err != nil {

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	containerTimeout = time.Duration(10 * time.Minute)
+	ContainerTimeout = time.Duration(10 * time.Minute)
 	maxToScan        = 1_000_000 // bytes
 	maxLogSize       = 30_000    // bytes
 	lastSegmentSize  = 1_000     // bytes

--- a/ci/docker_test.go
+++ b/ci/docker_test.go
@@ -173,6 +173,7 @@ func TestDockerTimeout(t *testing.T) {
 		Dockerfile: dockerfile,
 		Commands:   []string{script},
 	})
+	t.Log("Expecting ERROR line above; not test failure")
 	if out != wantOut {
 		t.Errorf("docker.Run(%#v) = %#v, want %#v", script, out, wantOut)
 	}

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -48,5 +48,5 @@ func (r RunData) parseScriptTemplate(secret string) (*Job, error) {
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("no docker image specified in script template for assignment %s in %s", info.AssignmentName, info.TestURL)
 	}
-	return &Job{Name: r.String(info.RandomSecret[:6]), Image: parts[1], Commands: s[1:]}, nil
+	return &Job{Name: r.String(), Image: parts[1], Commands: s[1:]}, nil
 }

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -5,39 +5,34 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
-
-	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal/rand"
 )
 
 // AssignmentInfo holds metadata needed to fetch student code
 // and the test repository for an assignment.
 type AssignmentInfo struct {
 	AssignmentName     string
-	Script             string
 	CreatorAccessToken string
 	GetURL             string
 	TestURL            string
 	RandomSecret       string
 }
 
-func newAssignmentInfo(course *pb.Course, assignment *pb.Assignment, cloneURL, testURL string) *AssignmentInfo {
-	return &AssignmentInfo{
-		AssignmentName:     assignment.GetName(),
-		Script:             assignment.ScriptFile,
-		CreatorAccessToken: course.GetAccessToken(),
-		GetURL:             cloneURL,
-		TestURL:            testURL,
-		RandomSecret:       rand.String(),
+// parseScriptTemplate returns a job specifying the docker image and commands
+// to be executed by the docker image. The job's commands are extracted from
+// the script template file (run.sh) associated with the RunData's assignment.
+// The script template may use the variables of the AssignmentInfo struct, e.g.,
+// {{ .AssignmentName }}, {{ .RandomSecret }}, etc.
+func (r RunData) parseScriptTemplate(secret string) (*Job, error) {
+	info := &AssignmentInfo{
+		AssignmentName:     r.Assignment.GetName(),
+		CreatorAccessToken: r.Course.GetAccessToken(),
+		GetURL:             r.Repo.GetHTMLURL(),
+		TestURL:            r.Repo.GetTestURL(),
+		RandomSecret:       secret,
 	}
-}
-
-// parseScriptTemplate returns a job describing the docker image to use and
-// the commands of the job. The job is extracted from a script template file
-// provided as input along with assignment metadata for the template.
-func parseScriptTemplate(info *AssignmentInfo) (*Job, error) {
-	// info.Script is the saved contents of the script, not the file name
-	t, err := template.New("scriptfile").Parse(info.Script)
+	// TODO(meling) rename ScriptFile field to ScriptTemplate
+	// ScriptTemplate contains the script itself with variables in double curly braces
+	t, err := template.New("script_template").Parse(r.Assignment.ScriptFile)
 	if err != nil {
 		return nil, err
 	}
@@ -53,5 +48,5 @@ func parseScriptTemplate(info *AssignmentInfo) (*Job, error) {
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("no docker image specified in script template for assignment %s in %s", info.AssignmentName, info.TestURL)
 	}
-	return &Job{Image: parts[1], Commands: s[1:]}, nil
+	return &Job{Name: r.String(info.RandomSecret[:6]), Image: parts[1], Commands: s[1:]}, nil
 }

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Testdata copied from run_tests_test.go (since they are in different packages)
-func testRunData(qfTestOrg string, userName, accessToken, scriptTemplate string) *RunData {
+func testRunData(qfTestOrg, userName, accessToken, scriptTemplate string) *RunData {
 	repo := pb.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	courseID := uint64(1)
 	pb.SetAccessToken(courseID, accessToken)

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -27,6 +27,7 @@ func testRunData(qfTestOrg, userName, accessToken, scriptTemplate string) *RunDa
 			RepoType: pb.Repository_USER,
 		},
 		JobOwner: "muggles",
+		CommitID: "deadbeef",
 	}
 	return runData
 }
@@ -59,8 +60,8 @@ RandomSecret: {{ .RandomSecret }}
 	if job.Commands[1] != "RandomSecret: "+randomSecret {
 		t.Errorf("job.Commands[1] = %s, want %s", job.Commands[1], "RandomSecret: "+randomSecret)
 	}
-	if job.Name != "DAT320-lab1-muggles-"+randomSecret[:6] {
-		t.Errorf("job.Name = %s, want %s", job.Name, "DAT320-lab1-muggles-"+randomSecret[:6])
+	if job.Name != "dat320-lab1-muggles-"+runData.CommitID[:6] {
+		t.Errorf("job.Name = %s, want %s", job.Name, "dat320-lab1-muggles-"+runData.CommitID[:6])
 	}
 }
 

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -67,12 +67,7 @@ func (r RunData) runTests(runner Runner, info *AssignmentInfo) (*execData, error
 	job.Name = r.String(info.RandomSecret[:6])
 	start := time.Now()
 
-	timeout := containerTimeout
-	t := r.Assignment.GetContainerTimeout()
-	if t > 0 {
-		timeout = time.Duration(t) * time.Minute
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := r.withTimeout(containerTimeout)
 	defer cancel()
 
 	out, err := runner.Run(ctx, job)
@@ -81,6 +76,14 @@ func (r RunData) runTests(runner Runner, info *AssignmentInfo) (*execData, error
 	}
 	// this may return a timeout error as well
 	return &execData{out: out, execTime: time.Since(start)}, err
+}
+
+func (r RunData) withTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := r.Assignment.GetContainerTimeout()
+	if t > 0 {
+		timeout = time.Duration(t) * time.Minute
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 // recordResults for the assignment given by the run data structure.

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -59,7 +59,7 @@ func TestRunTests(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runner.Close()
-	ed, err := runTests(runner, info, runData)
+	ed, err := runData.runTests(runner, info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestRecordResults(t *testing.T) {
 		JobOwner: "test",
 	}
 
-	recordResults(zap.NewNop().Sugar(), db, runData, results)
+	runData.recordResults(zap.NewNop().Sugar(), db, results)
 	submission, err := db.GetSubmission(&pb.Submission{AssignmentID: assignment.ID, UserID: admin.ID})
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +140,7 @@ func TestRecordResults(t *testing.T) {
 	// Updating submission after deadline: build info and slip days must be updated
 	newBuildDate := "2022-11-12T13:00:00"
 	results.BuildInfo.BuildDate = newBuildDate
-	recordResults(zap.NewNop().Sugar(), db, runData, results)
+	runData.recordResults(zap.NewNop().Sugar(), db, results)
 
 	enrollment, err := db.GetEnrollmentByCourseAndUser(course.ID, admin.ID)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestRecordResults(t *testing.T) {
 	runData.Rebuild = true
 	results.BuildInfo.BuildDate = "2022-11-13T13:00:00"
 	slipDaysBeforeUpdate := enrollment.RemainingSlipDays(course)
-	recordResults(zap.NewNop().Sugar(), db, runData, results)
+	runData.recordResults(zap.NewNop().Sugar(), db, results)
 	updatedEnrollment, err := db.GetEnrollmentByCourseAndUser(course.ID, admin.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -28,7 +28,7 @@ func loadRunScript(t *testing.T) string {
 	return string(b)
 }
 
-func testRunData(qfTestOrg string, userName, accessToken, scriptTemplate string) *ci.RunData {
+func testRunData(qfTestOrg, userName, accessToken, scriptTemplate string) *ci.RunData {
 	repo := pb.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	courseID := uint64(1)
 	pb.SetAccessToken(courseID, accessToken)

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -2,6 +2,7 @@ package ci
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
@@ -16,8 +17,17 @@ import (
 
 // To run this test, please see instructions in the developer guide (dev.md).
 
-// This test uses a test course for experimenting with go.sh behavior.
+// This test uses a test course for experimenting with run.sh behavior.
 // The test below will run locally on the test machine, not on the QuickFeed machine.
+
+func loadRunScript(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
 
 func TestRunTests(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
@@ -38,7 +48,7 @@ func TestRunTests(t *testing.T) {
 	repo := pb.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	info := &AssignmentInfo{
 		AssignmentName:     "lab1",
-		Script:             "go.sh",
+		Script:             loadRunScript(t),
 		CreatorAccessToken: accessToken,
 		GetURL:             repo.StudentRepoURL(userName),
 		TestURL:            repo.TestsRepoURL(),

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -49,6 +49,7 @@ func testRunData(qfTestOrg, userName, accessToken, scriptTemplate string) *ci.Ru
 			RepoType: pb.Repository_USER,
 		},
 		JobOwner: "muggles",
+		CommitID: "deadbeef",
 	}
 	return runData
 }
@@ -111,8 +112,6 @@ func TestRunTestsTimeout(t *testing.T) {
 	if results.BuildInfo != nil && !strings.HasPrefix(results.BuildInfo.BuildLog, wantOut) {
 		t.Errorf("RunTests(1s timeout) = '%s', got '%s'", wantOut, results.BuildInfo.BuildLog)
 	}
-	// We don't actually test anything here since we don't know how many assignments are in QF_TEST_ORG
-	// t.Logf("%+v\n", results)
 }
 
 func TestRecordResults(t *testing.T) {
@@ -121,6 +120,7 @@ func TestRecordResults(t *testing.T) {
 
 	course := &pb.Course{
 		Name:           "Test",
+		Code:           "DAT320",
 		OrganizationID: 1,
 		SlipDays:       5,
 	}
@@ -171,6 +171,7 @@ printf "RandomSecret: {{ .RandomSecret }}\n"
 			UserID: 1,
 		},
 		JobOwner: "test",
+		CommitID: "deadbeef",
 	}
 
 	// Check that submission is recorded correctly

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -1,0 +1,48 @@
+#image/quickfeed:go
+
+start=$SECONDS
+printf "*** Preparing for Test Execution ***\n"
+
+git config --global url."https://{{ .CreatorAccessToken }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
+ASSIGNMENTS=/quickfeed/assignments
+TESTDIR=/quickfeed/tests
+ASSIGNDIR=$ASSIGNMENTS/{{ .AssignmentName }}/
+
+# Fetch student and test repos
+git clone {{ .GetURL }} $ASSIGNMENTS
+git clone {{ .TestURL }} $TESTDIR
+
+if [ ! -d "$ASSIGNDIR" ]; then
+  printf "Folder $ASSIGNDIR not found in {{ .GetURL }}"
+  exit
+fi
+
+# Move to folder for assignment to test.
+cd $ASSIGNDIR
+
+# Fail student code that attempts to access secret
+if grep -r -e QUICKFEED_SESSION_SECRET * ; then
+  printf "\n=== Misbehavior Detected: Failed ===\n"
+  exit
+fi
+
+# Remove student written tests to avoid interference
+find . -name '*_test.go' -exec rm -rf {} \;
+
+# Copy tests into student assignments folder for running tests
+cp -r $TESTDIR/* $ASSIGNMENTS/
+
+# Clear access token and the shell history to avoid leaking information to student test code.
+git config --global url."https://0:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+history -c
+
+# (ensure) Move to folder for assignment to test.
+cd $ASSIGNDIR
+
+printf "\n*** Finished Test Setup in $(( SECONDS - start )) seconds ***\n"
+
+start=$SECONDS
+printf "\n*** Running Tests ***\n\n"
+QUICKFEED_SESSION_SECRET={{ .RandomSecret }} go test -v -timeout 30s ./... 2>&1
+printf "\n*** Finished Running Tests in $(( SECONDS - start )) seconds ***\n"

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -14,15 +14,15 @@ git clone {{ .GetURL }} $ASSIGNMENTS
 git clone {{ .TestURL }} $TESTDIR
 
 if [ ! -d "$ASSIGNDIR" ]; then
-  printf "Folder $ASSIGNDIR not found in {{ .GetURL }}"
+  printf "Folder %s not found in {{ .GetURL }}" "$ASSIGNDIR"
   exit
 fi
 
 # Move to folder for assignment to test.
-cd $ASSIGNDIR
+cd "$ASSIGNDIR"
 
 # Fail student code that attempts to access secret
-if grep -r -e QUICKFEED_SESSION_SECRET * ; then
+if grep -r -e QUICKFEED_SESSION_SECRET ./* ; then
   printf "\n=== Misbehavior Detected: Failed ===\n"
   exit
 fi
@@ -38,11 +38,11 @@ git config --global url."https://0:x-oauth-basic@github.com/".insteadOf "https:/
 history -c
 
 # (ensure) Move to folder for assignment to test.
-cd $ASSIGNDIR
+cd "$ASSIGNDIR"
 
-printf "\n*** Finished Test Setup in $(( SECONDS - start )) seconds ***\n"
+printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 
 start=$SECONDS
 printf "\n*** Running Tests ***\n\n"
 QUICKFEED_SESSION_SECRET={{ .RandomSecret }} go test -v -timeout 30s ./... 2>&1
-printf "\n*** Finished Running Tests in $(( SECONDS - start )) seconds ***\n"
+printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -75,12 +75,12 @@ However, it appears there is no per-organization approach to turn off notificati
 QuickFeed uses the following repository structure.
 These will be created automatically when a course is created.
 
-| Repository name | Description                                                                    | Access                         |
-|-----------------|--------------------------------------------------------------------------------|--------------------------------|
-| info            | Holds information about the course.                                            | Public                         |
-| assignments     | Contains a separate folder for each assignment.                                | Students, Teachers, QuickFeed  |
-| username-labs   | Created for each student username in QuickFeed                                 | Student, Teachers, QuickFeed   |
-| tests           | Contains a separate folder for each assignment with tests for that assignment. | Teachers, QuickFeed            |
+| Repository name | Description                                                                    | Access                        |
+|-----------------|--------------------------------------------------------------------------------|-------------------------------|
+| info            | Holds information about the course.                                            | Public                        |
+| assignments     | Contains a separate folder for each assignment.                                | Students, Teachers, QuickFeed |
+| username-labs   | Created for each student username in QuickFeed                                 | Student, Teachers, QuickFeed  |
+| tests           | Contains a separate folder for each assignment with tests for that assignment. | Teachers, QuickFeed           |
 
 *In QuickFeed, Teacher means any teaching staff, including teaching assistants and professors alike.*
 
@@ -198,7 +198,6 @@ An example is shown below for `lab1`.
 
 ```yml
 assignmentid: 1
-name: "lab1"
 title: "Introduction to Unix"
 deadline: "2020-08-30T23:59:00"
 autoapprove: true
@@ -210,17 +209,16 @@ reviewers: 2
 containertimeout: 10
 ```
 
-| Field              | Description                                                                                           |
-|--------------------|-------------------------------------------------------------------------------------------------------|
-| `assignmentid`     | TBD                                                                                                   |
-| `name`             | Name of assignment folder                                                                             |
-| `scriptfile`       | Script to use for running tests.                                                                      |
-| `deadline`         | Submission deadline for the assignment.                                                               |
-| `autoapprove`      | Automatically approve the assignment when `scorelimit` is achieved.                                   |
-| `scorelimit`       | Minimal score needed for approval. Default is 80 %.                                                   |
-| `isgrouplab`       | Assignment is considered a group assignment if true; otherwise it is an individual assignment.        |
-| `reviewers`        | Number of teachers that must review a student submission for approval.                                |
-| `containertimeout` | Timeout for CI container to finish building and testing student submitted code. Default is 10 minutes.|
+| Field              | Description                                                                                            |
+|--------------------|--------------------------------------------------------------------------------------------------------|
+| `assignmentid`     | TBD                                                                                                    |
+| `title`            | The assignment's title                                                                                 |
+| `deadline`         | Submission deadline for the assignment.                                                                |
+| `autoapprove`      | Automatically approve the assignment when `scorelimit` is achieved.                                    |
+| `scorelimit`       | Minimal score needed for approval. Default is 80 %.                                                    |
+| `isgrouplab`       | Assignment is considered a group assignment if true; otherwise it is an individual assignment.         |
+| `reviewers`        | Number of teachers that must review a student submission for approval.                                 |
+| `containertimeout` | Timeout for CI container to finish building and testing student submitted code. Default is 10 minutes. |
 
 ## Reviewing student submissions
 

--- a/kit/score/results.go
+++ b/kit/score/results.go
@@ -14,7 +14,7 @@ const (
 func NewResults(scores ...*Score) *Results {
 	r := &Results{
 		testNames: make([]string, 0),
-		scores:    make(map[string]*Score),
+		scoreMap:  make(map[string]*Score),
 	}
 	for _, sc := range scores {
 		r.addScore(sc)
@@ -27,7 +27,7 @@ func NewResults(scores ...*Score) *Results {
 func (r *Results) toScoreSlice() []*Score {
 	scores := make([]*Score, len(r.testNames))
 	for i, name := range r.testNames {
-		scores[i] = r.scores[name]
+		scores[i] = r.scoreMap[name]
 	}
 	return scores
 }
@@ -37,7 +37,7 @@ type Results struct {
 	BuildInfo *BuildInfo // build info for tests
 	Scores    []*Score   // list of scores for different tests
 	testNames []string   // defines the order
-	scores    map[string]*Score
+	scoreMap  map[string]*Score
 }
 
 // parseErrors encountered during test execution.
@@ -93,7 +93,7 @@ func ExtractResults(out, secret string, execTime time.Duration) (*Results, error
 // This method assumes that the provided score object is valid.
 func (r *Results) addScore(sc *Score) {
 	testName := sc.GetTestName()
-	if current, found := r.scores[testName]; found {
+	if current, found := r.scoreMap[testName]; found {
 		if current.GetScore() != 0 {
 			// We reach here only if a second non-zero score is found
 			// Mark it as faulty with -1.
@@ -107,7 +107,7 @@ func (r *Results) addScore(sc *Score) {
 	// Record score object if:
 	// - current score is nil or zero, or
 	// - the first score was zero.
-	r.scores[testName] = sc
+	r.scoreMap[testName] = sc
 }
 
 // Validate returns an error if one of the recorded score objects are invalid.

--- a/kit/score/results_test.go
+++ b/kit/score/results_test.go
@@ -21,9 +21,10 @@ func TestExtractResult(t *testing.T) {
 Here are some more logs for the student.
 `
 
-	res := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
-	if len(res.Errors) > 0 {
-		t.Fatal(res.Errors[0])
+	res, err := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		// err may contain multiple errors
+		t.Fatal(err)
 	}
 	if strings.Contains(res.BuildInfo.BuildLog, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73") {
 		t.Fatal("build log contains secret")
@@ -39,9 +40,10 @@ func TestExtractResultWithWhitespace(t *testing.T) {
 Here are some more logs for the student.
 `
 
-	res := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
-	if len(res.Errors) > 0 {
-		t.Fatal(res.Errors[0])
+	res, err := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		// err may contain multiple errors
+		t.Fatal(err)
 	}
 	if strings.Contains(res.BuildInfo.BuildLog, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73") {
 		t.Fatal("build log contains secret")
@@ -62,9 +64,10 @@ Here are some more logs for the student.
 Here are some more logs for the student.
 `
 
-	res := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
-	if len(res.Errors) > 0 {
-		t.Fatal(res.Errors[0])
+	res, err := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		// err may contain multiple errors
+		t.Fatal(err)
 	}
 	if len(res.Scores) != 2 {
 		t.Fatalf("ExtractResult() expected 2 Score entries, got %d: %+v", len(res.Scores), res.Scores)
@@ -85,9 +88,10 @@ func TestExtractResultWithPanicedAndMaliciousScoreLines(t *testing.T) {
 	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"MaliciousTest","Score":100,"MaxScore":100,"Weight":1}
 `
 
-	res := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
-	if len(res.Errors) > 0 {
-		t.Fatal(res.Errors[0])
+	res, err := score.ExtractResults(out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		// err may contain multiple errors
+		t.Fatal(err)
 	}
 	const expectedTests = 6
 	if len(res.Scores) != expectedTests {
@@ -244,9 +248,10 @@ func TestExecTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("ExecTime#"+tt.id, func(t *testing.T) {
-			res := score.ExtractResults("", "", tt.in)
-			if len(res.Errors) > 0 {
-				t.Fatal(res.Errors[0])
+			res, err := score.ExtractResults("", "", tt.in)
+			if err != nil {
+				// err may contain multiple errors
+				t.Fatal(err)
 			}
 			got := res.BuildInfo.ExecTime
 			if got != tt.want {

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -178,7 +178,7 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 	}
 
 	wh.logger.Debug("ci.RunTests", zap.Any("Results", log.IndentJson(results)))
-	err = runData.RecordResults(wh.logger, wh.db, results)
+	_, err = runData.RecordResults(wh.logger, wh.db, results)
 	if err != nil {
 		wh.logger.Errorf("Failed to record results for assignment %s for course %s: %v", assignment.Name, course.Name, err)
 	}

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -173,7 +173,7 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 		}
 		return
 	}
-	ctx, cancel := assignment.WithTimeout(ci.ContainerTimeout)
+	ctx, cancel := assignment.WithTimeout(ci.DefaultContainerTimeout)
 	defer cancel()
 	results, err := runData.RunTests(ctx, wh.logger, wh.runner)
 	if err != nil {

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -172,7 +172,7 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 		wh.recordSubmissionWithoutTests(runData)
 		return
 	}
-	ci.RunTests(wh.logger, wh.db, wh.runner, runData)
+	runData.RunTests(wh.logger, wh.db, wh.runner)
 }
 
 // recordSubmissionWithoutTests saves a new submission without running any tests

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -172,7 +172,9 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 		wh.recordSubmissionWithoutTests(runData)
 		return
 	}
-	results, err := runData.RunTests(wh.logger, wh.runner)
+	ctx, cancel := assignment.WithTimeout(ci.ContainerTimeout)
+	defer cancel()
+	results, err := runData.RunTests(ctx, wh.logger, wh.runner)
 	if err != nil {
 		wh.logger.Errorf("Failed to run tests for assignment %s for course %s: %v", assignment.Name, course.Name, err)
 	}

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -172,7 +172,16 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 		wh.recordSubmissionWithoutTests(runData)
 		return
 	}
-	runData.RunTests(wh.logger, wh.db, wh.runner)
+	results, err := runData.RunTests(wh.logger, wh.runner)
+	if err != nil {
+		wh.logger.Errorf("Failed to run tests for assignment %s for course %s: %v", assignment.Name, course.Name, err)
+	}
+
+	wh.logger.Debug("ci.RunTests", zap.Any("Results", log.IndentJson(results)))
+	err = runData.RecordResults(wh.logger, wh.db, results)
+	if err != nil {
+		wh.logger.Errorf("Failed to record results for assignment %s for course %s: %v", assignment.Name, course.Name, err)
+	}
 }
 
 // recordSubmissionWithoutTests saves a new submission without running any tests

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -47,7 +47,9 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 		JobOwner:   slug.Make(name),
 		Rebuild:    true,
 	}
-	results, err := runData.RunTests(s.logger, s.runner)
+	ctx, cancel := assignment.WithTimeout(ci.ContainerTimeout)
+	defer cancel()
+	results, err := runData.RunTests(ctx, s.logger, s.runner)
 	if err != nil {
 		return nil, err
 	}

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -47,7 +47,7 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 		JobOwner:   slug.Make(name),
 		Rebuild:    true,
 	}
-	ctx, cancel := assignment.WithTimeout(ci.ContainerTimeout)
+	ctx, cancel := assignment.WithTimeout(ci.DefaultContainerTimeout)
 	defer cancel()
 	results, err := runData.RunTests(ctx, s.logger, s.runner)
 	if err != nil {

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -51,11 +51,11 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 	if err != nil {
 		return nil, err
 	}
-	err = runData.RecordResults(s.logger, s.db, results)
+	submission, err = runData.RecordResults(s.logger, s.db, results)
 	if err != nil {
 		return nil, fmt.Errorf("failed to record results for assignment %s for course %s: %w", assignment.Name, course.Name, err)
 	}
-	return s.db.GetSubmission(&pb.Submission{ID: request.GetSubmissionID()})
+	return submission, nil
 }
 
 func (s *AutograderService) rebuildSubmissions(request *pb.AssignmentRequest) error {

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -46,7 +46,7 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 		JobOwner:   slug.Make(name),
 		Rebuild:    true,
 	}
-	ci.RunTests(s.logger, s.db, s.runner, runData)
+	runData.RunTests(s.logger, s.db, s.runner)
 	return s.db.GetSubmission(&pb.Submission{ID: request.GetSubmissionID()})
 }
 

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -46,7 +47,14 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 		JobOwner:   slug.Make(name),
 		Rebuild:    true,
 	}
-	runData.RunTests(s.logger, s.db, s.runner)
+	results, err := runData.RunTests(s.logger, s.runner)
+	if err != nil {
+		return nil, err
+	}
+	err = runData.RecordResults(s.logger, s.db, results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to record results for assignment %s for course %s: %w", assignment.Name, course.Name, err)
+	}
 	return s.db.GetSubmission(&pb.Submission{ID: request.GetSubmissionID()})
 }
 


### PR DESCRIPTION
- Converted funcs to methods on RunData type
- Added run.sh script to testdata and load into Script
- Docker cleanup and simplification
- Cleanup Docker tests; added TestDockerPull
- Replace logger.Errorf with return fmt.Errorf
- Moved timeout code to separate method
- Separated RunTests and RecordResults
- Return pb.Submission from RecordResults
- Log notice about error not being a test failure

Fixes #588.

