### PR TITLE
Add SCMInvite interface to limit exposure for user-only SCM clients

### DIFF
--- a/scm/scm.go
+++ b/scm/scm.go
@@ -87,9 +87,16 @@ type SCM interface {
 
 	// RequestReviewers requests reviewers for a pull request.
 	RequestReviewers(ctx context.Context, opt *RequestReviewersOptions) error
+}
 
+type SCMInvite interface {
 	// Accepts repository invite.
 	AcceptRepositoryInvites(context.Context, *RepositoryInvitationOptions) error
+}
+
+// NewInviteOnlySCMClient returns a new provider client implementing the SCM interface.
+func NewInviteOnlySCMClient(logger *zap.SugaredLogger, token string) SCMInvite {
+	return NewGithubSCMClient(logger, token)
 }
 
 // NewSCMClient returns a new provider client implementing the SCM interface.

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -59,12 +59,12 @@ func (q *QuickFeedService) getSCMForCourse(ctx context.Context, courseID uint64)
 }
 
 // getSCMForUser returns an SCM client based on the user's personal access token.
-func (q *QuickFeedService) getSCMForUser(user *qf.User) (scm.SCM, error) {
+func (q *QuickFeedService) getSCMForUser(user *qf.User) (scm.SCMInvite, error) {
 	accessToken, err := user.GetAccessToken(env.ScmProvider())
 	if err != nil {
 		return nil, err
 	}
-	return scm.NewSCMClient(q.logger, accessToken)
+	return scm.NewInviteOnlySCMClient(q.logger, accessToken), nil
 }
 
 // createRepoAndTeam invokes the SCM to create a repository and team for the


### PR DESCRIPTION
This prevents that a user-based SCM is used for other things than accepting repository invitations.

Fixes #709.

