### PR TITLE
Remove getCurrentUser(ctx)

### DIFF
--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/quickfeed/quickfeed/database"
@@ -17,7 +16,6 @@ import (
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web/auth"
-	"google.golang.org/grpc/metadata"
 )
 
 // TestDB returns a test database and close function.
@@ -187,10 +185,10 @@ func RandomString(t *testing.T) string {
 	return fmt.Sprintf("%x", sha256.Sum256(randomness))[:6]
 }
 
-// WithUserContext is a test helper function to create metadata for the
-// given user mimicking the context coming from the browser.
+// WithUserContext returns the context augmented with the given user's ID.
+// This aims to mimic the claims.Context() method.
 func WithUserContext(ctx context.Context, user *qf.User) context.Context {
-	return metadata.NewIncomingContext(ctx, metadata.Pairs(auth.UserKey, strconv.FormatUint(user.GetID(), 10)))
+	return context.WithValue(ctx, auth.ContextKeyUserID, user.GetID())
 }
 
 // AssignmentsWithTasks returns a list of test assignments with tasks for the given course.

--- a/web/access_control.go
+++ b/web/access_control.go
@@ -10,11 +10,7 @@ import (
 	"github.com/quickfeed/quickfeed/web/auth"
 )
 
-// ErrInvalidUserInfo is returned to user if user information in context is invalid.
-var (
-	ErrInvalidUserInfo     = status.Error(codes.PermissionDenied, "authorization failed. please try to logout and sign in again")
-	ErrMissingInstallation = status.Error(codes.PermissionDenied, "github application is not installed on the course organization")
-)
+var ErrMissingInstallation = status.Error(codes.PermissionDenied, "github application is not installed on the course organization")
 
 func userID(ctx context.Context) uint64 {
 	return ctx.Value(auth.ContextKeyUserID).(uint64)

--- a/web/access_control.go
+++ b/web/access_control.go
@@ -20,11 +20,6 @@ func userID(ctx context.Context) uint64 {
 	return ctx.Value(auth.ContextKeyUserID).(uint64)
 }
 
-func (s *QuickFeedService) getCurrentUser(ctx context.Context) (*qf.User, error) {
-	// return the user corresponding to userID, or an error.
-	return s.db.GetUser(userID(ctx))
-}
-
 // hasCourseAccess returns true if the given user has access to the given course,
 // as defined by the check function.
 func (s *QuickFeedService) hasCourseAccess(userID, courseID uint64, check func(*qf.Enrollment) bool) bool {

--- a/web/auth/consts.go
+++ b/web/auth/consts.go
@@ -12,7 +12,6 @@ const (
 const (
 	Cookie               = "cookie"
 	CookieName           = "auth"
-	UserKey              = "user"
 	SetCookie            = "Set-Cookie"
 	tokenExpirationTime  = 15 * time.Minute
 	cookieExpirationTime = 24 * time.Hour * 14 // 2 weeks

--- a/web/auth/consts.go
+++ b/web/auth/consts.go
@@ -2,6 +2,13 @@ package auth
 
 import "time"
 
+type contextKey int
+
+const (
+	contextNone contextKey = iota
+	ContextKeyUserID
+)
+
 const (
 	Cookie               = "cookie"
 	CookieName           = "auth"

--- a/web/auth/jwt.go
+++ b/web/auth/jwt.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -169,6 +170,11 @@ func extractToken(cookieString string) (string, error) {
 		}
 	}
 	return "", errors.New("failed to extract authentication cookie from request header")
+}
+
+// Context returns the given context augmented with the claims' user ID.
+func (c Claims) Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ContextKeyUserID, c.UserID)
 }
 
 // HasCourseStatus returns true if user has enrollment with given status in the course.

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/bufbuild/connect-go"
 	"go.uber.org/zap"
 
 	"github.com/quickfeed/quickfeed/web/auth"
-	"google.golang.org/grpc/metadata"
 )
 
 // UnaryUserVerifier returns a unary server interceptor verifying that the user is authenticated.
@@ -34,7 +32,7 @@ func UnaryUserVerifier(logger *zap.SugaredLogger, tm *auth.TokenManager) connect
 					return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))
 				}
 			}
