### PR TITLE
Improve support for env vars

### DIFF
--- a/internal/env/cert.go
+++ b/internal/env/cert.go
@@ -1,0 +1,34 @@
+package env
+
+import (
+	"os"
+)
+
+const (
+	defaultCertFile = "cert.pem"
+	defaultCertKey  = "key.pem"
+)
+
+var (
+	certFile string
+	certKey  string
+)
+
+func init() {
+	certFile = os.Getenv("QUICKFEED_CERT_FILE")
+	if certFile == "" {
+		certFile = defaultCertFile
+	}
+	certKey = os.Getenv("QUICKFEED_CERT_KEY")
+	if certKey == "" {
+		certKey = defaultCertKey
+	}
+}
+
+func CertFile() string {
+	return certFile
+}
+
+func CertKey() string {
+	return certKey
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,22 @@
+package env_test
+
+import (
+	"testing"
+
+	"github.com/quickfeed/quickfeed/internal/env"
+)
+
+func TestSCMProviderEnv(t *testing.T) {
+	want := "github"
+	got := env.ScmProvider()
+	if got != want {
+		t.Errorf("ScmProvider() = %s, wanted %s", got, want)
+	}
+
+	env.SetFakeProvider(t)
+	want = "fake"
+	got = env.ScmProvider()
+	if got != want {
+		t.Errorf("ScmProvider() = %s, wanted %s", got, want)
+	}
+}

--- a/internal/env/scm.go
+++ b/internal/env/scm.go
@@ -1,6 +1,9 @@
 package env
 
-import "os"
+import (
+	"os"
+	"testing"
+)
 
 const (
 	defaultProvider = "github"
@@ -18,4 +21,11 @@ func init() {
 // ScmProvider returns the current SCM provider supported by this backend.
 func ScmProvider() string {
 	return provider
+}
+
+// SetFakeProvider sets the provider to fake. This is only for testing.
+// The t argument is added as a reminder that this is only for testing.
+func SetFakeProvider(t *testing.T) {
+	t.Helper()
+	provider = "fake"
 }

--- a/internal/env/scm.go
+++ b/internal/env/scm.go
@@ -1,0 +1,21 @@
+package env
+
+import "os"
+
+const (
+	defaultProvider = "github"
+)
+
+var provider string
+
+func init() {
+	provider = os.Getenv("QUICKFEED_SCM_PROVIDER")
+	if provider == "" {
+		provider = defaultProvider
+	}
+}
+
+// ScmProvider returns the current SCM provider supported by this backend.
+func ScmProvider() string {
+	return provider
+}

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/quickfeed/quickfeed/database"
+	"github.com/quickfeed/quickfeed/internal/env"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
@@ -168,7 +169,7 @@ func EnrollTeacher(t *testing.T, db database.Database, student *qf.User, course 
 func FakeProviderMap(t *testing.T) (scm.SCM, *auth.Scms) {
 	t.Helper()
 	scms := auth.NewScms()
-	os.Setenv("SCM_PROVIDER", "fake")
+	env.SetFakeProvider(t)
 	scm, err := scms.GetOrCreateSCMEntry(Logger(t).Desugar(), "token")
 	if err != nil {
 		t.Fatal(err)

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -3,8 +3,8 @@ package scm
 import (
 	"context"
 	"errors"
-	"os"
 
+	"github.com/quickfeed/quickfeed/internal/env"
 	"github.com/quickfeed/quickfeed/qf"
 	"go.uber.org/zap"
 )
@@ -94,21 +94,9 @@ type SCM interface {
 	AcceptRepositoryInvites(context.Context, *RepositoryInvitationOptions) error
 }
 
-const defaultProvider = "github"
-
-var provider string
-
-// Provider returns the current SCM provider supported by this backend.
-func Provider() string {
-	return provider
-}
-
 // NewSCMClient returns a new provider client implementing the SCM interface.
 func NewSCMClient(logger *zap.SugaredLogger, token string) (SCM, error) {
-	provider = os.Getenv("SCM_PROVIDER")
-	if provider == "" {
-		provider = defaultProvider
-	}
+	provider := env.ScmProvider()
 	switch provider {
 	case "github":
 		return NewGithubSCMClient(logger, token), nil


### PR DESCRIPTION
The currently supported variables have default values; it may also
be possible to return an error to signal that a var must be defined.
