### PR TITLE
Add support for SCM_PROVIDER env var

### DIFF
--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -21,7 +21,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, course
 	logger.Debugf("Updating %s from '%s' repository", course.GetCode(), qf.TestsRepo)
 	// TODO(meling): Update this for GitHub web app.
 	// The scm client should ideally be passed in instead of creating another instance.
-	scm, err := scm.NewSCMClient(logger, course.GetProvider(), course.GetAccessToken())
+	scm, err := scm.NewSCMClient(logger, course.GetAccessToken())
 	if err != nil {
 		logger.Errorf("Failed to create SCM Client: %v", err)
 		return

--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -20,7 +20,7 @@ func TestFetchAssignments(t *testing.T) {
 	accessToken := scm.GetAccessToken(t)
 
 	logger := log.Zap(true).Sugar()
-	s, err := scm.NewSCMClient(logger, "github", accessToken)
+	s, err := scm.NewSCMClient(logger, accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/assignments/pull_requests_test.go
+++ b/assignments/pull_requests_test.go
@@ -71,7 +71,7 @@ func TestPublishFeedbackComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ci/clone_repositories.go
+++ b/ci/clone_repositories.go
@@ -19,7 +19,7 @@ func (r RunData) cloneRepositories(ctx context.Context, logger *zap.SugaredLogge
 
 	// TODO(meling): Update this for GitHub web app.
 	// The scm client should ideally be passed in instead of creating another instance.
-	sc, err := scm.NewSCMClient(logger, r.Course.GetProvider(), r.Course.GetAccessToken())
+	sc, err := scm.NewSCMClient(logger, r.Course.GetAccessToken())
 	if err != nil {
 		return fmt.Errorf("failed to create SCM Client: %w", err)
 	}

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -36,7 +36,7 @@ func testRunData(t *testing.T, scriptTemplate string) *ci.RunData {
 	accessToken := scm.GetAccessToken(t)
 
 	// Only used to fetch the user's GitHub login (user name)
-	s, err := scm.NewSCMClient(qtest.Logger(t), "github", accessToken)
+	s, err := scm.NewSCMClient(qtest.Logger(t), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -240,7 +240,7 @@ func before(client *scm.SCM) cli.BeforeFunc {
 		provider := c.String("provider")
 		accessToken := os.Getenv(c.String("token"))
 		if accessToken != "" {
-			*client, err = scm.NewSCMClient(zap.NewNop().Sugar(), provider, accessToken)
+			*client, err = scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 			return
 		}
 
@@ -263,7 +263,7 @@ func before(client *scm.SCM) cli.BeforeFunc {
 		if accessToken == "" {
 			return fmt.Errorf("access token not found in database for provider %s", provider)
 		}
-		*client, err = scm.NewSCMClient(zap.NewNop().Sugar(), provider, accessToken)
+		*client, err = scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 		return
 	}
 }

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -164,7 +164,8 @@ func EnrollTeacher(t *testing.T, db database.Database, student *qf.User, course 
 func FakeProviderMap(t *testing.T) (scm.SCM, *auth.Scms) {
 	t.Helper()
 	scms := auth.NewScms()
-	scm, err := scms.GetOrCreateSCMEntry(Logger(t).Desugar(), "fake", "token")
+	os.Setenv("SCM_PROVIDER", "fake")
+	scm, err := scms.GetOrCreateSCMEntry(Logger(t).Desugar(), "token")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scm/fetcher_test.go
+++ b/scm/fetcher_test.go
@@ -15,7 +15,7 @@ func TestClone(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
 
-	s, err := scm.NewSCMClient(log.Zap(true).Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(log.Zap(true).Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestCloneBranch(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
 
-	s, err := scm.NewSCMClient(log.Zap(true).Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(log.Zap(true).Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -27,7 +27,7 @@ func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
 
-	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestListHooks(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
 
-	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestCreateHook(t *testing.T) {
 		t.Skip("Disabled pending support for deleting webhooks")
 	}
 
-	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestUpdateIssue(t *testing.T) {
 func TestRequestReviewers(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	accessToken := scm.GetAccessToken(t)
-	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), "github", accessToken)
+	s, err := scm.NewSCMClient(zap.NewNop().Sugar(), accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -3,6 +3,7 @@ package scm
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/quickfeed/quickfeed/qf"
 	"go.uber.org/zap"
@@ -89,8 +90,21 @@ type SCM interface {
 	AcceptRepositoryInvites(context.Context, *RepositoryInvitationOptions) error
 }
 
+const defaultProvider = "github"
+
+var provider string
+
+// Provider returns the current SCM provider supported by this backend.
+func Provider() string {
+	return provider
+}
+
 // NewSCMClient returns a new provider client implementing the SCM interface.
-func NewSCMClient(logger *zap.SugaredLogger, provider, token string) (SCM, error) {
+func NewSCMClient(logger *zap.SugaredLogger, token string) (SCM, error) {
+	provider = os.Getenv("SCM_PROVIDER")
+	if provider == "" {
+		provider = defaultProvider
+	}
 	switch provider {
 	case "github":
 		return NewGithubSCMClient(logger, token), nil

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -442,7 +442,7 @@ func AccessControl(logger *zap.SugaredLogger, db database.Database, scms *Scms) 
 func updateScm(ctx echo.Context, logger *zap.SugaredLogger, scms *Scms, user *qf.User) bool {
 	foundSCMProvider := false
 	for _, remoteID := range user.RemoteIdentities {
-		scm, err := scms.GetOrCreateSCMEntry(logger.Desugar(), remoteID.GetProvider(), remoteID.GetAccessToken())
+		scm, err := scms.GetOrCreateSCMEntry(logger.Desugar(), remoteID.GetAccessToken())
 		if err != nil {
 			logger.Errorf("Unknown SCM provider: %v", err)
 			continue

--- a/web/auth/scm_storage.go
+++ b/web/auth/scm_storage.go
@@ -28,16 +28,16 @@ func (s *Scms) GetSCM(accessToken string) (sc scm.SCM, ok bool) {
 }
 
 // GetOrCreateSCMEntry returns an scm client for the given remote identity
-// (provider, access token) pair. If no scm client exists for the given
-// remote identity, one will be created and stored for later retrival.
-func (s *Scms) GetOrCreateSCMEntry(logger *zap.Logger, provider, accessToken string) (scm.SCM, error) {
+// (access token). If no scm client exists for the given remote identity,
+// one will be created and stored for later retrieval.
+func (s *Scms) GetOrCreateSCMEntry(logger *zap.Logger, accessToken string) (scm.SCM, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	client, ok := s.scms[accessToken]
 	if ok {
 		return client, nil
 	}
-	client, err := scm.NewSCMClient(logger.Sugar(), provider, accessToken)
+	client, err := scm.NewSCMClient(logger.Sugar(), accessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -39,7 +39,7 @@ func TestGitHubWebHook(t *testing.T) {
 	logger := logq.Zap(true).Sugar()
 	defer func() { _ = logger.Sync() }()
 
-	s, err := scm.NewSCMClient(logger, "github", accessToken)
+	s, err := scm.NewSCMClient(logger, accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -106,7 +106,7 @@ func (wh GitHubWebHook) handlePullRequestPush(payload *github.PushEvent, results
 	taskSum := results.TaskSum(taskName)
 
 	// TODO(espeland): Update this for GitHub web app.
-	sc, err := scm.NewSCMClient(wh.logger, course.GetProvider(), course.GetAccessToken())
+	sc, err := scm.NewSCMClient(wh.logger, course.GetAccessToken())
 	if err != nil {
 		wh.logger.Errorf("Failed to create SCM Client: %v", err)
 		return


### PR DESCRIPTION
This replaces the provider argument to NewSCMClient() with reading the SCM_PROVIDER environment variable.

Fixes #663.

