### PR TITLE
Add qcm tool for local testing of run.sh scripts and updates for cloning assignments repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ public/public/index.html
 public/public/styles.css
 public/assets/index.html
 TODO
+x

--- a/.vscode/quickfeed-words.txt
+++ b/.vscode/quickfeed-words.txt
@@ -1,5 +1,6 @@
 addstore
 agpath
+alecthomas
 allstudents
 allteachers
 apitest

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ webpack-dev-server:
 selenium:
 	@cd public && npm run test:selenium
 
+qcm:
+	@cd cmd/qcm; go install
+
 scm:
 	@echo "Compiling the scm tool"
 	@cd cmd/scm; go install

--- a/ci/local_unix.go
+++ b/ci/local_unix.go
@@ -15,7 +15,8 @@ type Local struct{}
 // completed or an error occurs, e.g., the context times out.
 func (l *Local) Run(ctx context.Context, job *Job) (string, error) {
 	// TODO: Execute tests in something like: os.CreateTemp(os.TempDir(), "local-ci")
-	cmd := exec.Command("/bin/sh", "-c", strings.Join(job.Commands, "\n"))
+	cmd := exec.Command("/bin/bash", "-c", strings.Join(job.Commands, "\n"))
+	cmd.Env = job.Env
 	b, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -1,6 +1,7 @@
 package ci
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -14,35 +15,50 @@ import (
 //
 // The script may use the following environment variables:
 //
-//	TESTS - to access the tests (cloned from the tests repository)
-//	ASSIGNMENTS - to access the assignments (cloned from the assignments repository)
-//	CURRENT - name of the current assignment folder
+//	TESTS       - to access the tests (cloned from the course's tests repository)
+//	ASSIGNMENTS - to access the assignments (cloned from the course's assignments repository)
+//	SUBMITTED   - to access the student's or group's submitted code (cloned from the student/group repository)
+//	CURRENT     - name of the current assignment folder
 //	QUICKFEED_SESSION_SECRET - typically used by the test code; not the script itself
 func (r RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
-	s := strings.Split(r.Assignment.GetRunScriptContent(), "\n")
+	envVars := EnvVars(secret, QuickFeedPath, r.Repo.Name(), r.Assignment.GetName())
+	job, err := ParseRunScript(r.Assignment.GetRunScriptContent(), envVars)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
+	}
+	job.set(r.String(), r.Course.Dockerfile, destDir)
+	return job, nil
+}
+
+func (j *Job) set(name, dockerfile, bindDir string) {
+	j.Name = name
+	j.Dockerfile = dockerfile
+	j.BindDir = bindDir
+}
+
+func ParseRunScript(scriptContent string, envVars []string) (*Job, error) {
+	s := strings.Split(scriptContent, "\n")
 	if len(s) < 2 {
-		return nil, fmt.Errorf("no run script for assignment %s in %s", r.Assignment.GetName(), r.Repo.GetTestURL())
+		return nil, errors.New("empty run script")
 	}
 	parts := strings.Split(s[0], "#image/")
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("no docker image specified in run script for assignment %s in %s", r.Assignment.GetName(), r.Repo.GetTestURL())
+		return nil, errors.New("no docker image specified in run script")
 	}
 	return &Job{
-		Name:       r.String(),
-		Image:      strings.ToLower(parts[1]),
-		Dockerfile: r.Course.Dockerfile,
-		BindDir:    destDir,
-		Env:        r.envVars(secret),
-		Commands:   s[1:],
+		Image:    strings.ToLower(parts[1]),
+		Env:      envVars,
+		Commands: s[1:],
 	}, nil
 }
 
