### PR TITLE
MockQuickFeedClient test helpers

### DIFF
--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -422,7 +422,7 @@ func TestGetCourse(t *testing.T) {
 }
 
 func TestPromoteDemoteRejectTeacher(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	teacher := qtest.CreateFakeUser(t, db, 10)
@@ -501,10 +501,6 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 
 	// teacher promotes students to teachers, must succeed
 	ctx := qtest.WithUserContext(context.Background(), teacher)
-	_, err = fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	request.Enrollments = []*qf.Enrollment{student1Enrollment, student2Enrollment, taEnrollment}
 	if _, err := ags.UpdateEnrollments(ctx, connect.NewRequest(request)); err != nil {

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -11,11 +11,10 @@ import (
 
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/scm"
 )
 
 func TestNewGroup(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -39,17 +38,9 @@ func TestNewGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err := fakeProvider.CreateOrganization(ctx,
-		&scm.OrganizationOptions{Path: "test", Name: "test"},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	createGroupRequest := connect.NewRequest(&qf.Group{Name: "Heins-Group", CourseID: course.ID, Users: []*qf.User{{ID: user.ID}}})
 	// current user (in context) must be in group being created
-	ctx = qtest.WithUserContext(context.Background(), user)
+	ctx := qtest.WithUserContext(context.Background(), user)
 	wantGroup, err := ags.CreateGroup(ctx, createGroupRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +55,7 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestCreateGroupWithMissingFields(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -87,22 +78,14 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err := fakeProvider.CreateOrganization(ctx,
-		&scm.OrganizationOptions{Path: "path", Name: "name"},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	users := []*qf.User{{ID: user.ID}}
 	group_wo_course_id := connect.NewRequest(&qf.Group{Name: "Hein's Group", Users: users})
 	group_wo_name := connect.NewRequest(&qf.Group{CourseID: course.ID, Users: users})
 	group_wo_users := connect.NewRequest(&qf.Group{Name: "Hein's Group", CourseID: course.ID})
 
 	// current user (in context) must be in group being created
-	ctx = qtest.WithUserContext(context.Background(), user)
-	_, err = ags.CreateGroup(ctx, group_wo_course_id)
+	ctx := qtest.WithUserContext(context.Background(), user)
+	_, err := ags.CreateGroup(ctx, group_wo_course_id)
 	if err == nil {
 		t.Fatal("expected CreateGroup to fail without a course ID")
 	}
@@ -117,7 +100,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 }
 
 func TestNewGroupTeacherCreator(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -150,13 +133,6 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 		CourseID: course.ID,
 		Status:   qf.Enrollment_STUDENT,
 	}); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := fakeProvider.CreateOrganization(context.Background(),
-		&scm.OrganizationOptions{Path: "path", Name: "name"},
-	)
-	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -193,7 +169,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 }
 
 func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -230,19 +206,13 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 	}
 
 	ctx := qtest.WithUserContext(context.Background(), user)
-	_, err := fakeProvider.CreateOrganization(ctx,
-		&scm.OrganizationOptions{Path: "path", Name: "name"},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	group_req := connect.NewRequest(&qf.Group{
 		Name:     "HeinsGroup",
 		CourseID: course.ID,
 		Users:    []*qf.User{{ID: user.ID}, {ID: teacher.ID}},
 	})
-	_, err = ags.CreateGroup(ctx, group_req)
+	_, err := ags.CreateGroup(ctx, group_req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,15 +221,8 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 }
 
 func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
-
-	_, err := fakeProvider.CreateOrganization(context.Background(),
-		&scm.OrganizationOptions{Path: "test", Name: "test"},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	admin := qtest.CreateFakeUser(t, db, 1)
 	course := qf.Course{Provider: "fake", OrganizationID: 1, OrganizationPath: "test"}
@@ -425,7 +388,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	testCourse := qf.Course{
@@ -441,9 +404,6 @@ func TestDeleteGroup(t *testing.T) {
 	admin := qtest.CreateFakeUser(t, db, 1)
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	if _, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "test", Name: "test"}); err != nil {
-		t.Fatal(err)
-	}
 	if _, err := ags.CreateCourse(ctx, connect.NewRequest(&testCourse)); err != nil {
 		t.Fatal(err)
 	}
@@ -585,7 +545,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestPatchGroupStatus(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	course := qf.Course{
@@ -621,12 +581,6 @@ func TestPatchGroupStatus(t *testing.T) {
 	}
 
 	ctx := qtest.WithUserContext(context.Background(), teacher)
-	if _, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{
-		Name: course.Code,
-		Path: course.Code,
-	}); err != nil {
-		t.Fatal(err)
-	}
 
 	user1 := qtest.CreateFakeUser(t, db, 3)
 	user2 := qtest.CreateFakeUser(t, db, 4)
@@ -765,21 +719,13 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 }
 
 func TestDeleteApprovedGroup(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
 	course := allCourses[0]
 	err := db.CreateCourse(admin.ID, course)
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := qtest.WithUserContext(context.Background(), admin)
-	if _, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{
-		Name: course.Code,
-		Path: course.Code,
-	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -826,7 +772,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 		Users:    []*qf.User{user1, user2},
 	}
 	// current user1 (in context) must be in group being created
-	ctx = qtest.WithUserContext(context.Background(), user1)
+	ctx := qtest.WithUserContext(context.Background(), user1)
 	createdGroup, err := ags.CreateGroup(ctx, connect.NewRequest(group))
 	if err != nil {
 		t.Fatal(err)

--- a/web/quickfeed_helper_test.go
+++ b/web/quickfeed_helper_test.go
@@ -24,19 +24,16 @@ func testQuickFeedService(t *testing.T) (database.Database, func(), scm.SCM, *we
 }
 
 // MockQuickFeedClient returns a QuickFeed client for invoking RPCs.
-// Currently no interceptors are passed.
-// TODO(meling): Consider passing interceptors as input to this function to accommodate different test scenarios.
-func MockQuickFeedClient(t *testing.T) (database.Database, func(context.Context), qfconnect.QuickFeedServiceClient) {
+func MockQuickFeedClient(t *testing.T, db database.Database, opts connect.Option) (func(context.Context), qfconnect.QuickFeedServiceClient) {
 	t.Helper()
-	db, cleanup := qtest.TestDB(t)
 	logger := qtest.Logger(t)
 
-	shutdown := web.MockQuickFeedServer(t, logger, db, connect.WithInterceptors(
-	// interceptor.Validation(logger),
-	))
+	if opts == nil {
+		opts = connect.WithInterceptors()
+	}
+	shutdown := web.MockQuickFeedServer(t, logger, db, opts)
 
-	return db, func(ctx context.Context) {
-		cleanup()
+	return func(ctx context.Context) {
 		shutdown(ctx)
 	}, qtest.QuickFeedClient("")
 }

--- a/web/quickfeed_helper_test.go
+++ b/web/quickfeed_helper_test.go
@@ -1,20 +1,42 @@
 package web_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/quickfeed/quickfeed/ci"
 	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf/qfconnect"
 	"github.com/quickfeed/quickfeed/qlog"
 	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 )
 
+// Deprecated: Will be replaced by MockQuickFeedClient
 func testQuickFeedService(t *testing.T) (database.Database, func(), scm.SCM, *web.QuickFeedService) {
 	t.Helper()
 	db, cleanup := qtest.TestDB(t)
 	sc, mgr := scm.MockSCMManager(t)
 	logger := qlog.Logger(t).Desugar()
 	return db, cleanup, sc, web.NewQuickFeedService(logger, db, mgr, web.BaseHookOptions{}, &ci.Local{})
+}
+
+// MockQuickFeedClient returns a QuickFeed client for invoking RPCs.
+// Currently no interceptors are passed.
+// TODO(meling): Consider passing interceptors as input to this function to accommodate different test scenarios.
+func MockQuickFeedClient(t *testing.T) (database.Database, func(context.Context), qfconnect.QuickFeedServiceClient) {
+	t.Helper()
+	db, cleanup := qtest.TestDB(t)
+	logger := qtest.Logger(t)
+
+	shutdown := web.MockQuickFeedServer(t, logger, db, connect.WithInterceptors(
+	// interceptor.Validation(logger),
+	))
+
+	return db, func(ctx context.Context) {
+		cleanup()
+		shutdown(ctx)
+	}, qtest.QuickFeedClient("")
 }

--- a/web/repositories_test.go
+++ b/web/repositories_test.go
@@ -1,8 +1,7 @@
-package web
+package web_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
@@ -10,75 +9,7 @@ import (
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
 	"google.golang.org/protobuf/testing/protocmp"
-	"gorm.io/gorm"
 )
-
-func TestGetRepo(t *testing.T) {
-	db, cleanup, _, ags := testQuickFeedService(t)
-	defer cleanup()
-
-	user := qtest.CreateFakeUser(t, db, 1)
-	course := &qf.Course{
-		OrganizationID: 1,
-		Code:           "DAT101",
-	}
-	qtest.CreateCourse(t, db, user, course)
-	group := &qf.Group{
-		Name:     "1001 Hacking Crew",
-		CourseID: course.ID,
-		Users:    []*qf.User{user},
-	}
-	if err := db.CreateGroup(group); err != nil {
-		t.Fatal(err)
-	}
-
-	wantUserRepo := &qf.Repository{
-		OrganizationID: 1,
-		RepositoryID:   1,
-		UserID:         user.ID,
-		RepoType:       qf.Repository_USER,
-		HTMLURL:        "http://assignment.com/",
-	}
-	if err := db.CreateRepository(wantUserRepo); err != nil {
-		t.Fatal(err)
-	}
-
-	wantGroupRepo := &qf.Repository{
-		OrganizationID: 1,
-		RepositoryID:   2,
-		GroupID:        group.ID,
-		RepoType:       qf.Repository_GROUP,
-		HTMLURL:        "http://assignment.com/",
-	}
-	if err := db.CreateRepository(wantGroupRepo); err != nil {
-		t.Fatal(err)
-	}
-
-	gotUserRepo, err := ags.getRepo(course, user.ID, qf.Repository_USER)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(wantUserRepo, gotUserRepo, protocmp.Transform()); diff != "" {
-		t.Errorf("getRepo() mismatch (-wantUserRepo, +gotUserRepo):\n%s", diff)
-	}
-
-	gotGroupRepo, err := ags.getRepo(course, group.ID, qf.Repository_GROUP)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(wantGroupRepo, gotGroupRepo, protocmp.Transform()); diff != "" {
-		t.Errorf("getRepo() mismatch (-wantGroupRepo, +gotGroupRepo):\n%s", diff)
-	}
-
-	_, err = ags.getRepo(course, group.ID+1, qf.Repository_GROUP)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Fatal(err)
-	}
-	_, err = ags.getRepo(course, user.ID+1, qf.Repository_USER)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Fatal(err)
-	}
-}
 
 func TestGetRepositories(t *testing.T) {
 	db, cleanup, _, ags := testQuickFeedService(t)

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/kit/score"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/scm"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestApproveSubmission(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -57,10 +56,6 @@ func TestApproveSubmission(t *testing.T) {
 	}
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err = fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if _, err = ags.UpdateSubmission(ctx, connect.NewRequest(&qf.UpdateSubmissionRequest{
 		SubmissionID: wantSubmission.ID,
@@ -102,7 +97,7 @@ func TestApproveSubmission(t *testing.T) {
 }
 
 func TestGetSubmissionsByCourse(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -113,9 +108,7 @@ func TestGetSubmissionsByCourse(t *testing.T) {
 	student3 := qtest.CreateFakeUser(t, db, 4)
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	if _, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"}); err != nil {
-		t.Fatal(err)
-	}
+
 	qtest.EnrollStudent(t, db, student1, course)
 	qtest.EnrollStudent(t, db, student2, course)
 	qtest.EnrollStudent(t, db, student3, course)
@@ -284,7 +277,7 @@ func TestGetSubmissionsByCourse(t *testing.T) {
 }
 
 func TestGetCourseLabSubmissions(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -388,10 +381,6 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 	wantSubmission2.BuildInfo = nil
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// check that all assignments were saved for the correct courses
 	wantAssignments1 := []*qf.Assignment{lab1c1, lab2c1}
@@ -500,7 +489,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 }
 
 func TestCreateApproveList(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -611,10 +600,6 @@ func TestCreateApproveList(t *testing.T) {
 	}
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	testCases := []struct {
 		student          *qf.User
@@ -696,7 +681,7 @@ func TestCreateApproveList(t *testing.T) {
 }
 
 func TestReleaseApproveAll(t *testing.T) {
-	db, cleanup, fakeProvider, ags := testQuickFeedService(t)
+	db, cleanup, _, ags := testQuickFeedService(t)
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 1)
@@ -713,10 +698,6 @@ func TestReleaseApproveAll(t *testing.T) {
 	qtest.EnrollStudent(t, db, student3, course)
 
 	ctx := qtest.WithUserContext(context.Background(), admin)
-	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	assignments := []*qf.Assignment{
 		{


### PR DESCRIPTION
- Removed unnecessary uses of fakeProvider
- Added MockQuickFeedClient to replace testQuickFeedService
- Removed TestGetRepo; was testing only internal func
- Updated TestUserVerifier to use MockQuickFeedServer
- Revised MockQuickFeedClient to accept interceptors

This is a partial fix for #791.