### PR TITLE
Cookie passed in header rather than context

### DIFF
--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/quickfeed/quickfeed/qf/qfconnect"
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
+	"github.com/quickfeed/quickfeed/web/auth"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -10,14 +10,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
 	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/internal/env"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/qf/qfconnect"
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
-	"github.com/quickfeed/quickfeed/web/auth"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -196,11 +194,6 @@ func WithUserContext(ctx context.Context, user *qf.User) context.Context {
 	return metadata.NewIncomingContext(ctx, meta)
 }
 
-// WithAuthCookie returns context containing an authentication cookie with JWT.
-func WithAuthCookie(ctx context.Context, cookie *http.Cookie) context.Context {
-	return context.WithValue(ctx, auth.Cookie, auth.TokenString(cookie)) // skipcq: GO-W5003
-}
-
 // AssignmentsWithTasks returns a list of test assignments with tasks for the given course.
 func AssignmentsWithTasks(courseID uint64) []*qf.Assignment {
 	return []*qf.Assignment{
@@ -295,16 +288,5 @@ func QuickFeedClient(url string) qfconnect.QuickFeedServiceClient {
 	if serverUrl == "" {
 		serverUrl = "http://127.0.0.1:8081"
 	}
-	interceptors := connect.WithInterceptors(requestInterceptor())
-	return qfconnect.NewQuickFeedServiceClient(http.DefaultClient, serverUrl, interceptors)
-}
-
-func requestInterceptor() connect.Interceptor {
-	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return connect.UnaryFunc(func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
-			token, _ := ctx.Value(auth.Cookie).(string)
-			request.Header().Set(auth.Cookie, token)
-			return next(ctx, request)
-		})
-	})
+	return qfconnect.NewQuickFeedServiceClient(http.DefaultClient, serverUrl)
 }

--- a/web/auth/jwt.go
+++ b/web/auth/jwt.go
@@ -159,7 +159,7 @@ func (tm *TokenManager) validateSignature(token *jwt.Token) error {
 	return token.Method.Verify(signingString, token.Signature, []byte(tm.secret))
 }
 
-// extractToken extracts a JWT authentication token from metadata.
+// extractToken returns a JWT authentication token extracted from the request header's cookie.
 func extractToken(cookieString string) (string, error) {
 	cookies := strings.Split(cookieString, ";")
 	for _, cookie := range cookies {
@@ -168,7 +168,7 @@ func extractToken(cookieString string) (string, error) {
 			return strings.TrimSpace(cookieValue), nil
 		}
 	}
-	return "", errors.New("failed to get authentication cookie from metadata")
+	return "", errors.New("failed to extract authentication cookie from request header")
 }
 
 // HasCourseStatus returns true if user has enrollment with given status in the course.

