### PR TITLE
Update signup documentation

### DIFF
--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -114,20 +114,14 @@ They will also be added to the `allteachers` team.
 
 ## Student Enrollments
 
-Students enroll into your course by logging in into QuickFeed with their GitHub accounts, following `Join course` link and choosing to enroll into your course. You can access the full list of students (both already enrolled into your course or waiting for enrollment approval) on the `Members` tab of your course page, and accept their enrollments.
+Students enroll in your course by logging in on QuickFeed with their GitHub accounts, find the course among the course cards and click the `Enroll` link.
+You can access the full list of students (both already enrolled and those waiting for approval) in the `Members` menu of your course page, and accept their enrollments.
 
-After a student's enrollment has been accepted, the student will receive three invitations to their registered GitHub email (corresponding with the account they have used to log in to QuickFeed). One to join the course organization, and another two to access the course's `assignments` repository and the student's personal repository.
-
-**Note: it can take GitHub some time to issue the invitation.**
-
-Students can also navigate to
-
-- <https://github.com/{organization_name}/assignments> and
-- <https://github.com/{organization_name}/{student_git_username}-labs>
-
-manually and accept the invitations from there. These links are also available from QuickFeed's frontend interface, in the course menu, under the User Repository heading.
-
+After a student's enrollment has been accepted into a course, the student will have access to the course's `assignment` repository and the student's personal repository, e.g., `student-labs`.
 All students in a course will be added to the `allstudents` team in the course's GitHub organization.
+
+Note that the student may receive three invitation emails from `quickfeed-uis[bot]`.
+These emails can be ignored.
 
 ## Student Groups
 

--- a/doc/templates/signup.md
+++ b/doc/templates/signup.md
@@ -48,24 +48,15 @@ Here are two short videos describing these steps: [Part 1](https://youtu.be/3KJm
 
 ## Signing up for the Course on QuickFeed
 
-1. Click the Plus (+) menu and select “Join course”. Available courses will be listed.
+1. Find the course in card list and click `Enroll`.
 
-2. Find the course and click Enroll.
+2. Wait for the teaching staff to confirm your QuickFeed registration.
 
-3. Wait for the teaching staff to confirm your QuickFeed registration.
+3. Once you have been accepted into the course, you will get access to the course's organization [`dat320-2020`](https://github.com/dat320-2020) on GitHub.
+   That is, you will get access to the `assignments` repository and a personal repository named `username-labs`.
 
-4. You will then be invited to the course organization on GitHub and two separate repositories.
-   You will need to navigate to each of these links and accept these invitations:
-
-   - Navigate to the course organization [dat320-2020](https://github.com/dat320-2020) accept the invitation.
-   - Navigate to the [assignments](https://github.com/dat320-2020/assignments) repository and accept the invitation.
-   - Navigate to your private <https://github.com/dat320-2020/username-labs> repository and accept the invitation.
-     Remember to replace `username` in this link with your own GitHub `username`.
-
-   Several invitation emails will also be sent to the email address associated with your GitHub account.
-   However, emails from GitHub can sometimes take a while to arrive.
-
-5. Once you have accepted the invitations, you will get your own repository under `dat320-2020`, which is the course's organization on GitHub.
+   Note you may receive three invitation emails from `quickfeed-uis[bot]`.
+   These emails can be ignored.
 
 ## Group Sign up on QuickFeed
 

--- a/doc/templates/signup.md
+++ b/doc/templates/signup.md
@@ -40,7 +40,7 @@ Here are two short videos describing these steps: [Part 1](https://youtu.be/3KJm
    A GitHub account is required to sign in to QuickFeed.
    You can skip this step if you already have an account.
 
-2. Click the "Sign in with GitHub" button in [QuickFeed](http://uis.itest.run) to register.
+2. Click the GitHub button in the navigation bar on [QuickFeed](http://uis.itest.run) to register.
    You will then be taken to GitHub's website.
 
 3. Approve that our QuickFeed application may have permission to access to the requested parts of your account.


### PR DESCRIPTION
This PR updates the signup documentation after the revised signup process with automatically accepting invitations on the user's behalf.

Added note about the invitation emails that can be ignored; there does not seem to be a solution to avoid these emails and thus closing #758 as there nothing that we can do.
