### PR TITLE
Accept repository invites on behalf of users

### DIFF
--- a/scm/fake.go
+++ b/scm/fake.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/google/go-github/v35/github"
 )
 
 // FakeSCM implements the SCM interface.
@@ -214,6 +215,18 @@ func (s *FakeSCM) RemoveMember(ctx context.Context, opt *OrgMembershipOptions) e
 
 // GetUserScopes implements the SCM interface
 func (s *FakeSCM) GetUserScopes(ctx context.Context) *Authorization {
+	// TODO no implementation provided yet
+	return nil
+}
+
+// GetRepositoryInvites implements the SCM interface
+func (s *FakeSCM) GetRepositoryInvites(ctx context.Context, org *RepositoryOptions) ([]*github.RepositoryInvitation, error) {
+	// TODO no implementation provided yet
+	return nil, nil
+}
+
+// AcceptRepositoryInvite implements the SCM interface
+func (s *FakeSCM) AcceptRepositoryInvite(ctx context.Context, opt *RepositoryInvitationOptions) error {
 	// TODO no implementation provided yet
 	return nil
 }

--- a/scm/github.go
+++ b/scm/github.go
@@ -689,6 +689,46 @@ func (s *GithubSCM) GetUserScopes(ctx context.Context) *Authorization {
 	return &Authorization{Scopes: gitScopes}
 }
 