--- a/web/auth/jwt_test.go
+++ b/web/auth/jwt_test.go
@@ -99,7 +99,7 @@ func TestUserClaims(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adminClaims, err := manager.GetClaims(auth.CookieString(adminCookie))
+	adminClaims, err := manager.GetClaims(adminCookie.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestUpdateCookie(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newClaims, err := tm.GetClaims(auth.CookieString(newCookie))
+	newClaims, err := tm.GetClaims(newCookie.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/auth/jwt_test.go
+++ b/web/auth/jwt_test.go
@@ -99,7 +99,7 @@ func TestUserClaims(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adminClaims, err := manager.GetClaims(auth.TokenString(adminCookie))
+	adminClaims, err := manager.GetClaims(auth.CookieString(adminCookie))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestUpdateCookie(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newClaims, err := tm.GetClaims(auth.TokenString(newCookie))
+	newClaims, err := tm.GetClaims(auth.CookieString(newCookie))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/auth/util.go
+++ b/web/auth/util.go
@@ -1,7 +1,5 @@
 package auth
 
-import "net/http"
-
 // GetCallbackURL returns the callback URL for a given base URL and a provider.
 func GetCallbackURL(baseURL string) string {
 	return getURL(baseURL, Callback)
@@ -24,9 +22,4 @@ type externalUser struct {
 	Name      string `json:"name"`
 	Login     string `json:"login"`
 	AvatarURL string `json:"avatar_url"`
-}
-
-// CookieString returns a string with JWT with correct format ("auth=JWT").
-func CookieString(cookie *http.Cookie) string {
-	return CookieName + "=" + cookie.Value
 }

--- a/web/auth/util.go
+++ b/web/auth/util.go
@@ -26,7 +26,7 @@ type externalUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-// TokenString returns a string with JWT with correct format ("auth=JWT").
-func TokenString(cookie *http.Cookie) string {
+// CookieString returns a string with JWT with correct format ("auth=JWT").
+func CookieString(cookie *http.Cookie) string {
 	return CookieName + "=" + cookie.Value
 }

--- a/web/interceptor/access_control.go
+++ b/web/interceptor/access_control.go
@@ -85,8 +85,8 @@ func AccessControl(tm *auth.TokenManager) connect.Interceptor {
 				return nil, connect.NewError(connect.CodeUnimplemented,
 					fmt.Errorf("%s failed: message type %T does not implement IDFor interface", method, request))
 			}
-			cookies := request.Header().Get(auth.Cookie)
-			claims, err := tm.GetClaims(cookies)
+			cookie := request.Header().Get(auth.Cookie)
+			claims, err := tm.GetClaims(cookie)
 			if err != nil {
 				return nil, connect.NewError(connect.CodePermissionDenied,
 					fmt.Errorf("AccessControl(%s): failed to get claims from request context: %w", method, err))

--- a/web/interceptor/access_control.go
+++ b/web/interceptor/access_control.go
@@ -79,7 +79,8 @@ var accessRolesFor = map[string]roles{
 func AccessControl(tm *auth.TokenManager) connect.Interceptor {
 	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return connect.UnaryFunc(func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
-			method := request.Spec().Procedure[strings.LastIndex(request.Spec().Procedure, "/")+1:]
+			procedure := request.Spec().Procedure
+			method := procedure[strings.LastIndex(procedure, "/")+1:]
 			req, ok := request.Any().(requestID)
 			if !ok {
 				return nil, connect.NewError(connect.CodeUnimplemented,

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -410,6 +410,12 @@ func TestAccessControl(t *testing.T) {
 	}
 }
 
+func requestWithCookie[T any](message *T, cookie string) *connect.Request[T] {
+	request := connect.NewRequest(message)
+	request.Header().Set(auth.Cookie, cookie)
+	return request
+}
+
 func checkAccess(t *testing.T, err error, wantAccess bool, method string) {
 	t.Helper()
 	if connErr, ok := err.(*connect.Error); ok {

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -133,7 +133,7 @@ func TestAccessControl(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return auth.CookieString(cookie)
+		return cookie.String()
 	}
 	courseAdminCookie := f(t, courseAdmin.ID)
 	groupStudentCookie := f(t, groupStudent.ID)

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -418,13 +418,12 @@ func requestWithCookie[T any](message *T, cookie string) *connect.Request[T] {
 
 func checkAccess(t *testing.T, err error, wantAccess bool, method string) {
 	t.Helper()
-	t.Logf("%#v", connect.CodeOf(err))
 	if connErr, ok := err.(*connect.Error); ok {
 		gotCode := connErr.Code()
 		wantCode := connect.CodePermissionDenied
 		gotAccess := gotCode == wantCode
 		if gotAccess == wantAccess {
-			t.Errorf("%23s: (%v == %v) = %t, want %t: %s", method, gotCode, wantCode, gotAccess, !wantAccess, connErr.Error())
+			t.Errorf("%23s: (%v == %v) = %t, want %t", method, gotCode, wantCode, gotAccess, !wantAccess)
 		}
 	} else if err != nil && wantAccess {
 		// got error and want access; expected non-error or not access

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -27,7 +27,7 @@ const (
 
 type accessTests []struct {
 	name     string
-	ctx      context.Context
+	cookie   string
 	userID   uint64
 	courseID uint64
 	groupID  uint64
@@ -128,41 +128,41 @@ func TestAccessControl(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	f := func(t *testing.T, id uint64) context.Context {
-		token, err := tm.NewAuthCookie(id)
+	f := func(t *testing.T, id uint64) string {
+		cookie, err := tm.NewAuthCookie(id)
 		if err != nil {
 			t.Fatal(err)
 		}
-		return qtest.WithAuthCookie(ctx, token)
+		return auth.CookieString(cookie)
 	}
-	courseAdminContext := f(t, courseAdmin.ID)
-	groupStudentContext := f(t, groupStudent.ID)
-	studentContext := f(t, student.ID)
-	userContext := f(t, user.ID)
-	adminContext := f(t, admin.ID)
+	courseAdminCookie := f(t, courseAdmin.ID)
+	groupStudentCookie := f(t, groupStudent.ID)
+	studentCookie := f(t, student.ID)
+	userCookie := f(t, user.ID)
+	adminCookie := f(t, admin.ID)
 
 	freeAccessTest := accessTests{
-		{"admin", courseAdminContext, 0, course.ID, 0, true},
-		{"student", studentContext, 0, course.ID, 0, true},
-		{"student", groupStudentContext, 0, course.ID, 0, true},
-		{"user", userContext, 0, course.ID, 0, true},
-		{"non-teacher admin", adminContext, 0, course.ID, 0, true},
-		{"empty context", ctx, 0, course.ID, 0, false},
+		{"admin", courseAdminCookie, 0, course.ID, 0, true},
+		{"student", studentCookie, 0, course.ID, 0, true},
+		{"student", groupStudentCookie, 0, course.ID, 0, true},
+		{"user", userCookie, 0, course.ID, 0, true},
+		{"non-teacher admin", adminCookie, 0, course.ID, 0, true},
+		{"empty context", "", 0, course.ID, 0, false},
 	}
 	for _, tt := range freeAccessTest {
 		t.Run("UnrestrictedAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.GetUser(tt.ctx, connect.NewRequest(&qf.Void{}))
+			_, err := client.GetUser(ctx, requestWithCookie(&qf.Void{}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetUser")
-			_, err = client.GetCourse(tt.ctx, connect.NewRequest(&qf.CourseRequest{CourseID: tt.courseID}))
+			_, err = client.GetCourse(ctx, requestWithCookie(&qf.CourseRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetCourse")
-			_, err = client.GetCourses(tt.ctx, connect.NewRequest(&qf.Void{}))
+			_, err = client.GetCourses(ctx, requestWithCookie(&qf.Void{}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetCourses")
 		})
 	}
 
 	userAccessTests := accessTests{
-		{"correct user ID", userContext, user.ID, course.ID, 0, true},
-		{"incorrect user ID", userContext, groupStudent.ID, course.ID, 0, false},
+		{"correct user ID", userCookie, user.ID, course.ID, 0, true},
+		{"incorrect user ID", userCookie, groupStudent.ID, course.ID, 0, false},
 	}
 	for _, tt := range userAccessTests {
 		t.Run("UserAccess/"+tt.name, func(t *testing.T) {
@@ -173,226 +173,226 @@ func TestAccessControl(t *testing.T) {
 			enrolRequest := &qf.EnrollmentStatusRequest{
 				UserID: tt.userID,
 			}
-			_, err := client.CreateEnrollment(tt.ctx, connect.NewRequest(enrol))
+			_, err := client.CreateEnrollment(ctx, requestWithCookie(enrol, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateEnrollment")
-			_, err = client.UpdateCourseVisibility(tt.ctx, connect.NewRequest(enrol))
+			_, err = client.UpdateCourseVisibility(ctx, requestWithCookie(enrol, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateCourseVisibility")
-			_, err = client.GetCoursesByUser(tt.ctx, connect.NewRequest(enrolRequest))
+			_, err = client.GetCoursesByUser(ctx, requestWithCookie(enrolRequest, tt.cookie))
 			checkAccess(t, err, tt.access, "GetCoursesByUser")
-			_, err = client.UpdateUser(tt.ctx, connect.NewRequest(&qf.User{ID: tt.userID}))
+			_, err = client.UpdateUser(ctx, requestWithCookie(&qf.User{ID: tt.userID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateUser")
-			_, err = client.GetEnrollmentsByUser(tt.ctx, connect.NewRequest(enrolRequest))
+			_, err = client.GetEnrollmentsByUser(ctx, requestWithCookie(enrolRequest, tt.cookie))
 			checkAccess(t, err, tt.access, "GetEnrollmentsByCourse")
-			_, err = client.UpdateUser(tt.ctx, connect.NewRequest(&qf.User{ID: tt.userID}))
+			_, err = client.UpdateUser(ctx, requestWithCookie(&qf.User{ID: tt.userID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateUser")
 		})
 	}
 
 	studentAccessTests := accessTests{
-		{"course admin", courseAdminContext, courseAdmin.ID, course.ID, 0, true},
-		{"admin, not enrolled in a course", adminContext, admin.ID, course.ID, 0, false},
-		{"user, not enrolled in the course", userContext, user.ID, course.ID, 0, false},
-		{"student", studentContext, student.ID, course.ID, 0, true},
-		{"student of another course", studentContext, student.ID, 123, 0, false},
+		{"course admin", courseAdminCookie, courseAdmin.ID, course.ID, 0, true},
+		{"admin, not enrolled in a course", adminCookie, admin.ID, course.ID, 0, false},
+		{"user, not enrolled in the course", userCookie, user.ID, course.ID, 0, false},
+		{"student", studentCookie, student.ID, course.ID, 0, true},
+		{"student of another course", studentCookie, student.ID, 123, 0, false},
 	}
 	for _, tt := range studentAccessTests {
 		t.Run("StudentAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.GetSubmissions(tt.ctx, connect.NewRequest(&qf.SubmissionRequest{
+			_, err := client.GetSubmissions(ctx, requestWithCookie(&qf.SubmissionRequest{
 				UserID:   tt.userID,
 				CourseID: tt.courseID,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetSubmissions")
-			_, err = client.GetAssignments(tt.ctx, connect.NewRequest(&qf.CourseRequest{CourseID: tt.courseID}))
+			_, err = client.GetAssignments(ctx, requestWithCookie(&qf.CourseRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetAssignments")
-			_, err = client.GetEnrollmentsByCourse(tt.ctx, connect.NewRequest(&qf.EnrollmentRequest{CourseID: tt.courseID}))
+			_, err = client.GetEnrollmentsByCourse(ctx, requestWithCookie(&qf.EnrollmentRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetEnrollmentsByCourse")
-			_, err = client.GetRepositories(tt.ctx, connect.NewRequest(&qf.URLRequest{CourseID: tt.courseID}))
+			_, err = client.GetRepositories(ctx, requestWithCookie(&qf.URLRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetRepositories")
-			_, err = client.GetGroupByUserAndCourse(tt.ctx, connect.NewRequest(&qf.GroupRequest{
+			_, err = client.GetGroupByUserAndCourse(ctx, requestWithCookie(&qf.GroupRequest{
 				CourseID: tt.courseID,
 				UserID:   tt.userID,
 				GroupID:  0,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetGroupByUserAndCourse")
 		})
 	}
 
 	groupAccessTests := accessTests{
-		{"student in a group", groupStudentContext, groupStudent.ID, course.ID, group.ID, true},
-		{"student, not in a group", studentContext, student.ID, course.ID, group.ID, false},
-		{"student in a group, wrong group ID in request", studentContext, student.ID, course.ID, 123, false},
+		{"student in a group", groupStudentCookie, groupStudent.ID, course.ID, group.ID, true},
+		{"student, not in a group", studentCookie, student.ID, course.ID, group.ID, false},
+		{"student in a group, wrong group ID in request", studentCookie, student.ID, course.ID, 123, false},
 	}
 	for _, tt := range groupAccessTests {
 		t.Run("GroupAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.GetGroup(tt.ctx, connect.NewRequest(&qf.GetGroupRequest{GroupID: tt.groupID}))
+			_, err := client.GetGroup(ctx, requestWithCookie(&qf.GetGroupRequest{GroupID: tt.groupID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetGroup")
 		})
 	}
 
 	teacherAccessTests := accessTests{
-		{"course teacher", courseAdminContext, groupStudent.ID, course.ID, group.ID, true},
-		{"student", studentContext, student.ID, course.ID, group.ID, false},
-		{"admin, not enrolled in the course", adminContext, admin.ID, course.ID, group.ID, false},
+		{"course teacher", courseAdminCookie, groupStudent.ID, course.ID, group.ID, true},
+		{"student", studentCookie, student.ID, course.ID, group.ID, false},
+		{"admin, not enrolled in the course", adminCookie, admin.ID, course.ID, group.ID, false},
 	}
 	for _, tt := range teacherAccessTests {
 		t.Run("TeacherAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.GetGroup(tt.ctx, connect.NewRequest(&qf.GetGroupRequest{GroupID: tt.groupID}))
+			_, err := client.GetGroup(ctx, requestWithCookie(&qf.GetGroupRequest{GroupID: tt.groupID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetGroup")
-			_, err = client.DeleteGroup(tt.ctx, connect.NewRequest(&qf.GroupRequest{
+			_, err = client.DeleteGroup(ctx, requestWithCookie(&qf.GroupRequest{
 				GroupID:  tt.groupID,
 				CourseID: tt.courseID,
 				UserID:   tt.userID,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "DeleteGroup")
-			_, err = client.UpdateGroup(tt.ctx, connect.NewRequest(&qf.Group{CourseID: tt.courseID}))
+			_, err = client.UpdateGroup(ctx, requestWithCookie(&qf.Group{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateGroup")
-			_, err = client.UpdateCourse(tt.ctx, connect.NewRequest(course))
+			_, err = client.UpdateCourse(ctx, requestWithCookie(course, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateCourse")
-			_, err = client.UpdateEnrollments(tt.ctx, connect.NewRequest(&qf.Enrollments{
+			_, err = client.UpdateEnrollments(ctx, requestWithCookie(&qf.Enrollments{
 				Enrollments: []*qf.Enrollment{{ID: 1, CourseID: tt.courseID}},
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateEnrollments")
-			_, err = client.UpdateAssignments(tt.ctx, connect.NewRequest(&qf.CourseRequest{CourseID: tt.courseID}))
+			_, err = client.UpdateAssignments(ctx, requestWithCookie(&qf.CourseRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateAssignments")
-			_, err = client.UpdateSubmission(tt.ctx, connect.NewRequest(&qf.UpdateSubmissionRequest{SubmissionID: 1, CourseID: tt.courseID}))
+			_, err = client.UpdateSubmission(ctx, requestWithCookie(&qf.UpdateSubmissionRequest{SubmissionID: 1, CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateSubmission")
-			_, err = client.UpdateSubmissions(tt.ctx, connect.NewRequest(&qf.UpdateSubmissionsRequest{AssignmentID: 1, CourseID: tt.courseID}))
+			_, err = client.UpdateSubmissions(ctx, requestWithCookie(&qf.UpdateSubmissionsRequest{AssignmentID: 1, CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateSubmissions")
-			_, err = client.RebuildSubmissions(tt.ctx, connect.NewRequest(&qf.RebuildRequest{
+			_, err = client.RebuildSubmissions(ctx, requestWithCookie(&qf.RebuildRequest{
 				AssignmentID: 1,
 				CourseID:     tt.courseID,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "RebuildSubmissions")
-			_, err = client.CreateBenchmark(tt.ctx, connect.NewRequest(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}))
+			_, err = client.CreateBenchmark(ctx, requestWithCookie(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateBenchmark")
-			_, err = client.UpdateBenchmark(tt.ctx, connect.NewRequest(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}))
+			_, err = client.UpdateBenchmark(ctx, requestWithCookie(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateBenchmark")
-			_, err = client.DeleteBenchmark(tt.ctx, connect.NewRequest(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}))
+			_, err = client.DeleteBenchmark(ctx, requestWithCookie(&qf.GradingBenchmark{CourseID: tt.courseID, AssignmentID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "DeleteBenchmark")
-			_, err = client.CreateCriterion(tt.ctx, connect.NewRequest(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}))
+			_, err = client.CreateCriterion(ctx, requestWithCookie(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateCriterion")
-			_, err = client.UpdateCriterion(tt.ctx, connect.NewRequest(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}))
+			_, err = client.UpdateCriterion(ctx, requestWithCookie(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateCriterion")
-			_, err = client.DeleteCriterion(tt.ctx, connect.NewRequest(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}))
+			_, err = client.DeleteCriterion(ctx, requestWithCookie(&qf.GradingCriterion{CourseID: tt.courseID, BenchmarkID: 1}, tt.cookie))
 			checkAccess(t, err, tt.access, "DeleteCriterion")
-			_, err = client.CreateReview(tt.ctx, connect.NewRequest(&qf.ReviewRequest{
+			_, err = client.CreateReview(ctx, requestWithCookie(&qf.ReviewRequest{
 				CourseID: tt.courseID,
 				Review: &qf.Review{
 					SubmissionID: 1,
 					ReviewerID:   1,
 				},
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateReview")
-			_, err = client.UpdateReview(tt.ctx, connect.NewRequest(&qf.ReviewRequest{
+			_, err = client.UpdateReview(ctx, requestWithCookie(&qf.ReviewRequest{
 				CourseID: tt.courseID,
 				Review: &qf.Review{
 					SubmissionID: 1,
 					ReviewerID:   1,
 				},
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateReview")
-			_, err = client.GetReviewers(tt.ctx, connect.NewRequest(&qf.SubmissionReviewersRequest{
+			_, err = client.GetReviewers(ctx, requestWithCookie(&qf.SubmissionReviewersRequest{
 				CourseID:     tt.courseID,
 				SubmissionID: 1,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetReviewers")
-			_, err = client.IsEmptyRepo(tt.ctx, connect.NewRequest(&qf.RepositoryRequest{CourseID: tt.courseID}))
+			_, err = client.IsEmptyRepo(ctx, requestWithCookie(&qf.RepositoryRequest{CourseID: tt.courseID}, tt.cookie))
 			checkAccess(t, err, tt.access, "IsEmptyRepo")
 		})
 	}
 
 	courseAdminTests := accessTests{
-		{"admin, not enrolled", adminContext, 0, course.ID, 0, false},
+		{"admin, not enrolled", adminCookie, 0, course.ID, 0, false},
 	}
 	for _, tt := range courseAdminTests {
 		t.Run("CourseAdminAccess/"+tt.name, func(t *testing.T) {
-			_, err = client.GetSubmissionsByCourse(tt.ctx, connect.NewRequest(&qf.SubmissionsForCourseRequest{
+			_, err = client.GetSubmissionsByCourse(ctx, requestWithCookie(&qf.SubmissionsForCourseRequest{
 				CourseID: tt.courseID,
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetSubmissionsByCourse")
 		})
 	}
 
 	adminAccessTests := accessTests{
-		{"admin (accessing own info)", courseAdminContext, courseAdmin.ID, course.ID, group.ID, true},
-		{"admin (accessing other user's info)", courseAdminContext, user.ID, course.ID, group.ID, true},
-		{"non admin (accessing admin's info)", studentContext, courseAdmin.ID, course.ID, group.ID, false},
-		{"non admin (accessing other user's info)", studentContext, user.ID, course.ID, group.ID, false},
+		{"admin (accessing own info)", courseAdminCookie, courseAdmin.ID, course.ID, group.ID, true},
+		{"admin (accessing other user's info)", courseAdminCookie, user.ID, course.ID, group.ID, true},
+		{"non admin (accessing admin's info)", studentCookie, courseAdmin.ID, course.ID, group.ID, false},
+		{"non admin (accessing other user's info)", studentCookie, user.ID, course.ID, group.ID, false},
 	}
 	for _, tt := range adminAccessTests {
 		t.Run("AdminAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.UpdateUser(tt.ctx, connect.NewRequest(&qf.User{ID: tt.userID}))
+			_, err := client.UpdateUser(ctx, requestWithCookie(&qf.User{ID: tt.userID}, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateUser")
-			_, err = client.GetEnrollmentsByUser(tt.ctx, connect.NewRequest(&qf.EnrollmentStatusRequest{UserID: tt.userID}))
+			_, err = client.GetEnrollmentsByUser(ctx, requestWithCookie(&qf.EnrollmentStatusRequest{UserID: tt.userID}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetEnrollmentsByUser")
-			_, err = client.GetUsers(tt.ctx, connect.NewRequest(&qf.Void{}))
+			_, err = client.GetUsers(ctx, requestWithCookie(&qf.Void{}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetUsers")
-			_, err = client.GetOrganization(tt.ctx, connect.NewRequest(&qf.OrgRequest{OrgName: "testorg"}))
+			_, err = client.GetOrganization(ctx, requestWithCookie(&qf.OrgRequest{OrgName: "testorg"}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetOrganization")
-			_, err = client.CreateCourse(tt.ctx, connect.NewRequest(course))
+			_, err = client.CreateCourse(ctx, requestWithCookie(course, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateCourse")
-			_, err = client.GetUserByCourse(tt.ctx, connect.NewRequest(&qf.CourseUserRequest{
+			_, err = client.GetUserByCourse(ctx, requestWithCookie(&qf.CourseUserRequest{
 				CourseCode: course.Code,
 				CourseYear: course.Year,
 				UserLogin:  "student",
-			}))
+			}, tt.cookie))
 			checkAccess(t, err, tt.access, "GetUserByCourse")
 		})
 	}
 
 	createGroupTests := []struct {
 		name   string
-		ctx    context.Context
+		cookie string
 		group  *qf.Group
 		access bool
 	}{
-		{"valid student, not in the request group", studentContext, &qf.Group{
+		{"valid student, not in the request group", studentCookie, &qf.Group{
 			CourseID: course.ID,
 		}, false},
-		{"valid student", studentContext, &qf.Group{
+		{"valid student", studentCookie, &qf.Group{
 			Name:     "test",
 			CourseID: course.ID,
 			Users:    []*qf.User{student},
 		}, true},
-		{"course teacher", courseAdminContext, &qf.Group{
+		{"course teacher", courseAdminCookie, &qf.Group{
 			CourseID: course.ID,
 			Users:    []*qf.User{courseAdmin},
 		}, true},
-		{"admin, not a teacher", adminContext, &qf.Group{
+		{"admin, not a teacher", adminCookie, &qf.Group{
 			CourseID: course.ID,
 		}, false},
 	}
 
 	for _, tt := range createGroupTests {
 		t.Run("CreateGroupAccess/"+tt.name, func(t *testing.T) {
-			_, err := client.CreateGroup(tt.ctx, connect.NewRequest(tt.group))
+			_, err := client.CreateGroup(ctx, requestWithCookie(tt.group, tt.cookie))
 			checkAccess(t, err, tt.access, "CreateGroup")
 		})
 	}
 
 	adminStatusChangeTests := []struct {
 		name   string
-		ctx    context.Context
+		cookie string
 		user   *qf.User
 		access bool
 	}{
-		{"admin demoting a user", courseAdminContext, &qf.User{
+		{"admin demoting a user", courseAdminCookie, &qf.User{
 			ID:      admin.ID,
 			IsAdmin: false,
 		}, true},
-		{"admin promoting a user", courseAdminContext, &qf.User{
+		{"admin promoting a user", courseAdminCookie, &qf.User{
 			ID:      admin.ID,
 			IsAdmin: true,
 		}, true},
-		{"admin demoting self", courseAdminContext, &qf.User{
+		{"admin demoting self", courseAdminCookie, &qf.User{
 			ID:      courseAdmin.ID,
 			IsAdmin: false,
 		}, true},
-		{"user promoting another user", userContext, &qf.User{
+		{"user promoting another user", userCookie, &qf.User{
 			ID:      groupStudent.ID,
 			IsAdmin: true,
 		}, false},
-		{"user promoting self", userContext, &qf.User{
+		{"user promoting self", userCookie, &qf.User{
 			ID:      user.ID,
 			IsAdmin: true,
 		}, false},
@@ -400,7 +400,7 @@ func TestAccessControl(t *testing.T) {
 
 	for _, tt := range adminStatusChangeTests {
 		t.Run("AdminStatusChange/"+tt.name, func(t *testing.T) {
-			_, err := client.UpdateUser(tt.ctx, connect.NewRequest(tt.user))
+			_, err := client.UpdateUser(ctx, requestWithCookie(tt.user, tt.cookie))
 			checkAccess(t, err, tt.access, "UpdateUser")
 		})
 	}
@@ -418,12 +418,13 @@ func requestWithCookie[T any](message *T, cookie string) *connect.Request[T] {
 
 func checkAccess(t *testing.T, err error, wantAccess bool, method string) {
 	t.Helper()
+	t.Logf("%#v", connect.CodeOf(err))
 	if connErr, ok := err.(*connect.Error); ok {
 		gotCode := connErr.Code()
 		wantCode := connect.CodePermissionDenied
 		gotAccess := gotCode == wantCode
 		if gotAccess == wantAccess {
-			t.Errorf("%23s: (%v == %v) = %t, want %t", method, gotCode, wantCode, gotAccess, !wantAccess)
+			t.Errorf("%23s: (%v == %v) = %t, want %t: %s", method, gotCode, wantCode, gotAccess, !wantAccess, connErr.Error())
 		}
 	} else if err != nil && wantAccess {
 		// got error and want access; expected non-error or not access

--- a/web/interceptor/auth_test.go
+++ b/web/interceptor/auth_test.go
@@ -81,8 +81,8 @@ func TestUserVerifier(t *testing.T) {
 	}{
 		{code: connect.CodeUnauthenticated, cookie: "", wantUser: nil},
 		{code: connect.CodeUnauthenticated, cookie: "should fail", wantUser: nil},
-		{code: 0, cookie: auth.CookieString(adminCookie), wantUser: adminUser},
-		{code: 0, cookie: auth.CookieString(studentCookie), wantUser: student},
+		{code: 0, cookie: adminCookie.String(), wantUser: adminUser},
+		{code: 0, cookie: studentCookie.String(), wantUser: student},
 	}
 
 	ctx := context.Background()

--- a/web/interceptor/auth_test.go
+++ b/web/interceptor/auth_test.go
@@ -36,11 +36,11 @@ func TestUserVerifier(t *testing.T) {
 	adminUser := qtest.CreateFakeUser(t, db, 1)
 	student := qtest.CreateFakeUser(t, db, 56)
 
-	adminToken, err := tm.NewAuthCookie(adminUser.ID)
+	adminCookie, err := tm.NewAuthCookie(adminUser.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	studentToken, err := tm.NewAuthCookie(student.ID)
+	studentCookie, err := tm.NewAuthCookie(student.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,24 +76,18 @@ func TestUserVerifier(t *testing.T) {
 
 	userTest := []struct {
 		code     connect.Code
-		metadata bool
-		token    string
+		cookie   string
 		wantUser *qf.User
 	}{
-		{code: connect.CodeUnauthenticated, metadata: false, token: "", wantUser: nil},
-		{code: connect.CodeUnauthenticated, metadata: true, token: "should fail", wantUser: nil},
-		{code: 0, metadata: true, token: auth.TokenString(adminToken), wantUser: adminUser},
-		{code: 0, metadata: true, token: auth.TokenString(studentToken), wantUser: student},
+		{code: connect.CodeUnauthenticated, cookie: "", wantUser: nil},
+		{code: connect.CodeUnauthenticated, cookie: "should fail", wantUser: nil},
+		{code: 0, cookie: auth.CookieString(adminCookie), wantUser: adminUser},
+		{code: 0, cookie: auth.CookieString(studentCookie), wantUser: student},
 	}
 
 	ctx := context.Background()
 	for _, user := range userTest {
-		req := connect.NewRequest(&qf.Void{})
-		if user.metadata {
-			ctx = context.WithValue(ctx, auth.Cookie, user.token) // skipcq: GO-W5003
-		}
-
-		gotUser, err := client.GetUser(ctx, req)
+		gotUser, err := client.GetUser(ctx, requestWithCookie(&qf.Void{}, user.cookie))
 		if err != nil {
 			// zero codes won't actually reach this check, but that's okay, since zero is CodeOK
 			if gotCode := connect.CodeOf(err); gotCode != user.code {

--- a/web/interceptor/helpers.go
+++ b/web/interceptor/helpers.go
@@ -15,8 +15,8 @@ import (
 // getAuthenticatedContext returns a new context with the user ID attached to it.
 // If the context does not contain a valid session cookie, it returns an error.
 func getAuthenticatedContext(ctx context.Context, header http.Header, logger *zap.SugaredLogger, tm *auth.TokenManager) (context.Context, *http.Cookie, error) {
-	cookies := header.Get(auth.Cookie)
-	claims, err := tm.GetClaims(cookies)
+	cookie := header.Get(auth.Cookie)
+	claims, err := tm.GetClaims(cookie)
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("UnaryUserVerifier(): failed to extract claims from JWT: %w", err))
 	}

--- a/web/interceptor/tokens.go
+++ b/web/interceptor/tokens.go
@@ -32,8 +32,8 @@ var tokenUpdateMethods = map[string]func(string, *auth.TokenManager, userIDs) er
 	"UpdateEnrollments": defaultTokenUpdater, // User enrolled into a new course or promoted to TA.
 
 	"CreateCourse": // The signed in user gets the teacher role in the new course.
-	func(cookies string, tm *auth.TokenManager, _ userIDs) error {
-		claims, err := tm.GetClaims(cookies)
+	func(cookie string, tm *auth.TokenManager, _ userIDs) error {
+		claims, err := tm.GetClaims(cookie)
 		if err != nil {
 			return err
 		}
@@ -62,8 +62,8 @@ func TokenRefresher(tm *auth.TokenManager) connect.Interceptor {
 			method := procedure[strings.LastIndex(procedure, "/")+1:]
 			if tokenUpdateFn, ok := tokenUpdateMethods[method]; ok {
 				if msg, ok := request.Any().(userIDs); ok {
-					cookies := request.Header().Get(auth.Cookie)
-					if err := tokenUpdateFn(cookies, tm, msg); err != nil {
+					cookie := request.Header().Get(auth.Cookie)
+					if err := tokenUpdateFn(cookie, tm, msg); err != nil {
 						return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("TokenRefresher(%s): %v", method, err))
 					}
 				} else {

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -61,7 +61,7 @@ func TestRefreshTokens(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return auth.CookieString(cookie)
+		return cookie.String()
 	}
 
 	admin := qtest.CreateFakeUser(t, db, 1)


### PR DESCRIPTION
- Removed interceptor and function inserting cookie into context
- Renamed `TokenString` func to `CookieString`
- Added generic function to insert cookie into request header
- Updated and slightly simplified TestUserVerifier
- Update access control tests to use `requestWithCookie`
- Update refresh tokens test to use `requestWithCookie`
- Update func call `TokenString(...)` -> `CookieString(...)`
