### PR TITLE
Renamed and removed fields in scm.Repository

### DIFF
--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -302,7 +302,7 @@ func deleteRepositories(client *scm.SCM) cli.ActionFunc {
 				if err := (*client).DeleteRepository(ctx, &scm.RepositoryOptions{ID: repo.ID}); err != nil {
 					errs = append(errs, err)
 				} else {
-					fmt.Println("Deleted repository", repo.WebURL)
+					fmt.Println("Deleted repository", repo.HTMLURL)
 				}
 				if len(errs) > 0 {
 					return cli.NewMultiError(errs...)
@@ -377,7 +377,7 @@ func getRepositories(client *scm.SCM) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		fmt.Println("Found repository ", repo.WebURL)
+		fmt.Println("Found repository ", repo.HTMLURL)
 		return nil
 	}
 }

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -252,7 +252,7 @@ func PopulateDatabaseWithInitialData(t *testing.T, db database.Database, sc scm.
 		dbRepo := &qf.Repository{
 			RepositoryID:   repo.ID,
 			OrganizationID: org.GetID(),
-			HTMLURL:        repo.WebURL,
+			HTMLURL:        repo.HTMLURL,
 			RepoType:       qf.RepoType(repo.Path),
 		}
 		if dbRepo.IsUserRepo() {

--- a/scm/fake.go
+++ b/scm/fake.go
@@ -73,7 +73,6 @@ func (s *FakeSCM) CreateRepository(_ context.Context, opt *CreateRepositoryOptio
 		ID:      uint64(len(s.Repositories) + 1),
 		Path:    opt.Path,
 		HTMLURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path,
-		SSHURL:  "git@example.com:" + opt.Organization.Path + "/" + opt.Path,
 		HTTPURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path + ".git",
 		OrgID:   opt.Organization.ID,
 	}

--- a/scm/fake.go
+++ b/scm/fake.go
@@ -73,7 +73,6 @@ func (s *FakeSCM) CreateRepository(_ context.Context, opt *CreateRepositoryOptio
 		ID:      uint64(len(s.Repositories) + 1),
 		Path:    opt.Path,
 		HTMLURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path,
-		HTTPURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path + ".git",
 		OrgID:   opt.Organization.ID,
 	}
 	s.Repositories[repo.ID] = repo

--- a/scm/fake.go
+++ b/scm/fake.go
@@ -72,7 +72,7 @@ func (s *FakeSCM) CreateRepository(_ context.Context, opt *CreateRepositoryOptio
 	repo := &Repository{
 		ID:      uint64(len(s.Repositories) + 1),
 		Path:    opt.Path,
-		WebURL:  "https://example.com/" + opt.Organization.Path + "/" + opt.Path,
+		HTMLURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path,
 		SSHURL:  "git@example.com:" + opt.Organization.Path + "/" + opt.Path,
 		HTTPURL: "https://example.com/" + opt.Organization.Path + "/" + opt.Path + ".git",
 		OrgID:   opt.Organization.ID,

--- a/scm/github.go
+++ b/scm/github.go
@@ -896,7 +896,7 @@ func toRepository(repo *github.Repository) *Repository {
 		ID:      uint64(repo.GetID()),
 		Path:    repo.GetName(),
 		Owner:   repo.Owner.GetLogin(),
-		WebURL:  repo.GetHTMLURL(),
+		HTMLURL: repo.GetHTMLURL(),
 		SSHURL:  repo.GetSSHURL(),
 		HTTPURL: repo.GetCloneURL(),
 		OrgID:   uint64(repo.Organization.GetID()),

--- a/scm/github.go
+++ b/scm/github.go
@@ -897,7 +897,6 @@ func toRepository(repo *github.Repository) *Repository {
 		Path:    repo.GetName(),
 		Owner:   repo.Owner.GetLogin(),
 		HTMLURL: repo.GetHTMLURL(),
-		HTTPURL: repo.GetCloneURL(),
 		OrgID:   uint64(repo.Organization.GetID()),
 		Size:    uint64(repo.GetSize()),
 	}

--- a/scm/github.go
+++ b/scm/github.go
@@ -897,7 +897,6 @@ func toRepository(repo *github.Repository) *Repository {
 		Path:    repo.GetName(),
 		Owner:   repo.Owner.GetLogin(),
 		HTMLURL: repo.GetHTMLURL(),
-		SSHURL:  repo.GetSSHURL(),
 		HTTPURL: repo.GetCloneURL(),
 		OrgID:   uint64(repo.Organization.GetID()),
 		Size:    uint64(repo.GetSize()),

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -84,7 +84,6 @@ func (s *GitlabSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 		ID:      uint64(repo.ID),
 		Path:    repo.Path,
 		HTMLURL: repo.WebURL,
-		SSHURL:  repo.SSHURLToRepo,
 		HTTPURL: repo.HTTPURLToRepo,
 		OrgID:   opt.Organization.ID,
 	}, nil
@@ -118,7 +117,6 @@ func (s *GitlabSCM) GetRepositories(ctx context.Context, directory *qf.Organizat
 			ID:      uint64(repo.ID),
 			Path:    repo.Path,
 			HTMLURL: repo.WebURL,
-			SSHURL:  repo.SSHURLToRepo,
 			HTTPURL: repo.HTTPURLToRepo,
 			OrgID:   directory.ID,
 		})

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -84,7 +84,6 @@ func (s *GitlabSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 		ID:      uint64(repo.ID),
 		Path:    repo.Path,
 		HTMLURL: repo.WebURL,
-		HTTPURL: repo.HTTPURLToRepo,
 		OrgID:   opt.Organization.ID,
 	}, nil
 }
@@ -117,7 +116,6 @@ func (s *GitlabSCM) GetRepositories(ctx context.Context, directory *qf.Organizat
 			ID:      uint64(repo.ID),
 			Path:    repo.Path,
 			HTMLURL: repo.WebURL,
-			HTTPURL: repo.HTTPURLToRepo,
 			OrgID:   directory.ID,
 		})
 	}

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -83,7 +83,7 @@ func (s *GitlabSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 	return &Repository{
 		ID:      uint64(repo.ID),
 		Path:    repo.Path,
-		WebURL:  repo.WebURL,
+		HTMLURL: repo.WebURL,
 		SSHURL:  repo.SSHURLToRepo,
 		HTTPURL: repo.HTTPURLToRepo,
 		OrgID:   opt.Organization.ID,
@@ -117,7 +117,7 @@ func (s *GitlabSCM) GetRepositories(ctx context.Context, directory *qf.Organizat
 		repositories = append(repositories, &Repository{
 			ID:      uint64(repo.ID),
 			Path:    repo.Path,
-			WebURL:  repo.WebURL,
+			HTMLURL: repo.WebURL,
 			SSHURL:  repo.SSHURLToRepo,
 			HTTPURL: repo.HTTPURLToRepo,
 			OrgID:   directory.ID,

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -142,7 +142,6 @@ type Repository struct {
 	Path    string
 	Owner   string // Only used by GitHub.
 	HTMLURL string // Repository website.
-	SSHURL  string // SSH clone URL, used by GitLab.
 	HTTPURL string // HTTP(S) clone URL.
 	OrgID   uint64
 	Size    uint64

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -142,7 +142,6 @@ type Repository struct {
 	Path    string
 	Owner   string // Only used by GitHub.
 	HTMLURL string // Repository website.
-	HTTPURL string // HTTP(S) clone URL.
 	OrgID   uint64
 	Size    uint64
 }

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -141,7 +141,7 @@ type Repository struct {
 	ID      uint64
 	Path    string
 	Owner   string // Only used by GitHub.
-	WebURL  string // Repository website.
+	HTMLURL string // Repository website.
 	SSHURL  string // SSH clone URL, used by GitLab.
 	HTTPURL string // HTTP(S) clone URL.
 	OrgID   uint64

--- a/web/courses.go
+++ b/web/courses.go
@@ -168,7 +168,7 @@ func (s *QuickFeedService) enrollStudent(ctx context.Context, sc scm.SCM, enroll
 		OrganizationID: course.GetOrganizationID(),
 		RepositoryID:   scmRepo.ID,
 		UserID:         user.ID,
-		HTMLURL:        scmRepo.WebURL,
+		HTMLURL:        scmRepo.HTMLURL,
 		RepoType:       qf.Repository_USER,
 	}
 	if err := s.db.CreateRepository(&userRepo); err != nil {

--- a/web/courses_new.go
+++ b/web/courses_new.go
@@ -79,7 +79,7 @@ func (s *QuickFeedService) createCourse(ctx context.Context, sc scm.SCM, request
 		dbRepo := qf.Repository{
 			OrganizationID: org.ID,
 			RepositoryID:   repo.ID,
-			HTMLURL:        repo.WebURL,
+			HTMLURL:        repo.HTMLURL,
 			RepoType:       qf.RepoType(path),
 		}
 		if err := s.db.CreateRepository(&dbRepo); err != nil {
@@ -119,7 +119,7 @@ func (s *QuickFeedService) createCourse(ctx context.Context, sc scm.SCM, request
 		OrganizationID: org.GetID(),
 		RepositoryID:   scmRepo.ID,
 		UserID:         courseCreator.ID,
-		HTMLURL:        scmRepo.WebURL,
+		HTMLURL:        scmRepo.HTMLURL,
 		RepoType:       qf.Repository_USER,
 	}
 	if err := s.db.CreateRepository(repoQuery); err != nil {

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -75,7 +75,7 @@ func createRepoAndTeam(ctx context.Context, sc scm.SCM, course *qf.Course, group
 		OrganizationID: course.GetOrganizationID(),
 		RepositoryID:   repo.ID,
 		GroupID:        group.GetID(),
-		HTMLURL:        repo.WebURL,
+		HTMLURL:        repo.HTMLURL,
 		RepoType:       qf.Repository_GROUP,
 	}
 	return groupRepo, team, nil


### PR DESCRIPTION
- Renamed scm.Repository.WebURL field to HTMLURL
- Removed SSHURL because it is not used
- Removed HTTPURL field since is same as HTMLURL except .git

Fixes #654.

