### PR TITLE
Prevent creating bad group names on backend

### DIFF
--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -1,11 +1,13 @@
 package qtest
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
@@ -13,6 +15,7 @@ import (
 	"github.com/autograde/quickfeed/log"
 	"github.com/autograde/quickfeed/scm"
 	"github.com/autograde/quickfeed/web/auth"
+	"google.golang.org/grpc/metadata"
 )
 
 // TestDB returns a test database and close function.
@@ -146,4 +149,12 @@ func RandomString(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return fmt.Sprintf("%x", sha1.Sum(randomness))[:6]
+}
+
+// WithUserContext is a test helper function to create metadata for the
+// given user mimicking the context coming from the browser.
+func WithUserContext(ctx context.Context, user *pb.User) context.Context {
+	userID := strconv.Itoa(int(user.GetID()))
+	meta := metadata.New(map[string]string{"user": userID})
+	return metadata.NewIncomingContext(ctx, meta)
 }

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -2,7 +2,6 @@ package web_test
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
@@ -10,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -85,20 +83,12 @@ func TestGetCourses(t *testing.T) {
 	}
 }
 
-// withUserContext is a test helper function to create metadata for the
-// given user mimicking the context coming from the browser.
-func withUserContext(ctx context.Context, user *pb.User) context.Context {
-	userID := strconv.Itoa(int(user.GetID()))
-	meta := metadata.New(map[string]string{"user": userID})
-	return metadata.NewIncomingContext(ctx, meta)
-}
-
 func TestNewCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 10)
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -134,7 +124,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 10)
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -161,7 +151,7 @@ func TestEnrollmentProcess(t *testing.T) {
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	_, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"})
@@ -478,7 +468,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// student1 attempts to promote student2 to teacher, must fail
-	ctx := withUserContext(context.Background(), student1)
+	ctx := qtest.WithUserContext(context.Background(), student1)
 	if _, err := ags.UpdateEnrollment(ctx, &pb.Enrollment{
 		UserID:   student2.ID,
 		CourseID: course.ID,
@@ -488,7 +478,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// teacher promotes students to teachers, must succeed
-	ctx = withUserContext(context.Background(), teacher)
+	ctx = qtest.WithUserContext(context.Background(), teacher)
 	_, err = fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
 		t.Fatal(err)
@@ -520,7 +510,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// TA attempts to demote self, must succeed
-	ctx = withUserContext(context.Background(), ta)
+	ctx = qtest.WithUserContext(context.Background(), ta)
 	if _, err := ags.UpdateEnrollment(ctx, &pb.Enrollment{
 		UserID:   ta.ID,
 		CourseID: course.ID,
@@ -530,7 +520,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// student2 attempts to demote course creator, must fail
-	ctx = withUserContext(context.Background(), student2)
+	ctx = qtest.WithUserContext(context.Background(), student2)
 	if _, err := ags.UpdateEnrollment(ctx, &pb.Enrollment{
 		UserID:   teacher.ID,
 		CourseID: course.ID,
@@ -549,7 +539,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// teacher demotes student1, must succeed
-	ctx = withUserContext(context.Background(), teacher)
+	ctx = qtest.WithUserContext(context.Background(), teacher)
 	if _, err := ags.UpdateEnrollment(ctx, &pb.Enrollment{
 		UserID:   student1.ID,
 		CourseID: course.ID,
@@ -602,7 +592,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 
 	// ta attempts to demote course creator, must fail
-	ctx = withUserContext(context.Background(), ta)
+	ctx = qtest.WithUserContext(context.Background(), ta)
 	if _, err := ags.UpdateEnrollment(ctx, &pb.Enrollment{
 		UserID:   teacher.ID,
 		CourseID: course.ID,

--- a/web/groups_name_test.go
+++ b/web/groups_name_test.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/ci"
+	"github.com/autograde/quickfeed/internal/qtest"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+)
+
+// withUserContext is a test helper function to create metadata for the
+// given user mimicking the context coming from the browser.
+func withUserContext(ctx context.Context, user *pb.User) context.Context {
+	userID := strconv.Itoa(int(user.GetID()))
+	meta := metadata.New(map[string]string{"user": userID})
+	return metadata.NewIncomingContext(ctx, meta)
+}
+
+func TestBadGroupNames(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+
+	admin := qtest.CreateFakeUser(t, db, 1)
+	course := &pb.Course{
+		Name: "Distributed Systems",
+		Code: "DAT520",
+		Year: 2018,
+	}
+	qtest.CreateCourse(t, db, admin, course)
+
+	_, scms := qtest.FakeProviderMap(t)
+	ags := NewAutograderService(zap.NewNop(), db, scms, BaseHookOptions{}, &ci.Local{})
+	user1 := qtest.CreateFakeUser(t, db, 2)
+	user2 := qtest.CreateFakeUser(t, db, 3)
+	// enroll users in course
+	qtest.EnrollStudent(t, db, user1, course)
+	qtest.EnrollStudent(t, db, user2, course)
+
+	group := &pb.Group{
+		ID:       1,
+		CourseID: course.ID,
+		Name:     "DuplicateGroupName",
+		Users:    []*pb.User{user1, user2},
+	}
+	// current user1 (in context) must be in group being created
+	ctx := withUserContext(context.Background(), user1)
+	gotGroup, err := ags.CreateGroup(ctx, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	groupNames := []struct {
+		name      string
+		wantError error
+	}{
+		{"abcdefghijklmnopqrstuvwxyz", errGroupNameTooLong},
+		{"groupNameStillTooLong", errGroupNameTooLong},
+		{"groupNameNotTooLong", nil},
+		{"a", nil},
+		{"a1", nil},
+		{"23", nil},
+		{"HeinsGroup", nil},
+		{"Heins-group", nil},
+		{"Heins_group", nil},
+		{"Hein's group", errGroupNameInvalid},
+		{"a" + string([]byte{0x7f}), errGroupNameInvalid},
+		{"a" + string([]byte{0x80}), errGroupNameInvalid},
+		{"abc ", errGroupNameInvalid},
+		{"æ", errGroupNameInvalid},
+		{"ø", errGroupNameInvalid},
+		{"å", errGroupNameInvalid},
+		{"Æ", errGroupNameInvalid},
+		{"Ø", errGroupNameInvalid},
+		{"Å", errGroupNameInvalid},
+		{gotGroup.GetName(), errGroupNameDuplicate},
+	}
+	for _, test := range groupNames {
+		if err := ags.checkGroupName(course.ID, test.name); err != test.wantError {
+			t.Errorf("checkGroupName(%q) = %s, expected %s", test.name, err, test.wantError)
+		}
+	}
+}

--- a/web/groups_name_test.go
+++ b/web/groups_name_test.go
@@ -2,23 +2,13 @@ package web
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
 	"github.com/autograde/quickfeed/internal/qtest"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/metadata"
 )
-
-// withUserContext is a test helper function to create metadata for the
-// given user mimicking the context coming from the browser.
-func withUserContext(ctx context.Context, user *pb.User) context.Context {
-	userID := strconv.Itoa(int(user.GetID()))
-	meta := metadata.New(map[string]string{"user": userID})
-	return metadata.NewIncomingContext(ctx, meta)
-}
 
 func TestBadGroupNames(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
@@ -47,7 +37,7 @@ func TestBadGroupNames(t *testing.T) {
 		Users:    []*pb.User{user1, user2},
 	}
 	// current user1 (in context) must be in group being created
-	ctx := withUserContext(context.Background(), user1)
+	ctx := qtest.WithUserContext(context.Background(), user1)
 	gotGroup, err := ags.CreateGroup(ctx, group)
 	if err != nil {
 		t.Fatal(err)

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -52,7 +52,7 @@ func TestNewGroup(t *testing.T) {
 
 	users := make([]*pb.User, 0)
 	users = append(users, &pb.User{ID: user.ID})
-	createGroupRequest := &pb.Group{Name: "Hein's Group", CourseID: course.ID, Users: users}
+	createGroupRequest := &pb.Group{Name: "Heins-Group", CourseID: course.ID, Users: users}
 
 	// current user (in context) must be in group being created
 	ctx = withUserContext(context.Background(), user)
@@ -175,7 +175,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 
 	users := make([]*pb.User, 0)
 	users = append(users, &pb.User{ID: user.ID})
-	createGroupRequest := &pb.Group{Name: "Hein's Group", CourseID: course.ID, Users: users}
+	createGroupRequest := &pb.Group{Name: "HeinsGroup", CourseID: course.ID, Users: users}
 
 	ctx := withUserContext(context.Background(), user)
 	wantGroup, err := ags.CreateGroup(ctx, createGroupRequest)
@@ -257,7 +257,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 	users := make([]*pb.User, 0)
 	users = append(users, &pb.User{ID: user.ID})
 	users = append(users, &pb.User{ID: teacher.ID})
-	group_req := &pb.Group{Name: "Hein's Group", CourseID: course.ID, Users: users}
+	group_req := &pb.Group{Name: "HeinsGroup", CourseID: course.ID, Users: users}
 
 	_, err = ags.CreateGroup(ctx, group_req)
 	if err != nil {
@@ -336,7 +336,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 	users := make([]*pb.User, 0)
 	users = append(users, user1)
 	users = append(users, user2)
-	createGroupRequest := &pb.Group{Name: "Hein's two member Group", CourseID: course.ID, Users: users}
+	createGroupRequest := &pb.Group{Name: "HeinsTwoMemberGroup", CourseID: course.ID, Users: users}
 
 	// set ID of user3 to context, user3 is not member of group (should fail)
 	ctx := withUserContext(context.Background(), user3)
@@ -369,7 +369,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 	users1 = append(users1, user2)
 	users1 = append(users1, user3)
 
-	updateGroupRequest := &pb.Group{ID: gotGroup.ID, Name: "Hein's three member Group", CourseID: course.ID, Users: users1}
+	updateGroupRequest := &pb.Group{ID: gotGroup.ID, Name: "Heins3MemberGroup", CourseID: course.ID, Users: users1}
 
 	// set teacher ID in context
 	ctx = withUserContext(context.Background(), teacher)
@@ -509,7 +509,7 @@ func TestDeleteGroup(t *testing.T) {
 	}
 
 	// create group as student user
-	group := &pb.Group{Name: "Test Delete Group", CourseID: testCourse.ID, Users: []*pb.User{user}}
+	group := &pb.Group{Name: "TestDeleteGroup", CourseID: testCourse.ID, Users: []*pb.User{user}}
 	ctx = withUserContext(context.Background(), user)
 	respGroup, err := ags.CreateGroup(ctx, group)
 	if err != nil {
@@ -558,7 +558,7 @@ func TestGetGroup(t *testing.T) {
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), user)
 
-	group := &pb.Group{Name: "Test Group", CourseID: testCourse.ID, Users: []*pb.User{user}}
+	group := &pb.Group{Name: "TestGroup", CourseID: testCourse.ID, Users: []*pb.User{user}}
 	wantGroup, err := ags.CreateGroup(ctx, group)
 	if err != nil {
 		t.Fatal(err)
@@ -818,7 +818,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 	group := &pb.Group{
 		ID:       1,
 		CourseID: course.ID,
-		Name:     "Test Group",
+		Name:     "TestGroup",
 		Users:    []*pb.User{user1, user2},
 	}
 	// current user1 (in context) must be in group being created
@@ -914,12 +914,12 @@ func TestGetGroups(t *testing.T) {
 	// place some students in groups
 	// current user (in context) must be in group being created
 	ctx := withUserContext(context.Background(), users[2])
-	group1, err := ags.CreateGroup(ctx, &pb.Group{Name: "Group 1", CourseID: course.ID, Users: []*pb.User{users[1], users[2]}})
+	group1, err := ags.CreateGroup(ctx, &pb.Group{Name: "Group1", CourseID: course.ID, Users: []*pb.User{users[1], users[2]}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx = withUserContext(context.Background(), users[5])
-	group2, err := ags.CreateGroup(ctx, &pb.Group{Name: "Group 2", CourseID: course.ID, Users: []*pb.User{users[4], users[5]}})
+	group2, err := ags.CreateGroup(ctx, &pb.Group{Name: "Group2", CourseID: course.ID, Users: []*pb.User{users[4], users[5]}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -8,7 +8,6 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
-	"github.com/gosimple/slug"
 )
 
 const maxContainers = 10
@@ -44,7 +43,7 @@ func (s *AutograderService) rebuildSubmission(request *pb.RebuildRequest) (*pb.S
 		Assignment: assignment,
 		Repo:       repo,
 		CommitID:   submission.GetCommitHash(),
-		JobOwner:   slug.Make(name),
+		JobOwner:   name,
 		Rebuild:    true,
 	}
 	ctx, cancel := assignment.WithTimeout(ci.DefaultContainerTimeout)

--- a/web/rebuild_test.go
+++ b/web/rebuild_test.go
@@ -115,7 +115,7 @@ func TestRebuildSubmissions(t *testing.T) {
 	}
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), teacher)
+	ctx := qtest.WithUserContext(context.Background(), teacher)
 
 	_, err = fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
@@ -197,7 +197,7 @@ printf "RandomSecret: {{ .RandomSecret }}\n"
 	}
 
 	// check access control
-	ctx = withUserContext(ctx, student1)
+	ctx = qtest.WithUserContext(ctx, student1)
 	if _, err = ags.RebuildSubmissions(ctx, &request); err == nil {
 		t.Fatal("Expected error: authentication failed")
 	}

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -75,7 +75,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	}
 
 	users := []*pb.User{student1, student2}
-	group_req := &pb.Group{Name: "Test group", CourseID: course.ID, Users: users}
+	group_req := &pb.Group{Name: "TestGroup", CourseID: course.ID, Users: users}
 
 	_, err = ags.CreateGroup(ctx, group_req)
 	if err != nil {

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -67,7 +67,7 @@ func TestSubmissionsAccess(t *testing.T) {
 
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), teacher)
+	ctx := qtest.WithUserContext(context.Background(), teacher)
 
 	_, err = fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
@@ -172,7 +172,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	}
 
 	// admin not enrolled in the course must not be able to access any course submissions
-	ctx = withUserContext(context.Background(), admin)
+	ctx = qtest.WithUserContext(context.Background(), admin)
 	submissions, err = ags.GetSubmissions(ctx, &pb.SubmissionRequest{CourseID: course.ID})
 	if err == nil {
 		t.Error("Expected error: user not enrolled")
@@ -204,7 +204,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	}
 
 	// the first student must be able to access own submissions as well as submissions made by group he has membership in
-	ctx = withUserContext(context.Background(), student1)
+	ctx = qtest.WithUserContext(context.Background(), student1)
 
 	personalSubmission, err := ags.GetSubmissions(ctx, &pb.SubmissionRequest{CourseID: course.ID, UserID: student1.ID})
 	if err != nil {
@@ -229,7 +229,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	}
 
 	// the second student should not be able to access the submission by student1
-	ctx = withUserContext(context.Background(), student2)
+	ctx = qtest.WithUserContext(context.Background(), student2)
 	personalSubmission, err = ags.GetSubmissions(ctx, &pb.SubmissionRequest{CourseID: course.ID, UserID: student1.ID})
 	if err == nil || personalSubmission != nil {
 		t.Error("Expected error: only owner and teachers can get submissions")
@@ -251,7 +251,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	}
 
 	// the third student (not enrolled in the course) should not be able to access submission even if it belongs to that student
-	ctx = withUserContext(context.Background(), student3)
+	ctx = qtest.WithUserContext(context.Background(), student3)
 	personalSubmission, err = ags.GetSubmissions(ctx, &pb.SubmissionRequest{CourseID: course.ID, UserID: student3.ID})
 	if err == nil || personalSubmission != nil {
 		t.Error("Expected error: only owner and teachers can get submissions")
@@ -303,7 +303,7 @@ func TestApproveSubmission(t *testing.T) {
 
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 
 	_, err = fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
@@ -470,7 +470,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(log.Zap(false), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 
 	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
@@ -574,12 +574,12 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 
 	// check that method fails for unenrolled student user
 	unenrolledStudent := qtest.CreateFakeUser(t, db, 3)
-	ctx = withUserContext(ctx, unenrolledStudent)
+	ctx = qtest.WithUserContext(ctx, unenrolledStudent)
 	if _, err := ags.GetSubmissionsByCourse(ctx, &pb.SubmissionsForCourseRequest{CourseID: course1.ID}); err == nil {
 		t.Error("Expected 'only teachers can get all lab submissions'")
 	}
 	// check that method fails for non-teacher user
-	ctx = withUserContext(ctx, student)
+	ctx = qtest.WithUserContext(ctx, student)
 	if _, err = ags.GetSubmissionsByCourse(ctx, &pb.SubmissionsForCourseRequest{CourseID: course1.ID}); err == nil {
 		t.Error("Expected 'only teachers can get all lab submissions'")
 	}
@@ -698,7 +698,7 @@ func TestCreateApproveList(t *testing.T) {
 
 	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
 		t.Fatal(err)

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -137,13 +137,13 @@ func TestGetUsers(t *testing.T) {
 
 	admin := qtest.CreateFakeUser(t, db, 1)
 	user2 := qtest.CreateFakeUser(t, db, 2)
-	ctx := withUserContext(context.Background(), user2)
+	ctx := qtest.WithUserContext(context.Background(), user2)
 	_, err = ags.GetUsers(ctx, &pb.Void{})
 	if err == nil {
 		t.Fatal("expected 'rpc error: code = PermissionDenied desc = only admin can access other users'")
 	}
 	// now switch to use admin as the user; this should pass
-	ctx = withUserContext(context.Background(), admin)
+	ctx = qtest.WithUserContext(context.Background(), admin)
 	foundUsers, err := ags.GetUsers(ctx, &pb.Void{})
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +194,7 @@ func TestGetEnrollmentsByCourse(t *testing.T) {
 
 	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 
 	// users to enroll in course DAT520 Distributed Systems
 	// (excluding admin because admin is enrolled on creation)
@@ -264,7 +264,7 @@ func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
 
 	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), admin)
+	ctx := qtest.WithUserContext(context.Background(), admin)
 
 	course := allCourses[1]
 	err := db.CreateCourse(admin.ID, course)
@@ -341,7 +341,7 @@ func TestUpdateUser(t *testing.T) {
 
 	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
-	ctx := withUserContext(context.Background(), firstAdminUser)
+	ctx := qtest.WithUserContext(context.Background(), firstAdminUser)
 
 	// we want to update nonAdminUser to become admin
 	nonAdminUser.IsAdmin = true
@@ -404,7 +404,7 @@ func TestUpdateUserFailures(t *testing.T) {
 		t.Fatalf("expected user %v to be non-admin", u)
 	}
 	// context with user u (non-admin user); can only change its own name etc
-	ctx := withUserContext(context.Background(), u)
+	ctx := qtest.WithUserContext(context.Background(), u)
 
 	// trying to demote current adminUser by setting IsAdmin to false
 	nameChangeRequest := &pb.User{


### PR DESCRIPTION
New rules:
- Group names can be no longer than 20 characters
- Group names can only contain letters, numbers and - and _
- As before only unique group names are allowed

This updates the backend to enforce these rules.

Fixes #345.
Fixes #546.

