### PR TITLE
Test runner script with environment variables

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17]
+        go-version: [1.18]
 
     steps:
       - name: Cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.18]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - uses: actions/checkout@v3
 
       - name: golangci-lint

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -14,6 +14,8 @@ type Job struct {
 	Dockerfile string
 	// BindDir is the directory to bind to the container's /quickfeed directory.
 	BindDir string
+	// Env is a list of environment variables to set for the job.
+	Env []string
 	// Commands is a list of shell commands to run as part of the job.
 	Commands []string
 }

--- a/ci/clone_repositories.go
+++ b/ci/clone_repositories.go
@@ -71,8 +71,6 @@ func (r RunData) validate(testsDir, assignmentsDir string) error {
 	if err != nil {
 		return err
 	}
-	// Check that the student code files don't contain the secret string
-	const secretEnvName = "QUICKFEED_SESSION_SECRET"
 	for file, content := range files {
 		if strings.Contains(string(content), secretEnvName) {
 			return fmt.Errorf("file %q in %s contains %s environment variable", filepath.Base(file), r, secretEnvName)

--- a/ci/clone_repositories.go
+++ b/ci/clone_repositories.go
@@ -71,6 +71,7 @@ func (r RunData) validate(testsDir, assignmentsDir string) error {
 	if err != nil {
 		return err
 	}
+	// Ensure that the student code files does not contain the session secret environment variable.
 	for file, content := range files {
 		if strings.Contains(string(content), secretEnvName) {
 			return fmt.Errorf("file %q in %s contains %s environment variable", filepath.Base(file), r, secretEnvName)

--- a/ci/consts.go
+++ b/ci/consts.go
@@ -1,4 +1,5 @@
 package ci
 
-// Check that the student code files don't contain the secret string
+// Environment variable used by the CI system to pass
+// the session secret from QuickFeed to the test code.
 const secretEnvName = "QUICKFEED_SESSION_SECRET"

--- a/ci/consts.go
+++ b/ci/consts.go
@@ -1,0 +1,4 @@
+package ci
+
+// Check that the student code files don't contain the secret string
+const secretEnvName = "QUICKFEED_SESSION_SECRET"

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -125,6 +125,7 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.Containe
 	create := func() (container.ContainerCreateCreatedBody, error) {
 		return d.client.ContainerCreate(ctx, &container.Config{
 			Image: job.Image,
+			Env:   job.Env, // Set default environment variables
 			Cmd:   []string{"/bin/bash", "-c", strings.Join(job.Commands, "\n")},
 		}, hostConfig, nil, nil, job.Name)
 	}

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -1,46 +1,49 @@
 package ci
 
 import (
-	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
-	"text/template"
+
+	"github.com/quickfeed/quickfeed/qf"
 )
 
-// AssignmentInfo holds metadata needed to fetch student code
-// and the test repository for an assignment.
-type AssignmentInfo struct {
-	AssignmentName string
-	RandomSecret   string
-}
-
-// parseScriptTemplate returns a job specifying the docker image and commands
+// parseTestRunnerScript returns a job specifying the docker image and commands
 // to be executed by the docker image. The job's commands are extracted from
-// the script template file (run.sh) associated with the RunData's assignment.
-// The script template may use the variables of the AssignmentInfo struct, e.g.,
-// {{ .AssignmentName }}, {{ .RandomSecret }}, etc.
-func (r RunData) parseScriptTemplate(secret string) (*Job, error) {
-	info := &AssignmentInfo{
-		AssignmentName: r.Assignment.GetName(),
-		RandomSecret:   secret,
-	}
-	// TODO(meling) rename ScriptFile field to ScriptTemplate
-	// ScriptTemplate contains the script itself with variables in double curly braces
-	t, err := template.New("script_template").Parse(r.Assignment.ScriptFile)
-	if err != nil {
-		return nil, err
-	}
-	buffer := new(bytes.Buffer)
-	if err := t.Execute(buffer, info); err != nil {
-		return nil, err
-	}
-	s := strings.Split(buffer.String(), "\n")
+// the test runner script (run.sh) associated with the RunData's assignment.
+//
+// The script may use the following environment variables:
+//   TESTS - to access the tests (cloned from the tests repository)
+//   ASSIGNMENTS - to access the assignments (cloned from the assignments repository)
+//   CURRENT - name of the current assignment folder
+//   QUICKFEED_SESSION_SECRET - typically used by the test code; not the script itself
+func (r RunData) parseTestRunnerScript(secret string) (*Job, error) {
+	s := strings.Split(r.Assignment.GetScriptFile(), "\n")
 	if len(s) < 2 {
-		return nil, fmt.Errorf("no script template for assignment %s in %s", info.AssignmentName, r.Repo.GetTestURL())
+		return nil, fmt.Errorf("no script template for assignment %s in %s", r.Assignment.GetName(), r.Repo.GetTestURL())
 	}
 	parts := strings.Split(s[0], "#image/")
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("no docker image specified in script template for assignment %s in %s", info.AssignmentName, r.Repo.GetTestURL())
+		return nil, fmt.Errorf("no docker image specified in script template for assignment %s in %s", r.Assignment.GetName(), r.Repo.GetTestURL())
 	}
-	return &Job{Name: r.String(), Image: parts[1], Commands: s[1:]}, nil
+	return &Job{
+		Name:     r.String(),
+		Image:    parts[1],
+		Env:      r.envVars(secret),
+		Commands: s[1:],
+	}, nil
+}
+
+func (r RunData) envVars(sessionSecret string) []string {
+	envMap := map[string]string{
+		"TESTS":       filepath.Join(QuickFeedPath, qf.TestsRepo),
+		"ASSIGNMENTS": filepath.Join(QuickFeedPath, qf.AssignmentRepo),
+		"CURRENT":     r.Assignment.GetName(),
+		secretEnvName: sessionSecret,
+	}
+	envVars := make([]string, 0, len(envMap))
+	for varName, value := range envMap {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", varName, value))
+	}
+	return envVars
 }

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -59,7 +59,7 @@ func (r RunData) RunTests(ctx context.Context, logger *zap.SugaredLogger, runner
 	}
 
 	randomSecret := rand.String()
-	job, err := r.parseScriptTemplate(randomSecret)
+	job, err := r.parseTestRunnerScript(randomSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse script template: %w", err)
 	}

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -3,12 +3,8 @@
 start=$SECONDS
 printf "*** Preparing for Test Execution ***\n"
 
-ASSIGNMENTS=/quickfeed/assignments
-TESTS=/quickfeed/tests
-ASSIGNDIR=$ASSIGNMENTS/{{ .AssignmentName }}/
-
-# Move to folder for assignment to test.
-cd "$ASSIGNDIR"
+# Move to folder for the current assignment to test.
+cd "$ASSIGNMENTS/$CURRENT"
 
 # Remove student written tests to avoid interference
 find . -name '*_test.go' -exec rm -rf {} \;
@@ -19,5 +15,5 @@ cp -r $TESTS/* $ASSIGNMENTS/
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS
 printf "\n*** Running Tests ***\n\n"
-QUICKFEED_SESSION_SECRET={{ .RandomSecret }} go test -v -timeout 30s ./... 2>&1
+go test -v -timeout 30s ./... 2>&1
 printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -10,7 +10,7 @@ cd "$ASSIGNMENTS/$CURRENT"
 find . -name '*_test.go' -exec rm -rf {} \;
 
 # Copy tests into student assignments folder for running tests
-cp -r $TESTS/* $ASSIGNMENTS/
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
 
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -294,7 +294,7 @@ cd "$ASSIGNMENTS/$CURRENT"
 find . -name '*_test.go' -exec rm -rf {} \;
 
 # Copy tests into student assignments folder for running tests
-cp -r $TESTS/* $ASSIGNMENTS/
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
 
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -164,8 +164,8 @@ The file system layout of the `tests` repository must match that of the `assignm
 The `assignment.yml` files contains the [assignment information](#assignment-information).
 In addition, each assignment folder should also contain test code for the corresponding assignment.
 
-The `scripts` folder may contain a course-specific [test runner](#test-runners) template, named `run.sh`, for running the tests.
-If an assignment requires a different test runner, you can supply a custom `run.sh` template for that assignment.
+The `scripts` folder may contain a course-specific [test runner](#test-runners), named `run.sh`, for running the tests.
+If an assignment requires a different test runner, you can supply a custom `run.sh` script for that assignment.
 
 The `scripts` folder may also contain a [custom Dockerfile](#dockerfile) for the course.
 Otherwise, the [test runner](#test-runners) for each assignment specifies which Docker image to use.
@@ -237,7 +237,7 @@ A course may specify a test runner that runs the tests for all assignments.
 The course-specific test runner is located in `scripts/run.sh`.
 Assignment-specific test runners are located in the individual assignment folders.
 
-The test runner is a bash script template; an example is shown below.
+The test runner is a bash script; an example is shown below.
 
 The first line of the template specifies which Docker image to use for the tests.
 For example, the test runner can specify a publicly available Docker image, such as `#image/mcr.microsoft.com/dotnet/sdk:5.0`.
@@ -246,16 +246,29 @@ In this case, the test runner should specify the course code as the image to use
 The example below is for our QF101 test course.
 Note that the image will only be built/downloaded once, and will be cached for subsequent test runs.
 
-Further, the test runner can make use of two template variables that will be replaced by QuickFeed before execution:
-
-- `{{ .AssignmentName }}`: the name of the assignment folder (for the current test execution), e.g., `lab1`.
-- `{{ .RandomSecret }}`: a session secret used to match the test execution with the test results.
-
-The specific details regarding the session secret is explained in the `kit` module.
-The short explanation is that the `Score` JSON objects produced by assignment tests should contain the value `{{ .RandomSecret }}` in the `Secret` field.
-
-QuickFeed will clone a student's repository or a group repository, and makes them available via the `/quickfeed/assignments` folder.
+QuickFeed will clone a student's repository or a group repository, and make them available via the `/quickfeed/assignments` folder inside the docker image.
 Similarly, QuickFeed will also clone the `tests` repository and make it available via the `/quickfeed/tests` folder.
+
+To simplify the test runner script QuickFeed makes the following environment variables available:
+
+- `$TESTS`: Path to the root of the course's `test` repository.
+- `$ASSIGNMENTS`: Path to the root of the course's `assignments` repository.
+- `$CURRENT`: The current assignment folder; this folder should exist in both the `tests` and `assignments` repositories.
+
+The `$TESTS` and `$ASSIGNMENTS` variables are always set to the following paths:
+
+```bash
+TESTS=/quickfeed/tests
+ASSIGNMENTS=/quickfeed/assignments
+```
+
+Whereas the `$CURRENT` variable is set to the current assignment folder, e.g.,:
+
+```bash
+CURRENT=lab1
+```
+
+Thus, the test runner script can use these variables to manipulate the filesystem as needed.
 
 To prepare a custom test runner, it is recommended to use the `docker run` command to ensure that the code is accessible at the appropriate locations.
 You may use the `ls` command to list the contents of the various `/quickfeed` folders.
@@ -274,12 +287,8 @@ Note that QuickFeed performs a lightweight sanity check of the cloned student re
 start=$SECONDS
 printf "*** Preparing for Test Execution ***\n"
 
-ASSIGNMENTS=/quickfeed/assignments
-TESTS=/quickfeed/tests
-ASSIGNDIR=$ASSIGNMENTS/{{ .AssignmentName }}/
-
-# Move to folder for assignment to test.
-cd "$ASSIGNDIR"
+# Move to folder for the current assignment to test.
+cd "$ASSIGNMENTS/$CURRENT"
 
 # Remove student written tests to avoid interference
 find . -name '*_test.go' -exec rm -rf {} \;
@@ -290,9 +299,25 @@ cp -r $TESTS/* $ASSIGNMENTS/
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS
 printf "\n*** Running Tests ***\n\n"
-QUICKFEED_SESSION_SECRET={{ .RandomSecret }} go test -v -timeout 30s ./... 2>&1
+go test -v -timeout 30s ./... 2>&1
 printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"
 ```
+
+## Writing Tests
+
+The test runner script will run the tests for the current assignment.
+However, the teacher must write the tests so that each test emits a `Score` JSON object.
+This `Score` object must be written to `stdout` and must contain the following fields:
+
+```json
+{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"Gradle","Score":100,"MaxScore":100,"Weight":1}
+```
+
+The session secret is generated by QuickFeed and is used to identify the test run.
+A test execution can read the session secret from the `$QUICKFEED_SESSION_SECRET` environment variable.
+However, once the test code has read the session secret into memory, it should set the environment variable to the empty string `""`.
+
+For additional information about writing tests, please see the Go-based `score` package in the `kit` module.
 
 ## Tasks and Pull Requests (Experimental feature)
 

--- a/doc/templates/dotnet-course/scripts/run.sh
+++ b/doc/templates/dotnet-course/scripts/run.sh
@@ -3,10 +3,7 @@
 start=$SECONDS
 printf "*** Preparing for Test Execution ***\n"
 
-ASSIGNDIR=/quickfeed/assignments/{{ .AssignmentName }}/
-TESTS=/quickfeed/tests/{{ .AssignmentName }}/
-
-cd "$TESTS"
+cd "$TESTS/$CURRENT"
 
 # Perform lab specific setup
 if [ -f "setup.sh" ]; then
@@ -16,5 +13,5 @@ fi
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS
 printf "\n*** Running Tests ***\n\n"
-QUICKFEED_SESSION_SECRET={{ .RandomSecret }} dotnet test "--logger:console;verbosity=detailed" 2>&1
+dotnet test "--logger:console;verbosity=detailed" 2>&1
 printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"

--- a/doc/templates/go-course/scripts/run.sh
+++ b/doc/templates/go-course/scripts/run.sh
@@ -3,12 +3,8 @@
 start=$SECONDS
 printf "*** Preparing for Test Execution ***\n"
 
-ASSIGNMENTS=/quickfeed/assignments
-TESTS=/quickfeed/tests
-ASSIGNDIR=$ASSIGNMENTS/{{ .AssignmentName }}/
-
-# Move to folder for assignment to test.
-cd "$ASSIGNDIR"
+# Move to folder for the current assignment to test.
+cd "$ASSIGNMENTS/$CURRENT"
 
 # Remove student written tests to avoid interference
 find . -name '*_test.go' -exec rm -rf {} \;
@@ -19,5 +15,5 @@ cp -r $TESTS/* $ASSIGNMENTS/
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS
 printf "\n*** Running Tests ***\n\n"
-QUICKFEED_SESSION_SECRET={{ .RandomSecret }} go test -v -timeout 30s ./... 2>&1
+go test -v -timeout 30s ./... 2>&1
 printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"

--- a/doc/templates/go-course/scripts/run.sh
+++ b/doc/templates/go-course/scripts/run.sh
@@ -10,7 +10,7 @@ cd "$ASSIGNMENTS/$CURRENT"
 find . -name '*_test.go' -exec rm -rf {} \;
 
 # Copy tests into student assignments folder for running tests
-cp -r $TESTS/* $ASSIGNMENTS/
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
 
 printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
 start=$SECONDS

--- a/quickfeed.code-workspace
+++ b/quickfeed.code-workspace
@@ -7,4 +7,8 @@
 			"path": "kit"
 		}
 	],
+	"settings": {
+		"go.formatTool": "gofumports",
+		"go.languageServerExperimentalFeatures": {}
+	},
 }


### PR DESCRIPTION
This obviates the need to use template variables in the `run.sh` script all together by replacing them with default environment variables (`$TESTS`, `$ASSIGNMENTS`, `$CURRENT`, `$QUICKFEED_SESSION_SECRET`) that can be used similarly. However, it avoids the additional complexity for users to understand how templates works (although it isn't too difficult, it adds another layer...)

Fixes #680.