-			newCtx := metadata.NewIncomingContext(ctx, metadata.Pairs(auth.UserKey, strconv.FormatUint(claims.UserID, 10)))
+			newCtx := context.WithValue(ctx, auth.ContextKeyUserID, claims.UserID)
 			response, err := next(newCtx, request)
 			if err != nil {
 				return nil, err

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -32,8 +32,7 @@ func UnaryUserVerifier(logger *zap.SugaredLogger, tm *auth.TokenManager) connect
 					return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))
 				}
 			}
-			newCtx := context.WithValue(ctx, auth.ContextKeyUserID, claims.UserID)
-			response, err := next(newCtx, request)
+			response, err := next(claims.Context(ctx), request)
 			if err != nil {
 				return nil, err
 			}

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -77,9 +77,9 @@ func (s *QuickFeedService) GetUserByCourse(_ context.Context, in *connect.Reques
 // UpdateUser updates the current users's information and returns the updated user.
 // This function can also promote a user to admin or demote a user.
 func (s *QuickFeedService) UpdateUser(ctx context.Context, in *connect.Request[qf.User]) (*connect.Response[qf.Void], error) {
-	usr, err := s.getCurrentUser(ctx)
+	usr, err := s.db.GetUser(userID(ctx))
 	if err != nil {
-		s.logger.Errorf("UpdateUser failed: authentication error: %v", err)
+		s.logger.Errorf("UpdateUser failed: %v", err)
 		return nil, ErrInvalidUserInfo
 	}
 	if _, err = s.updateUser(usr, in.Msg); err != nil {
@@ -185,9 +185,9 @@ func (s *QuickFeedService) CreateEnrollment(_ context.Context, in *connect.Reque
 // UpdateEnrollments changes status of all pending enrollments for the specified course to approved.
 // If the request contains a single enrollment, it will be updated to the specified status.
 func (s *QuickFeedService) UpdateEnrollments(ctx context.Context, in *connect.Request[qf.Enrollments]) (*connect.Response[qf.Void], error) {
-	usr, err := s.getCurrentUser(ctx)
+	usr, err := s.db.GetUser(userID(ctx))
 	if err != nil {
-		s.logger.Errorf("UpdateEnrollments failed: scm authentication error: %v", err)
+		s.logger.Errorf("UpdateEnrollments failed: %v", err)
 		return nil, ErrInvalidUserInfo
 	}
 	scmClient, err := s.getSCMForCourse(ctx, in.Msg.GetCourseID())
@@ -537,10 +537,10 @@ func (s *QuickFeedService) UpdateAssignments(_ context.Context, in *connect.Requ
 
 // GetOrganization fetches a github organization by name.
 func (s *QuickFeedService) GetOrganization(ctx context.Context, in *connect.Request[qf.OrgRequest]) (*connect.Response[qf.Organization], error) {
-	usr, err := s.getCurrentUser(ctx)
+	usr, err := s.db.GetUser(userID(ctx))
 	if err != nil {
-		s.logger.Errorf("GetOrganization failed: scm authentication error: %v", err)
-		return nil, err
+		s.logger.Errorf("GetOrganization failed: %v", err)
+		return nil, ErrInvalidUserInfo
 	}
 	scmClient, err := s.getSCM(ctx, in.Msg.GetOrgName())
 	if err != nil {

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -42,12 +42,7 @@ func NewQuickFeedService(logger *zap.Logger, db database.Database, mgr *scm.Mana
 // GetUser will return current user with active course enrollments
 // to use in separating teacher and admin roles
 func (s *QuickFeedService) GetUser(ctx context.Context, _ *connect.Request[qf.Void]) (*connect.Response[qf.User], error) {
-	usr, err := s.getCurrentUser(ctx)
-	if err != nil {
-		s.logger.Errorf("GetUser failed: authentication error: %v", err)
-		return nil, ErrInvalidUserInfo
-	}
-	userInfo, err := s.db.GetUserWithEnrollments(usr.GetID())
+	userInfo, err := s.db.GetUserWithEnrollments(userID(ctx))
 	if err != nil {
 		s.logger.Errorf("GetUser failed to get user with enrollments: %v ", err)
 		return nil, ErrInvalidUserInfo
@@ -96,18 +91,13 @@ func (s *QuickFeedService) UpdateUser(ctx context.Context, in *connect.Request[q
 
 // CreateCourse creates a new course.
 func (s *QuickFeedService) CreateCourse(ctx context.Context, in *connect.Request[qf.Course]) (*connect.Response[qf.Course], error) {
-	usr, err := s.getCurrentUser(ctx)
-	if err != nil {
-		s.logger.Errorf("CreateCourse failed: user authentication error: %v", err)
-		return nil, ErrInvalidUserInfo
-	}
 	scmClient, err := s.getSCM(ctx, in.Msg.OrganizationPath)
 	if err != nil {
 		s.logger.Errorf("CreateCourse failed: could not create scm client for organization %s: %v", in.Msg.OrganizationPath, err)
 		return nil, ErrMissingInstallation
 	}
 	// make sure that the current user is set as course creator
-	in.Msg.CourseCreatorID = usr.GetID()
+	in.Msg.CourseCreatorID = userID(ctx)
 	course, err := s.createCourse(ctx, scmClient, in.Msg)
 	if err != nil {
 		s.logger.Errorf("CreateCourse failed: %v", err)
@@ -363,11 +353,6 @@ func (s *QuickFeedService) DeleteGroup(ctx context.Context, in *connect.Request[
 
 // GetSubmissions returns the submissions matching the query encoded in the action request.
 func (s *QuickFeedService) GetSubmissions(ctx context.Context, in *connect.Request[qf.SubmissionRequest]) (*connect.Response[qf.Submissions], error) {
-	usr, err := s.getCurrentUser(ctx)
-	if err != nil {
-		s.logger.Errorf("GetSubmissions failed: authentication error: %v", err)
-		return nil, ErrInvalidUserInfo
-	}
 	s.logger.Debugf("GetSubmissions: %v", in)
 	submissions, err := s.getSubmissions(in.Msg)
 	if err != nil {
@@ -375,7 +360,7 @@ func (s *QuickFeedService) GetSubmissions(ctx context.Context, in *connect.Reque
 		return nil, status.Error(codes.NotFound, "no submissions found")
 	}
 	// If the user is not a teacher, remove score and reviews from submissions that are not released.
-	if !s.isTeacher(usr.ID, in.Msg.CourseID) {
+	if !s.isTeacher(userID(ctx), in.Msg.CourseID) {
 		submissions.Clean()
 	}
 	return connect.NewResponse(submissions), nil
@@ -584,26 +569,20 @@ func (s *QuickFeedService) GetOrganization(ctx context.Context, in *connect.Requ
 
 // GetRepositories returns URL strings for repositories of given type for the given course.
 func (s *QuickFeedService) GetRepositories(ctx context.Context, in *connect.Request[qf.URLRequest]) (*connect.Response[qf.Repositories], error) {
-	usr, err := s.getCurrentUser(ctx)
-	if err != nil {
-		s.logger.Errorf("GetRepositories failed: authentication error: %v", err)
-		return nil, ErrInvalidUserInfo
-	}
-
 	course, err := s.db.GetCourse(in.Msg.GetCourseID(), false)
 	if err != nil {
 		s.logger.Errorf("GetRepositories failed: course %d not found: %v", in.Msg.GetCourseID(), err)
 		return nil, status.Error(codes.NotFound, "course not found")
 	}
-
-	enrol, _ := s.db.GetEnrollmentByCourseAndUser(course.GetID(), usr.GetID())
+	usrID := userID(ctx)
+	enrol, _ := s.db.GetEnrollmentByCourseAndUser(course.GetID(), usrID)
 
 	urls := make(map[string]string)
 	for _, repoType := range in.Msg.GetRepoTypes() {
 		var id uint64
 		switch repoType {
 		case qf.Repository_USER:
-			id = usr.GetID()
+			id = usrID
 		case qf.Repository_GROUP:
 			id = enrol.GetGroupID() // will be 0 if not enrolled in a group
 		}


### PR DESCRIPTION
We can simply pass along the UserID from the claims as a regular uint64 context value. This avoids doing database lookup for many cases where this wasn't needed and also avoids string parsing.

Fixes #735.

