### PR TITLE
Adds GetTestSCM and migrate GithubV4 API into scm.SCM interface

### DIFF
--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -16,13 +16,7 @@ import (
 
 func TestFetchAssignments(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	logger := qlog.Logger(t)
-	s, err := scm.NewSCMClient(logger, accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 
 	course := &qf.Course{
 		Name:             "QuickFeed Test Course",
@@ -41,7 +35,7 @@ func TestFetchAssignments(t *testing.T) {
 	}
 	// This just to simulate the behavior of UpdateFromTestsRepo to confirm that the Dockerfile is built
 	course.Dockerfile = dockerfile
-	if err := buildDockerImage(context.Background(), logger, course); err != nil {
+	if err := buildDockerImage(context.Background(), qlog.Logger(t), course); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/assignments/pull_requests_test.go
+++ b/assignments/pull_requests_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/quickfeed/quickfeed/kit/score"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -69,12 +68,9 @@ func TestGetNextReviewer(t *testing.T) {
 // TestPublishFeedbackComment tests creating a feedback comment on a pull request, with the given result.
 func TestPublishFeedbackComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
+
 	results := &score.Results{
 		Scores: []*score.Score{
 			{TestName: "Test1", TaskName: "1", Score: 5, MaxScore: 7, Weight: 2},

--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 )
 
@@ -16,10 +15,7 @@ import (
 // behind newly created issues on the user repositories for manual inspection.
 func TestSynchronizeTasksWithIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	logger := qlog.Logger(t)
-	s := scm.NewGithubV4SCMClient(logger, accessToken)
+	s := scm.GetTestSCM(t)
 
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -33,13 +33,8 @@ func loadRunScript(t *testing.T) string {
 
 func testRunData(t *testing.T, runScriptContent string) *ci.RunData {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
 	// Only used to fetch the user's GitHub login (user name)
-	s, err := scm.NewSCMClient(qtest.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 	userName, err := s.GetUserName(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +42,7 @@ func testRunData(t *testing.T, runScriptContent string) *ci.RunData {
 
 	repo := qf.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	courseID := uint64(1)
-	qf.SetAccessToken(courseID, accessToken)
+	qf.SetAccessToken(courseID, scm.GetAccessToken(t))
 	runData := &ci.RunData{
 		Course: &qf.Course{
 			ID:               courseID,

--- a/scm/env_helper.go
+++ b/scm/env_helper.go
@@ -3,6 +3,8 @@ package scm
 import (
 	"os"
 	"testing"
+
+	"github.com/quickfeed/quickfeed/qlog"
 )
 
 func GetTestOrganization(t *testing.T) string {
@@ -41,4 +43,14 @@ func GetWebHookServer(t *testing.T) string {
 		t.Skipf("This test requires that 'QF_WEBHOOK_SERVER' is set and that you have access to the '%v' GitHub organization", qfTestOrg)
 	}
 	return serverURL
+}
+
+func GetTestSCM(t *testing.T) SCM {
+	t.Helper()
+	accessToken := GetAccessToken(t)
+	s, err := NewSCMClient(qlog.Logger(t), accessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
 }

--- a/scm/fake.go
+++ b/scm/fake.go
@@ -257,6 +257,14 @@ func (*FakeSCM) GetIssues(_ context.Context, _ *RepositoryOptions) ([]*Issue, er
 	}
 }
 
+func (*FakeSCM) DeleteIssue(_ context.Context, _ *RepositoryOptions, _ int) error {
+	return nil
+}
+
+func (*FakeSCM) DeleteIssues(_ context.Context, _ *RepositoryOptions) error {
+	return nil
+}
+
 // CreateIssueComment implements the SCM interface
 func (*FakeSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptions) (int64, error) {
 	return 0, ErrNotSupported{

--- a/scm/fetcher_test.go
+++ b/scm/fetcher_test.go
@@ -7,18 +7,12 @@ import (
 	"testing"
 
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 )
 
 func TestClone(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 	userName, err := s.GetUserName(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -71,12 +65,7 @@ func TestClone(t *testing.T) {
 
 func TestCloneBranch(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 	userName, err := s.GetUserName(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/scm/github.go
+++ b/scm/github.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/gosimple/slug"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
@@ -18,17 +19,21 @@ import (
 type GithubSCM struct {
 	logger      *zap.SugaredLogger
 	client      *github.Client
+	clientV4    *githubv4.Client
 	token       string
 	providerURL string
 }
 
 // NewGithubSCMClient returns a new Github client implementing the SCM interface.
 func NewGithubSCMClient(logger *zap.SugaredLogger, token string) *GithubSCM {
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	client := github.NewClient(oauth2.NewClient(context.Background(), ts))
+	src := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	httpClient := oauth2.NewClient(context.Background(), src)
 	return &GithubSCM{
 		logger:      logger,
-		client:      client,
+		client:      github.NewClient(httpClient),
+		clientV4:    githubv4.NewClient(httpClient),
 		token:       token,
 		providerURL: "github.com",
 	}

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -25,12 +25,7 @@ const (
 
 func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{Name: qfTestOrg})
 	if err != nil {
 		t.Fatal(err)
@@ -47,15 +42,9 @@ func TestGetOrganization(t *testing.T) {
 
 func TestListHooks(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
-
 	hooks, err := s.ListHooks(ctx, nil, qfTestOrg)
 	if err != nil {
 		t.Fatal(err)
@@ -84,26 +73,21 @@ func TestListHooks(t *testing.T) {
 
 func TestCreateHook(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	serverURL := scm.GetWebHookServer(t)
 	// Only enable this test to add a new webhook to your test course organization
 	if serverURL == "" {
 		t.Skip("Disabled pending support for deleting webhooks")
 	}
 
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
-
 	opt := &scm.CreateHookOptions{
 		URL:        serverURL,
 		Secret:     secret,
 		Repository: &scm.Repository{Owner: qfTestOrg, Path: "tests"},
 	}
-	err = s.CreateHook(ctx, opt)
+	err := s.CreateHook(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,11 +217,7 @@ func TestUpdateIssue(t *testing.T) {
 
 func TestRequestReviewers(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
-	s, err := scm.NewSCMClient(qlog.Logger(t), accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := scm.GetTestSCM(t)
 
 	// Set these when testing
 	opt := &scm.RequestReviewersOptions{
@@ -246,8 +226,7 @@ func TestRequestReviewers(t *testing.T) {
 		Number:       1,
 		Reviewers:    []string{"reviewer-login"},
 	}
-
-	err = s.RequestReviewers(context.Background(), opt)
+	err := s.RequestReviewers(context.Background(), opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 )
 
@@ -105,11 +104,8 @@ func TestCreateHook(t *testing.T) {
 // Test case for Creating new Issue on a git Repository
 func TestCreateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	// Creating new Client
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	issue, cleanup := createIssue(t, s, qfTestOrg, qf.StudentRepoName(qfTestUser))
 	defer cleanup()
@@ -122,11 +118,8 @@ func TestCreateIssue(t *testing.T) {
 // NOTE: This test only works if the given repository has no previous issues
 func TestGetIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	// Creating new Client
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -158,11 +151,8 @@ func TestGetIssues(t *testing.T) {
 
 func TestGetIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	// Creating new Client
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -186,11 +176,8 @@ func TestGetIssue(t *testing.T) {
 // Test case for Updating existing Issue in a git Repository
 func TestUpdateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	// Creating new Client
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 
@@ -234,9 +221,8 @@ func TestRequestReviewers(t *testing.T) {
 
 func TestCreateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	body := "Test"
 	opt := &scm.IssueCommentOptions{
@@ -257,9 +243,8 @@ func TestCreateIssueComment(t *testing.T) {
 
 func TestUpdateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	body := "Issue Comment"
 	opt := &scm.IssueCommentOptions{
@@ -287,7 +272,7 @@ func TestUpdateIssueComment(t *testing.T) {
 }
 
 // createIssue on the given repository; returns the issue and a cleanup function.
-func createIssue(t *testing.T, s *scm.GithubV4SCM, org, repo string) (*scm.Issue, func()) {
+func createIssue(t *testing.T, s scm.SCM, org, repo string) (*scm.Issue, func()) {
 	t.Helper()
 	issue, err := s.CreateIssue(context.Background(), &scm.IssueOptions{
 		Organization: org,

--- a/scm/githubv4.go
+++ b/scm/githubv4.go
@@ -6,34 +6,9 @@ import (
 
 	"github.com/google/go-github/v45/github"
 	"github.com/shurcooL/githubv4"
-	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
-type GithubV4SCM struct {
-	GithubSCM
-	clientV4     *githubv4.Client
-	bypassClient *github.Client
-}
-
-func NewGithubV4SCMClient(logger *zap.SugaredLogger, token string) *GithubV4SCM {
-	src := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	httpClient := oauth2.NewClient(context.Background(), src)
-	client := github.NewClient(httpClient)
-	return &GithubV4SCM{
-		GithubSCM: GithubSCM{
-			logger: logger,
-			client: client,
-			token:  token,
-		},
-		clientV4:     githubv4.NewClient(httpClient),
-		bypassClient: client,
-	}
-}
-
-func (s *GithubV4SCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, issueNumber int) error {
+func (s *GithubSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, issueNumber int) error {
 	var q struct {
 		Repository struct {
 			Issue struct {
@@ -65,9 +40,9 @@ func (s *GithubV4SCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, i
 	return s.clientV4.Mutate(ctx, &m, input, nil)
 }
 
-func (s *GithubV4SCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) error {
+func (s *GithubSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) error {
 	// List all open and closed issues (and pull requests)
-	issueList, _, err := s.bypassClient.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{State: "all"})
+	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{State: "all"})
 	if err != nil {
 		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Path, err)
 	}

--- a/scm/githubv4_test.go
+++ b/scm/githubv4_test.go
@@ -7,16 +7,13 @@ import (
 	"time"
 
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 )
 
 func TestDeleteIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	repo, err := s.GetRepository(ctx, &scm.RepositoryOptions{
@@ -76,10 +73,8 @@ func TestDeleteAllIssues(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	qfTestUser := scm.GetTestUser(t)
-
-	s := scm.NewGithubV4SCMClient(qlog.Logger(t), accessToken)
+	s := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -298,6 +298,14 @@ func (*GitlabSCM) GetIssues(_ context.Context, _ *RepositoryOptions) ([]*Issue, 
 	}
 }
 
+func (*GitlabSCM) DeleteIssue(_ context.Context, _ *RepositoryOptions, _ int) error {
+	return nil
+}
+
+func (*GitlabSCM) DeleteIssues(_ context.Context, _ *RepositoryOptions) error {
+	return nil
+}
+
 // CreateIssueComment implements the SCM interface
 func (*GitlabSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptions) (int64, error) {
 	return 0, ErrNotSupported{

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -77,6 +77,10 @@ type SCM interface {
 	GetIssue(ctx context.Context, opt *RepositoryOptions, number int) (*Issue, error)
 	// GetIssues fetches all issues in a repository.
 	GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Issue, error)
+	// DeleteIssue deletes the given issue number in the given repository.
+	DeleteIssue(context.Context, *RepositoryOptions, int) error
+	// DeleteIssues deletes all issues in the given repository.
+	DeleteIssues(context.Context, *RepositoryOptions) error
 
 	// CreateIssueComment creates a comment on a SCM issue.
 	CreateIssueComment(ctx context.Context, opt *IssueCommentOptions) (int64, error)

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -33,16 +33,11 @@ const (
 // TestGitHubWebHook tests listening to events from the tests repository.
 func TestGitHubWebHook(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	accessToken := scm.GetAccessToken(t)
 	serverURL := scm.GetWebHookServer(t)
+	s := scm.GetTestSCM(t)
 
 	logger := logq.Logger(t)
 	defer func() { _ = logger.Sync() }()
-
-	s, err := scm.NewSCMClient(logger, accessToken)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	ctx := context.Background()
 	opt := &scm.CreateHookOptions{
@@ -50,7 +45,7 @@ func TestGitHubWebHook(t *testing.T) {
 		Secret:     secret,
 		Repository: &scm.Repository{Owner: qfTestOrg, Path: "tests"},
 	}
-	err = s.CreateHook(ctx, opt)
+	err := s.CreateHook(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Adds new scm.GetTestSCM() helper
- Migrated away from NewGithubV4SCMClient

Fixes #644
Fixes #690

