### PR TITLE
Add env.Load() to load .env file

### DIFF
--- a/cmd/envoy/envoy_config_gen.go
+++ b/cmd/envoy/envoy_config_gen.go
@@ -24,7 +24,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/joho/godotenv"
+	"github.com/quickfeed/quickfeed/internal/env"
 )
 
 const defaultFileFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
@@ -35,7 +35,7 @@ var (
 	keyFile         string
 	_, pwd, _, _    = runtime.Caller(0)
 	codePath        = path.Join(path.Dir(pwd), "../..")
-	env             = filepath.Join(codePath, ".env")
+	dotEnv          = filepath.Join(codePath, ".env")
 	envoyDockerRoot = filepath.Join(codePath, "ci/docker/envoy")
 	certsDir        = path.Join(envoyDockerRoot, "certs")
 )
@@ -339,12 +339,17 @@ func generateSelfSignedCert(opts certOptions) (err error) {
 // It will not override a variable that already exists.
 // Consider the .env file to set development vars or defaults.
 func loadConfigEnv(withTLS bool, config *CertificateConfig) (*EnvoyConfig, error) {
-	err := godotenv.Load(env)
-	if err != nil {
+	if err := env.Load(dotEnv); err != nil {
 		return nil, err
 	}
-
-	return newEnvoyConfig(os.Getenv("DOMAIN"), os.Getenv("SERVER_HOST"), os.Getenv("GRPC_PORT"), os.Getenv("HTTP_PORT"), withTLS, config)
+	return newEnvoyConfig(
+		os.Getenv("DOMAIN"),
+		os.Getenv("SERVER_HOST"),
+		os.Getenv("GRPC_PORT"),
+		os.Getenv("HTTP_PORT"),
+		withTLS,
+		config,
+	)
 }
 
 // TODO: improve parameter handling when generating certificates (keyType, etc).

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/gosimple/slug v1.12.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/joho/godotenv v1.4.0
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/markbates/goth v1.73.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,6 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
-github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,12 +1,13 @@
 package env_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/quickfeed/quickfeed/internal/env"
 )
 
-func TestSCMProviderEnv(t *testing.T) {
+func TestScmProviderEnv(t *testing.T) {
 	want := "github"
 	got := env.ScmProvider()
 	if got != want {
@@ -18,5 +19,48 @@ func TestSCMProviderEnv(t *testing.T) {
 	got = env.ScmProvider()
 	if got != want {
 		t.Errorf("ScmProvider() = %s, wanted %s", got, want)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	fi, err := os.Create(".env")
+	if err != nil {
+		t.Errorf("os.Create() = %v", err)
+	}
+	defer fi.Close()
+
+	want := map[string]string{
+		"QUICKFEED_TEST_ENV":  "test",
+		"QUICKFEED_TEST_ENV2": "test2",
+		"QUICKFEED_TEST_ENV3": "test3",
+		"QUICKFEED_TEST_ENV4": "test4 xyz",
+		"QUICKFEED_TEST_ENV5": "test5 = zyx",
+	}
+
+	input := `QUICKFEED_TEST_ENV=test
+QUICKFEED_TEST_ENV2= test2
+
+QUICKFEED_TEST_ENV3=test3
+# Comment
+QUICKFEED_TEST_ENV4=test4 xyz
+## Another comment
+QUICKFEED_TEST_ENV5=test5 = zyx
+`
+	if _, err = fi.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = env.Load(""); err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range want {
+		if got := os.Getenv(k); got != v {
+			t.Errorf("os.Getenv(%q) = %q, wanted %q", k, got, v)
+		}
+	}
+
+	if err = os.Remove(".env"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/env/load.go
+++ b/internal/env/load.go
@@ -1,0 +1,42 @@
+package env
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+var dotEnvPath = ".env"
+
+// Load loads environment variables from .env in the current folder.
+// Note that the variable's values are not expanded.
+func Load(filename string) error {
+	if filename == "" {
+		filename = dotEnvPath
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if ignore(line) {
+			continue
+		}
+		key, val, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		os.Setenv(strings.TrimSpace(key), strings.TrimSpace(val))
+	}
+
+	return scanner.Err()
+}
+
+func ignore(line string) bool {
+	trimmedLine := strings.TrimSpace(line)
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}


### PR DESCRIPTION
This replaces a dependency for loading .env files with a custom one. The idea is that this can also be used to load the .env file when deploying the quickfeed server. 

Note: this custom env.Load() function will not expand environment variables.

