### PR TITLE
Clean up make submission results functions used by GetSubmissionsByCourse

### DIFF
--- a/ag/assignment.go
+++ b/ag/assignment.go
@@ -3,6 +3,8 @@ package ag
 import (
 	context "context"
 	"time"
+
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -44,21 +46,11 @@ func (a *Assignment) IsApproved(latest *Submission, score uint32) Submission_Sta
 	return latest.GetStatus()
 }
 
-// CloneWithoutSubmissions returns a deep copy of the given assignment
-// without submissions.
+// CloneWithoutSubmissions returns a deep copy of the assignment without submissions.
 func (a *Assignment) CloneWithoutSubmissions() *Assignment {
-	return &Assignment{
-		ID:                a.ID,
-		CourseID:          a.CourseID,
-		Name:              a.Name,
-		Deadline:          a.Deadline,
-		AutoApprove:       a.AutoApprove,
-		Order:             a.Order,
-		IsGroupLab:        a.IsGroupLab,
-		ScoreLimit:        a.ScoreLimit,
-		Reviewers:         a.Reviewers,
-		GradingBenchmarks: a.GradingBenchmarks,
-	}
+	clone := proto.Clone(a).(*Assignment)
+	clone.Submissions = nil
+	return clone
 }
 
 // GradedManually returns true if the assignment will be graded manually.

--- a/ag/submission.go
+++ b/ag/submission.go
@@ -26,3 +26,11 @@ func (s *Submission) NewestBuildDate(submissionDate time.Time) (t time.Time, err
 	}
 	return submissionDate, nil
 }
+
+func (s *Submission) ByUser(userID uint64) bool {
+	return s.GetGroupID() == 0 && s.GetUserID() > 0 && s.GetUserID() == userID
+}
+
+func (s *Submission) ByGroup(groupID uint64) bool {
+	return s.GetUserID() == 0 && s.GetGroupID() > 0 && s.GetGroupID() == groupID
+}

--- a/ag/submission_test.go
+++ b/ag/submission_test.go
@@ -54,3 +54,63 @@ func TestNewestSubmissionDate(t *testing.T) {
 		t.Errorf("NewestBuildDate(%v) = %v, expected '%v'\n", tim, new, buildDate)
 	}
 }
+
+func TestByUser(t *testing.T) {
+	submission := &pb.Submission{}
+	if submission.ByUser(0) {
+		t.Errorf("ByUser(0) = true, expected false\n")
+	}
+
+	submission = &pb.Submission{
+		UserID: 1,
+	}
+	if !submission.ByUser(1) {
+		t.Errorf("ByUser(1) = false, expected true\n")
+	}
+
+	submission = &pb.Submission{
+		GroupID: 1,
+	}
+	if submission.ByUser(1) {
+		t.Errorf("ByUser(1) = true, expected false\n")
+	}
+
+	// submissions with both user and group ID are invalid
+	submission = &pb.Submission{
+		UserID:  1,
+		GroupID: 2,
+	}
+	if submission.ByUser(1) {
+		t.Errorf("ByUser(1) = true, expected false\n")
+	}
+}
+
+func TestByGroup(t *testing.T) {
+	submission := &pb.Submission{}
+	if submission.ByGroup(0) {
+		t.Errorf("ByGroup(0) = true, expected false\n")
+	}
+
+	submission = &pb.Submission{
+		GroupID: 1,
+	}
+	if !submission.ByGroup(1) {
+		t.Errorf("ByGroup(1) = false, expected true\n")
+	}
+
+	submission = &pb.Submission{
+		UserID: 1,
+	}
+	if submission.ByGroup(1) {
+		t.Errorf("ByGroup(1) = true, expected false\n")
+	}
+
+	// submissions with both user and group ID are invalid
+	submission = &pb.Submission{
+		UserID:  1,
+		GroupID: 2,
+	}
+	if submission.ByGroup(1) {
+		t.Errorf("ByGroup(1) = true, expected false\n")
+	}
+}

--- a/ag/validation.go
+++ b/ag/validation.go
@@ -170,7 +170,7 @@ func (req *EnrollmentRequest) IsValid() bool {
 	return req.GetCourseID() > 0
 }
 
-// Isvalid ensures that course and assignment IDs are set.
+// IsValid ensures that course and assignment IDs are set.
 func (req *AssignmentRequest) IsValid() bool {
 	return req.CourseID > 0 && req.AssignmentID > 0
 }

--- a/ag/validation.go
+++ b/ag/validation.go
@@ -67,7 +67,7 @@ func Interceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 }
 
 // IsValid on void message always returns true.
-func (v *Void) IsValid() bool {
+func (*Void) IsValid() bool {
 	return true
 }
 

--- a/web/courses.go
+++ b/web/courses.go
@@ -159,7 +159,7 @@ func (s *AutograderService) getAllCourseSubmissions(request *pb.SubmissionsForCo
 		enrolLinks = s.makeGroupResults(course, assignments)
 	case pb.SubmissionsForCourseRequest_INDIVIDUAL:
 		enrolLinks = makeResults(course, assignments, false)
-	default:
+	case pb.SubmissionsForCourseRequest_ALL:
 		enrolLinks = makeResults(course, assignments, true)
 	}
 	return &pb.CourseSubmissions{Course: course, Links: enrolLinks}, nil

--- a/web/courses.go
+++ b/web/courses.go
@@ -153,15 +153,14 @@ func (s *AutograderService) getAllCourseSubmissions(request *pb.SubmissionsForCo
 
 	course.SetSlipDays()
 
-	enrolLinks := make([]*pb.EnrollmentLink, 0)
-
+	var enrolLinks []*pb.EnrollmentLink
 	switch request.Type {
 	case pb.SubmissionsForCourseRequest_GROUP:
-		enrolLinks = append(enrolLinks, s.makeGroupResults(course, assignments)...)
+		enrolLinks = s.makeGroupResults(course, assignments)
 	case pb.SubmissionsForCourseRequest_INDIVIDUAL:
-		enrolLinks = append(enrolLinks, makeResults(course, assignments, false)...)
+		enrolLinks = makeResults(course, assignments, false)
 	default:
-		enrolLinks = append(enrolLinks, makeResults(course, assignments, true)...)
+		enrolLinks = makeResults(course, assignments, true)
 	}
 	return &pb.CourseSubmissions{Course: course, Links: enrolLinks}, nil
 }

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
 	"github.com/autograde/quickfeed/internal/qtest"
+	"github.com/autograde/quickfeed/log"
 	"github.com/autograde/quickfeed/scm"
 	"github.com/autograde/quickfeed/web"
 )
@@ -471,7 +472,7 @@ func TestDeleteGroup(t *testing.T) {
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
 	fakeProvider, scms := qtest.FakeProviderMap(t)
-	ags := web.NewAutograderService(qtest.Logger(t).Desugar(), db, scms, web.BaseHookOptions{}, &ci.Local{})
+	ags := web.NewAutograderService(log.Zap(false), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	if _, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Trivial makeResults simplification; no need to append
- Use pb.SubmissionsForCourseRequest_ALL instead of default
- Make Assignment.CloneWithoutSubmissions robust
- Added ByUser and ByGroup predicate methods to Submission
- Typo
- Added TestGetSubmissionsByCourse
- Disabled output from TestDeleteGroup
- Refactor make{All|Individual|Group}Results functions

Fixes #621