-func (r RunData) envVars(sessionSecret string) []string {
+func EnvVars(sessionSecret, home, repoName, currentAssignment string) []string {
 	envMap := map[string]string{
-		"HOME":        QuickFeedPath,
-		"TESTS":       filepath.Join(QuickFeedPath, qf.TestsRepo),
-		"ASSIGNMENTS": filepath.Join(QuickFeedPath, qf.AssignmentRepo),
-		"CURRENT":     r.Assignment.GetName(),
+		"HOME":        home,
+		"TESTS":       filepath.Join(home, qf.TestsRepo),
+		"ASSIGNMENTS": filepath.Join(home, qf.AssignmentRepo),
+		"SUBMITTED":   filepath.Join(home, repoName),
+		"CURRENT":     currentAssignment,
 		secretEnvName: sessionSecret,
 	}
 	envVars := make([]string, 0, len(envMap))

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -43,6 +43,7 @@ func TestParseTestRunnerScript(t *testing.T) {
 		runScriptContent = `#image/quickfeed:go
 echo $TESTS
 echo $ASSIGNMENTS
+echo $SUBMITTED
 echo $CURRENT
 echo $QUICKFEED_SESSION_SECRET
 `
@@ -64,6 +65,7 @@ echo $QUICKFEED_SESSION_SECRET
 		"HOME=" + QuickFeedPath,
 		"TESTS=" + filepath.Join(QuickFeedPath, qf.TestsRepo),
 		"ASSIGNMENTS=" + filepath.Join(QuickFeedPath, qf.AssignmentRepo),
+		"SUBMITTED=" + filepath.Join(QuickFeedPath, qf.StudentRepoName(githubUserName)),
 		"CURRENT=" + runData.Assignment.GetName(),
 		"QUICKFEED_SESSION_SECRET=" + randomSecret,
 	}
@@ -102,7 +104,7 @@ func TestParseBadTestRunnerScript(t *testing.T) {
 	const runScriptContent = `#image/quickfeed:go`
 	runData := testRunData(qfTestOrg, githubUserName, runScriptContent)
 	_, err := runData.parseTestRunnerScript(randomSecret, "")
-	const wantMsg = "no run script for assignment lab1 in https://github.com/qf101/tests"
+	const wantMsg = "failed to parse run script for assignment lab1 in https://github.com/qf101/tests: empty run script"
 	if err.Error() != wantMsg {
 		t.Errorf("err = '%s', want '%s'", err, wantMsg)
 	}
@@ -114,7 +116,7 @@ printf "*** Preparing for Test Execution ***\n"
 `
 	runData = testRunData(qfTestOrg, githubUserName, runScriptContent2)
 	_, err = runData.parseTestRunnerScript(randomSecret, "")
-	const wantMsg2 = "no docker image specified in run script for assignment lab1 in https://github.com/qf101/tests"
+	const wantMsg2 = "failed to parse run script for assignment lab1 in https://github.com/qf101/tests: no docker image specified in run script"
 	if err.Error() != wantMsg2 {
 		t.Errorf("err = '%s', want '%s'", err, wantMsg2)
 	}

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -74,7 +75,8 @@ func (r RunData) RunTests(ctx context.Context, logger *zap.SugaredLogger, sc scm
 	if _, err = CloneRepositories(ctx, sc, in); err != nil {
 		return nil, err
 	}
-	if err := ScanStudentRepo(r.Repo.Name(), in.CourseCode, in.JobOwner); err != nil {
+	logger.Debugf("Scanning repository for %s", r.Repo.Name())
+	if err := ScanStudentRepo(filepath.Join(dstDir, r.Repo.Name()), in.CourseCode, in.JobOwner); err != nil {
 		return nil, err
 	}
 

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -1,7 +1,7 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Initializing Tests for $CURRENT ***\n"
+printf "*** Initializing Tests for %s ***\n" "$CURRENT"
 
 # Move to folder with assignment handout code for the current assignment to test.
 cd "$ASSIGNMENTS/$CURRENT"
@@ -17,7 +17,7 @@ go mod tidy
 # Initialize test scores
 SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
 
-printf "*** Preparing Test Execution for $CURRENT ***\n"
+printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.
 cd "$SUBMITTED/$CURRENT"

--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -1,16 +1,31 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Preparing for Test Execution ***\n"
+printf "*** Initializing Tests for $CURRENT ***\n"
 
-# Move to folder for the current assignment to test.
+# Move to folder with assignment handout code for the current assignment to test.
 cd "$ASSIGNMENTS/$CURRENT"
+# Remove assignment handout tests to avoid interference
+find . -name '*_test.go' -exec rm -rf {} \;
 
+# Copy tests into the base assignments folder for initializing test scores
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
+
+# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
+go get -t github.com/quickfeed/quickfeed/kit/score
+go mod tidy
+# Initialize test scores
+SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
+
+printf "*** Preparing Test Execution for $CURRENT ***\n"
+
+# Move to folder with submitted code for the current assignment to test.
+cd "$SUBMITTED/$CURRENT"
 # Remove student written tests to avoid interference
 find . -name '*_test.go' -exec rm -rf {} \;
 
 # Copy tests into student assignments folder for running tests
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
+cp -r "$TESTS"/* "$SUBMITTED"/
 
 # $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
 go get -t github.com/quickfeed/quickfeed/kit/score

--- a/cmd/qcm/copy_dir.go
+++ b/cmd/qcm/copy_dir.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// copyDir copies the given source directory to the destination directory, recursively.
+// Mostly borrowed from https://stackoverflow.com/questions/51779243/copy-a-folder-in-go
+func copyDir(srcDir, dest string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(srcDir, entry.Name())
+		destPath := filepath.Join(dest, entry.Name())
+
+		fileInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			return err
+		}
+
+		stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", sourcePath)
+		}
+
+		switch fileInfo.Mode() & os.ModeType {
+		case os.ModeDir:
+			if err := createIfNotExists(destPath, 0o700); err != nil {
+				return err
+			}
+			if err := copyDir(sourcePath, destPath); err != nil {
+				return err
+			}
+		case os.ModeSymlink:
+			if err := copySymLink(sourcePath, destPath); err != nil {
+				return err
+			}
+		default:
+			if err := copyFile(sourcePath, destPath); err != nil {
+				return err
+			}
+		}
+
+		if err := os.Lchown(destPath, int(stat.Uid), int(stat.Gid)); err != nil {
+			return err
+		}
+
+		fInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		isSymlink := fInfo.Mode()&os.ModeSymlink != 0
+		if !isSymlink {
+			if err := os.Chmod(destPath, fInfo.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func copyFile(srcFile, dstFile string) error {
+	out, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := os.Open(srcFile)
+	defer in.Close()
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func exists(filePath string) bool {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func createIfNotExists(dir string, perm os.FileMode) error {
+	if exists(dir) {
+		return nil
+	}
+	if err := os.MkdirAll(dir, perm); err != nil {
+		return fmt.Errorf("failed to create directory: '%s', error: '%s'", dir, err.Error())
+	}
+	return nil
+}
+
+func copySymLink(source, dest string) error {
+	link, err := os.Readlink(source)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(link, dest)
+}

--- a/cmd/qcm/copy_dir.go
+++ b/cmd/qcm/copy_dir.go
@@ -66,24 +66,31 @@ func copyDir(srcDir, dest string) error {
 	return nil
 }
 
-func copyFile(srcFile, dstFile string) error {
+func copyFile(srcFile, dstFile string) (err error) {
+	in, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := in.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
 	out, err := os.Create(dstFile)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-
-	in, err := os.Open(srcFile)
-	defer in.Close()
-	if err != nil {
-		return err
-	}
+	defer func() {
+		closeErr := out.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 
 	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-	return nil
+	return
 }
 
 func exists(filePath string) bool {

--- a/cmd/qcm/main.go
+++ b/cmd/qcm/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/alecthomas/kong"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/qlog"
+	"github.com/quickfeed/quickfeed/scm"
+)
+
+var cli struct {
+	Clone struct {
+		Course string `help:"Course code." default:"dat320-2022"`
+		User   string `help:"GitHub user name for student in course." xor:"repo" required:""`
+		Group  string `help:"GitHub group name for course." xor:"repo" required:""`
+		Token  string `help:"GitHub personal access token." env:"GITHUB_ACCESS_TOKEN"`
+		Dir    string `help:"Destination directory for cloned repositories." default:"."`
+		Merge  bool   `help:"Merge tests repository into user/group directory." default:"false"`
+	} `cmd:"" help:"Clone repositories for local test execution."`
+}
+
+func main() {
+	ctx := kong.Parse(&cli,
+		kong.Name("qcm"),
+		kong.Description("QuickFeed course manager."),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact: true,
+			Summary: true,
+		}))
+
+	switch ctx.Command() {
+	case "clone":
+		client := getSCMClient()
+		err := clone(client)
+		check(err)
+		fmt.Printf("merge: %t\n", cli.Clone.Merge)
+	default:
+		panic(ctx.Command())
+	}
+}
+
+func getSCMClient() scm.SCM {
+	logger, err := qlog.Zap()
+	check(err)
+	client, err := scm.NewSCMClient(logger.Sugar(), cli.Clone.Token)
+	check(err)
+	return client
+}
+
+func clone(client scm.SCM) error {
+	repo := cli.Clone.Group
+	if repo == "" {
+		repo = qf.StudentRepoName(cli.Clone.User)
+	}
+	dir := filepath.Join(cli.Clone.Dir, cli.Clone.Course)
+	fmt.Printf("course=%s, repo=%s, dir=%s\n", cli.Clone.Course, repo, dir)
+
+	cloneDir, err := client.Clone(context.Background(), &scm.CloneOptions{
+		Organization: cli.Clone.Course,
+		Repository:   repo,
+		DestDir:      dir,
+	})
+	if err != nil {
+		return err
+	}
+	assignmentsDir, err := client.Clone(context.Background(), &scm.CloneOptions{
+		Organization: cli.Clone.Course,
+		Repository:   qf.AssignmentRepo,
+		DestDir:      dir,
+	})
+	if err != nil {
+		return err
+	}
+	testsDir, err := client.Clone(context.Background(), &scm.CloneOptions{
+		Organization: cli.Clone.Course,
+		Repository:   qf.TestsRepo,
+		DestDir:      dir,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("cloneDir       %s\n", cloneDir)
+	fmt.Printf("assignmentsDir %s\n", assignmentsDir)
+	fmt.Printf("testsDir       %s\n", testsDir)
+	return nil
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/cmd/qcm/main.go
+++ b/cmd/qcm/main.go
@@ -40,36 +40,39 @@ func main() {
 		client := getSCMClient()
 		studRepo := studentRepo()
 		destDir := filepath.Join(cli.Clone.Dir, cli.Clone.Course)
-		clone(client, []string{studRepo, qf.AssignmentRepo, qf.TestsRepo}, destDir)
-		if cli.Clone.Merge {
-			fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, qf.AssignmentRepo)
-			err := copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, qf.AssignmentRepo))
-			check(err)
-			fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, studRepo)
-			err = copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, studRepo))
-			check(err)
+		if !exists(destDir) {
+			// Only clone and merge if destination directory does not exist
+			clone(client, studRepo, destDir)
+			if cli.Clone.Merge {
+				merge(destDir, studRepo)
+			}
 		}
 		if cli.Clone.Lab != "" {
-			fmt.Printf("Running tests for %s\n", cli.Clone.Lab)
-			scriptContent, err := os.ReadFile(filepath.Join(destDir, qf.AssignmentRepo, "scripts", "run.sh"))
-			check(err)
-			// destDir = home folder for the test execution
-			home := filepath.Join(os.Getenv("PWD"), destDir)
-			envVars := ci.EnvVars("secret", home, studRepo, cli.Clone.Lab)
-			for _, envVar := range envVars {
-				fmt.Println(envVar)
-			}
-			job, err := ci.ParseRunScript(string(scriptContent), envVars)
-			check(err)
-			runner := ci.Local{}
-			out, err := runner.Run(context.Background(), job)
-			check(err)
-			fmt.Println(out)
+			runTests(destDir, studRepo)
 		}
 
 	default:
 		panic(ctx.Command())
 	}
+}
+
+func runTests(destDir string, studRepo string) {
+	fmt.Printf("Running tests for %s\n", cli.Clone.Lab)
+	scriptContent, err := os.ReadFile(filepath.Join(destDir, qf.AssignmentRepo, "scripts", "run.sh"))
+	check(err)
+
+	// destDir = home folder for the test execution
+	home := filepath.Join(os.Getenv("PWD"), destDir)
+	envVars := ci.EnvVars("secret", home, studRepo, cli.Clone.Lab)
+	for _, envVar := range envVars {
+		fmt.Println(envVar)
+	}
+	job, err := ci.ParseRunScript(string(scriptContent), envVars)
+	check(err)
+	runner := ci.Local{}
+	out, err := runner.Run(context.Background(), job)
+	check(err)
+	fmt.Println(out)
 }
 
 func getSCMClient() scm.SCM {
@@ -88,15 +91,34 @@ func studentRepo() string {
 	return studRepo
 }
 
-func clone(client scm.SCM, cloneRepos []string, dstDir string) {
-	for _, repo := range cloneRepos {
-		_, err := client.Clone(context.Background(), &scm.CloneOptions{
-			Organization: cli.Clone.Course,
-			Repository:   repo,
-			DestDir:      dstDir,
-		})
+func clone(client scm.SCM, studRepo, dstDir string) {
+	in := &ci.CloneInfo{
+		CourseCode:        cli.Clone.Course,
+		JobOwner:          studRepo,
+		OrganizationPath:  cli.Clone.Course,
+		CurrentAssignment: cli.Clone.Lab,
+		DestDir:           dstDir,
+		CloneRepos: []ci.RepoInfo{
+			{Repo: studRepo},
+			{Repo: qf.TestsRepo},
+			{Repo: qf.AssignmentRepo},
+		},
+	}
+	if _, err := ci.CloneRepositories(context.Background(), client, in); err != nil {
 		check(err)
 	}
+	if err := ci.ScanStudentRepo(filepath.Join(dstDir, studRepo), in.CourseCode, in.JobOwner); err != nil {
+		check(err)
+	}
+}
+
+func merge(destDir string, studRepo string) {
+	fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, qf.AssignmentRepo)
+	err := copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, qf.AssignmentRepo))
+	check(err)
+	fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, studRepo)
+	err = copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, studRepo))
+	check(err)
 }
 
 func check(err error) {

--- a/cmd/qcm/main.go
+++ b/cmd/qcm/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
+	"github.com/quickfeed/quickfeed/ci"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
@@ -13,12 +15,13 @@ import (
 
 var cli struct {
 	Clone struct {
-		Course string `help:"Course code." default:"dat320-2022"`
+		Course string `help:"Course organization." default:"dat320-2022"`
 		User   string `help:"GitHub user name for student in course." xor:"repo" required:""`
 		Group  string `help:"GitHub group name for course." xor:"repo" required:""`
 		Token  string `help:"GitHub personal access token." env:"GITHUB_ACCESS_TOKEN"`
 		Dir    string `help:"Destination directory for cloned repositories." default:"."`
 		Merge  bool   `help:"Merge tests repository into user/group directory." default:"false"`
+		Lab    string `help:"Assignment to test."`
 	} `cmd:"" help:"Clone repositories for local test execution."`
 }
 
@@ -35,9 +38,35 @@ func main() {
 	switch ctx.Command() {
 	case "clone":
 		client := getSCMClient()
-		err := clone(client)
-		check(err)
-		fmt.Printf("merge: %t\n", cli.Clone.Merge)
+		studRepo := studentRepo()
+		destDir := filepath.Join(cli.Clone.Dir, cli.Clone.Course)
+		clone(client, []string{studRepo, qf.AssignmentRepo, qf.TestsRepo}, destDir)
+		if cli.Clone.Merge {
+			fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, qf.AssignmentRepo)
+			err := copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, qf.AssignmentRepo))
+			check(err)
+			fmt.Printf("Merging: %s -> %s\n", qf.TestsRepo, studRepo)
+			err = copyDir(filepath.Join(destDir, qf.TestsRepo), filepath.Join(destDir, studRepo))
+			check(err)
+		}
+		if cli.Clone.Lab != "" {
+			fmt.Printf("Running tests for %s\n", cli.Clone.Lab)
+			scriptContent, err := os.ReadFile(filepath.Join(destDir, qf.AssignmentRepo, "scripts", "run.sh"))
+			check(err)
+			// destDir = home folder for the test execution
+			home := filepath.Join(os.Getenv("PWD"), destDir)
+			envVars := ci.EnvVars("secret", home, studRepo, cli.Clone.Lab)
+			for _, envVar := range envVars {
+				fmt.Println(envVar)
+			}
+			job, err := ci.ParseRunScript(string(scriptContent), envVars)
+			check(err)
+			runner := ci.Local{}
+			out, err := runner.Run(context.Background(), job)
+			check(err)
+			fmt.Println(out)
+		}
+
 	default:
 		panic(ctx.Command())
 	}
@@ -51,46 +80,27 @@ func getSCMClient() scm.SCM {
 	return client
 }
 
-func clone(client scm.SCM) error {
-	repo := cli.Clone.Group
-	if repo == "" {
-		repo = qf.StudentRepoName(cli.Clone.User)
+func studentRepo() string {
+	studRepo := cli.Clone.Group
+	if studRepo == "" {
+		studRepo = qf.StudentRepoName(cli.Clone.User)
 	}
-	dir := filepath.Join(cli.Clone.Dir, cli.Clone.Course)
-	fmt.Printf("course=%s, repo=%s, dir=%s\n", cli.Clone.Course, repo, dir)
+	return studRepo
+}
 
-	cloneDir, err := client.Clone(context.Background(), &scm.CloneOptions{
-		Organization: cli.Clone.Course,
-		Repository:   repo,
-		DestDir:      dir,
-	})
-	if err != nil {
-		return err
+func clone(client scm.SCM, cloneRepos []string, dstDir string) {
+	for _, repo := range cloneRepos {
+		_, err := client.Clone(context.Background(), &scm.CloneOptions{
+			Organization: cli.Clone.Course,
+			Repository:   repo,
+			DestDir:      dstDir,
+		})
+		check(err)
 	}
-	assignmentsDir, err := client.Clone(context.Background(), &scm.CloneOptions{
-		Organization: cli.Clone.Course,
-		Repository:   qf.AssignmentRepo,
-		DestDir:      dir,
-	})
-	if err != nil {
-		return err
-	}
-	testsDir, err := client.Clone(context.Background(), &scm.CloneOptions{
-		Organization: cli.Clone.Course,
-		Repository:   qf.TestsRepo,
-		DestDir:      dir,
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("cloneDir       %s\n", cloneDir)
-	fmt.Printf("assignmentsDir %s\n", assignmentsDir)
-	fmt.Printf("testsDir       %s\n", testsDir)
-	return nil
 }
 
 func check(err error) {
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 }

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -281,7 +281,7 @@ Note that QuickFeed performs a lightweight sanity check of the cloned student re
 #image/qf101
 
 start=$SECONDS
-printf "*** Initializing Tests for $CURRENT ***\n"
+printf "*** Initializing Tests for %s ***\n" "$CURRENT"
 
 # Move to folder with assignment handout code for the current assignment to test.
 cd "$ASSIGNMENTS/$CURRENT"
@@ -297,7 +297,7 @@ go mod tidy
 # Initialize test scores
 SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
 
-printf "*** Preparing Test Execution for $CURRENT ***\n"
+printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.
 cd "$SUBMITTED/$CURRENT"

--- a/doc/templates/go-course/scripts/run.sh
+++ b/doc/templates/go-course/scripts/run.sh
@@ -1,7 +1,7 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Initializing Tests for $CURRENT ***\n"
+printf "*** Initializing Tests for %s ***\n" "$CURRENT"
 
 # Move to folder with assignment handout code for the current assignment to test.
 cd "$ASSIGNMENTS/$CURRENT"
@@ -17,7 +17,7 @@ go mod tidy
 # Initialize test scores
 SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
 
-printf "*** Preparing Test Execution for $CURRENT ***\n"
+printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.
 cd "$SUBMITTED/$CURRENT"

--- a/doc/templates/go-course/scripts/run.sh
+++ b/doc/templates/go-course/scripts/run.sh
@@ -1,16 +1,31 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Preparing for Test Execution ***\n"
+printf "*** Initializing Tests for $CURRENT ***\n"
 
-# Move to folder for the current assignment to test.
+# Move to folder with assignment handout code for the current assignment to test.
 cd "$ASSIGNMENTS/$CURRENT"
+# Remove assignment handout tests to avoid interference
+find . -name '*_test.go' -exec rm -rf {} \;
 
+# Copy tests into the base assignments folder for initializing test scores
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
+
+# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
+go get -t github.com/quickfeed/quickfeed/kit/score
+go mod tidy
+# Initialize test scores
+SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
+
+printf "*** Preparing Test Execution for $CURRENT ***\n"
+
+# Move to folder with submitted code for the current assignment to test.
+cd "$SUBMITTED/$CURRENT"
 # Remove student written tests to avoid interference
 find . -name '*_test.go' -exec rm -rf {} \;
 
 # Copy tests into student assignments folder for running tests
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
+cp -r "$TESTS"/* "$SUBMITTED"/
 
 # $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
 go get -t github.com/quickfeed/quickfeed/kit/score

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1
+	github.com/alecthomas/kong v0.6.1
 	github.com/alta/protopatch v0.5.0
 	github.com/beatlabs/github-auth v0.0.0-20220721134423-2b8d98e205d1
 	github.com/bufbuild/connect-go v0.3.0
@@ -89,7 +90,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220808204814-fd01256a5276 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,10 @@ github.com/ProtonMail/go-crypto v0.0.0-20220714114130-e85cedf506cd h1:sOpOKHLKfQ
 github.com/ProtonMail/go-crypto v0.0.0-20220714114130-e85cedf506cd/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/alecthomas/kong v0.6.1 h1:1kNhcFepkR+HmasQpbiKDLylIL8yh5B5y1zPp5bJimA=
+github.com/alecthomas/kong v0.6.1/go.mod h1:JfHWDzLmbh/puW6I3V7uWenoh56YNVONW+w8eKeUr9I=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/quickfeed.code-workspace
+++ b/quickfeed.code-workspace
@@ -27,6 +27,12 @@
 		"cSpell.enableFiletypes": [
 			"plaintext"
 		],
+		"files.exclude": {
+			"**/.git": true,
+			"**/.DS_Store": true,
+			"**/node_modules": true,
+			"x": true,
+		},
 		"files.insertFinalNewline": true,
 		"files.trimFinalNewlines": true,
 		"files.trimTrailingWhitespace": true,
@@ -61,6 +67,7 @@
 				"-public",
 				"-doc",
 				"-dev",
+				"-x",
 			],
 			// Add parameter placeholders when completing a function.
 			"usePlaceholders": true,

--- a/scm/fake.go
+++ b/scm/fake.go
@@ -30,7 +30,7 @@ func NewFakeSCMClient() *FakeSCM {
 }
 
 func (FakeSCM) Clone(_ context.Context, opt *CloneOptions) (string, error) {
-	cloneDir := filepath.Join(opt.DestDir, repoDir(opt))
+	cloneDir := filepath.Join(opt.DestDir, opt.Repository)
 	// This is a hack to make sure the lab1 directory exists,
 	// required by the web/rebuild_test.go:TestRebuildSubmissions()
 	lab1Dir := filepath.Join(cloneDir, "lab1")

--- a/scm/fetcher.go
+++ b/scm/fetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/quickfeed/quickfeed/qf"
 )
 
 const authUserName = "quickfeed" // can be anything except an empty string
@@ -24,7 +23,7 @@ func (s *GithubSCM) Clone(ctx context.Context, opt *CloneOptions) (string, error
 			return "", err
 		}
 	}
-	cloneDir := filepath.Join(opt.DestDir, repoDir(opt))
+	cloneDir := filepath.Join(opt.DestDir, opt.Repository)
 	s.logger.Debugf("Clone(%s)", s.cloneURL(opt))
 	var branch plumbing.ReferenceName
 	if opt.Branch != "" {
@@ -40,13 +39,6 @@ func (s *GithubSCM) Clone(ctx context.Context, opt *CloneOptions) (string, error
 	}
 	s.logger.Debugf("CloneDir = %s", cloneDir)
 	return cloneDir, nil
-}
-
-func repoDir(opt *CloneOptions) string {
-	if qf.RepoType(opt.Repository).IsStudentRepo() {
-		return qf.AssignmentRepo
-	}
-	return qf.TestsRepo
 }
 
 // cloneURL returns the URL to clone the given repository.


### PR DESCRIPTION
This adds support for a new tool, `qcm`, for local testing of `run.sh` scripts. Additionally, it adds support for cloning the assignments folder, which will enable `run.sh` scripts to initialize the `MaxScore` for all tests before running tests on student code, thus preventing students from disabling tests by making them not compile.

Fixes #761
Fixes #750 