### PR TITLE
Report real error from GetOrganization

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -96,8 +96,11 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *GetOrgOptions) (*q
 		// fetch user membership in that organization, if exists
 		membership, _, err := s.client.Organizations.GetOrgMembership(ctx, opt.Username, slug.Make(opt.Name))
 		if err != nil {
-			s.logger.Debug("User ", opt.Username, " is not a member of ", slug.Make(opt.Name))
-			return nil, ErrNotMember
+			return nil, ErrFailedSCM{
+				Method:   "GetOrganization",
+				Message:  fmt.Sprintf("Failed to GetOrganization for (%q, %q)", opt.Username, slug.Make(opt.Name)),
+				GitError: fmt.Errorf("failed to GetOrgMembership(%q, %q): %w", opt.Username, slug.Make(opt.Name), err),
+			}
 		}
 		// membership role must be "admin", if not, return error (possibly to show user)
 		if membership.GetRole() != OrgOwner {

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -24,14 +24,18 @@ const (
 
 func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
+	qfTestUser := scm.GetTestUser(t)
 	s := scm.GetTestSCM(t)
-	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{Name: qfTestOrg})
+	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{
+		Name:     qfTestOrg,
+		Username: qfTestUser,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if qfTestOrg == qf101Org {
 		if org.ID != qf101OrdID {
-			t.Errorf("scm.GetOrganization('%s') = %d, expected %d", qfTestOrg, org.ID, qf101OrdID)
+			t.Errorf("GetOrganization(%q) = %d, expected %d", qfTestOrg, org.ID, qf101OrdID)
 		}
 	} else {
 		// Otherwise, we just print the organization result


### PR DESCRIPTION
Previously `scm.GetOrganization` would translate any err to `ErrNotMember`.

This isn't really changing anything except returning the actual error rather than assuming that the error is an `ErrNotMember`. It is unlikely that this fixes the problem in #565, but at least it should surface the real error in the future should it reappear.