+// GetRepositoryInvites implements the SCM interface
+func (s *GithubSCM) GetRepositoryInvites(ctx context.Context, opt *RepositoryOptions) ([]*github.RepositoryInvitation, error) {
+	if !opt.valid() {
+		return nil, ErrMissingFields{
+			Method:  "GetRepositoryInvites",
+			Message: fmt.Sprintf("%+v", opt),
+		}
+	}
+
+	invites, _, err := s.client.Repositories.ListInvitations(ctx, opt.Owner, opt.Path, nil)
+	if err != nil {
+		return nil, ErrFailedSCM{
+			Method:   "GetRepositoryInvites",
+			GitError: fmt.Errorf("failed to list repository invitations for organization %s and repository %s: %w", opt.Owner, opt.Path, err),
+			Message:  fmt.Sprintf("failed to list repository invitations for organization %s and repository %s", opt.Owner, opt.Path),
+		}
+	}
+	return invites, nil
+}
+
+// AcceptRepositoryInvite implements the SCM interface
+func (s *GithubSCM) AcceptRepositoryInvite(ctx context.Context, opt *RepositoryInvitationOptions) error {
+	if !opt.valid() {
+		return ErrMissingFields{
+			Method:  "AcceptRepositoryInvite",
+			Message: fmt.Sprintf("%+v", opt),
+		}
+	}
+
+	_, err := s.client.Users.AcceptInvitation(ctx, int64(opt.InvitationID))
+	if err != nil {
+		return ErrFailedSCM{
+			Method:   "AcceptRepositoryInvite",
+			GitError: fmt.Errorf("failed to accept repository invitation %d: %w", opt.InvitationID, err),
+			Message:  fmt.Sprintf("failed to accept repository invitation %d", opt.InvitationID),
+		}
+	}
+	return nil
+}
+
 func toRepository(repo *github.Repository) *Repository {
 	return &Repository{
 		ID:      uint64(repo.GetID()),

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/google/go-github/v35/github"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -279,4 +280,22 @@ func (s *GitlabSCM) RemoveMember(ctx context.Context, opt *OrgMembershipOptions)
 func (s *GitlabSCM) GetUserScopes(ctx context.Context) *Authorization {
 	// TODO no implementation provided yet
 	return nil
+}
+
+// GetRepositoryInvites implements the SCM interface
+func (s *GitlabSCM) GetRepositoryInvites(ctx context.Context, opt *RepositoryOptions) ([]*github.RepositoryInvitation, error) {
+	// TODO no implementation provided yet
+	return nil, ErrNotSupported{
+		SCM:    "gitlab",
+		Method: "GetRepositoryInvites",
+	}
+}
+
+// AcceptRepositoryInvite implements the SCM interface
+func (s *GitlabSCM) AcceptRepositoryInvite(ctx context.Context, opt *RepositoryInvitationOptions) error {
+	// TODO no implementation provided yet
+	return ErrNotSupported{
+		SCM:    "gitlab",
+		Method: "AcceptRepositoryInvite",
+	}
 }

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -112,6 +112,10 @@ func (opt RepositoryOptions) valid() bool {
 	return opt.ID > 0 || (opt.Path != "" && opt.Owner != "")
 }
 
+func (opt RepositoryInvitationOptions) valid() bool {
+	return opt.InvitationID > 0
+}
+
 // Errors //
 
 // ErrNotSupported is returned when the source code management solution used

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/google/go-github/v35/github"
 	"go.uber.org/zap"
 )
 
@@ -62,6 +63,10 @@ type SCM interface {
 	RemoveMember(context.Context, *OrgMembershipOptions) error
 	// Lists all authorizations for authenticated user.
 	GetUserScopes(context.Context) *Authorization
+	// Lists all pending repository invites.
+	GetRepositoryInvites(context.Context, *RepositoryOptions) ([]*github.RepositoryInvitation, error)
+	// Accepts repository invite.
+	AcceptRepositoryInvite(context.Context, *RepositoryInvitationOptions) error
 }
 
 // NewSCMClient returns a new provider client implementing the SCM interface.
@@ -213,4 +218,9 @@ type Team struct {
 // Authorization stores information about user scopes
 type Authorization struct {
 	Scopes []string
+}
+
+// RepositoryInvitation represents a repository invitation.
+type RepositoryInvitationOptions struct {
+	InvitationID uint64
 }

--- a/web/courses.go
+++ b/web/courses.go
@@ -442,6 +442,36 @@ func (s *AutograderService) enrollStudent(ctx context.Context, sc scm.SCM, enrol
 		if err := s.db.CreateRepository(&userRepo); err != nil {
 			return err
 		}
+
+		// TODO: We can get invites for assignments and info repositories here as well.
+		// TODO: The invites returned for those repositories could include invitees other than the student to be enrolled
+		// TODO: We could either get all invites, filter them by the student being enrolled - then accept those
+		// TODO: Or we could store invites in the database and send them to the student to accept in the frontend
+		// TODO: Or some alternate method I haven't thought of yet.
+		// NOTE: Unsure if we need the SCM of the course creator to get invites
+		invites, err := sc.GetRepositoryInvites(ctx, &scm.RepositoryOptions{ID: repo.ID, Owner: course.GetOrganizationPath(), Path: repo.Path})
+		if err != nil {
+			return err
+		}
+		if len(invites) > 0 {
+			user, err := s.db.GetUser(user.ID)
+			if err != nil {
+				s.logger.Errorf("Failed to get user %d: %v", user.ID, err)
+			}
+			accessToken, err := user.GetAccessToken("github")
+			if err != nil {
+				s.logger.Errorf("Failed to get access token for user %s: %v", user.Login, err)
+			}
+			if sc, ok := s.scms.GetSCM(accessToken); ok {
+				for _, invite := range invites {
+					if err := sc.AcceptRepositoryInvite(ctx, &scm.RepositoryInvitationOptions{InvitationID: uint64(*invite.ID)}); err != nil {
+						s.logger.Errorf("Failed to accept repository invite for user %s: %v", user.Login, err)
+					} else {
+						s.logger.Debug("Accepted repository invite for user ", user.Login)
+					}
+				}
+			}
+		}
 	}
 
 	return s.db.UpdateEnrollment(userEnrolQuery)

--- a/web/webserver.go
+++ b/web/webserver.go
@@ -77,7 +77,7 @@ func enableProviders(l *zap.SugaredLogger, baseURL string) map[string]bool {
 		KeyEnv:        "GITHUB_KEY",
 		SecretEnv:     "GITHUB_SECRET",
 		CallbackURL:   auth.GetCallbackURL(baseURL, "github"),
-		StudentScopes: []string{},
+		StudentScopes: []string{"repo:invite"},
 		TeacherScopes: []string{"user", "repo", "delete_repo", "admin:org", "admin:org_hook"},
 	}, func(key, secret, callback string, scopes ...string) goth.Provider {
 		return github.New(key, secret, callback, scopes...)


### PR DESCRIPTION
This PR implements functionality to accept repository invites on behalf of a student when accepting their enrollment.

Currently it only accepts the invite to `<studentLogin>-labs`, but could easily add accepting invites for `info` and `assignments` as well. 

This functionality requires students to grant additional GitHub scopes, `repo:invite`