### PR TITLE
Remove debugging from auth API mock tests.

### DIFF
--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -25,22 +25,19 @@ func TestOAuth2Login(t *testing.T) {
 	logger := qlog.Logger(t)
 	authConfig := auth.NewGitHubConfig("", &scm.Config{})
 	// Incorrect request method.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
+	apitest.New().HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
 		Post(auth.Auth).
 		Expect(t).
 		Status(http.StatusUnauthorized).
 		End()
 	// No existing auth cookie.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
+	apitest.New().HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
 		Get(auth.Auth).
 		Expect(t).
 		Status(http.StatusTemporaryRedirect).
 		End()
 	// Outdated auth cookie with expected name should not break API.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
+	apitest.New().HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
 		Get(auth.Auth).
 		Cookie(auth.CookieName, "empty").
 		Expect(t).
@@ -52,8 +49,7 @@ func TestOAuth2LoginRedirect(t *testing.T) {
 	logger := qlog.Logger(t)
 	authConfig := auth.NewGitHubConfig("", &scm.Config{})
 
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
+	apitest.New().HandlerFunc(auth.OAuth2Login(logger, authConfig, "")).
 		Get(authGithub).
 		Expect(t).
 		Status(http.StatusTemporaryRedirect).
@@ -93,8 +89,7 @@ func TestOAuth2Callback(t *testing.T) {
 		Status(http.StatusOK).
 		End()
 
-	apitest.New().Debug().
-		Mocks(mockTokenExchange, mockUserExchange).
+	apitest.New().Mocks(mockTokenExchange, mockUserExchange).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -147,8 +142,7 @@ func TestOAuth2CallbackUserExchange(t *testing.T) {
 		Status(http.StatusBadRequest).
 		End()
 
-	apitest.New().Debug().
-		Mocks(mockTokenExchange, mockEmptyUserInfo).
+	apitest.New().Mocks(mockTokenExchange, mockEmptyUserInfo).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -157,8 +151,7 @@ func TestOAuth2CallbackUserExchange(t *testing.T) {
 		Status(http.StatusUnauthorized).
 		HeaderNotPresent(auth.SetCookie).
 		End()
-	apitest.New().Debug().
-		Mocks(mockTokenExchange, mockEmptyResponseBody).
+	apitest.New().Mocks(mockTokenExchange, mockEmptyResponseBody).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -167,8 +160,7 @@ func TestOAuth2CallbackUserExchange(t *testing.T) {
 		Status(http.StatusUnauthorized).
 		HeaderNotPresent(auth.SetCookie).
 		End()
-	apitest.New().Debug().
-		Mocks(mockTokenExchange, mockBadRequestStatus).
+	apitest.New().Mocks(mockTokenExchange, mockBadRequestStatus).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -203,8 +195,7 @@ func TestOAuth2CallbackTokenExchange(t *testing.T) {
 		Status(http.StatusOK).
 		End()
 	// Token value is an empty string.
-	apitest.New().Debug().
-		Mocks(mockEmptyAccessToken).
+	apitest.New().Mocks(mockEmptyAccessToken).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -214,8 +205,7 @@ func TestOAuth2CallbackTokenExchange(t *testing.T) {
 		HeaderNotPresent(auth.SetCookie).
 		End()
 	// No values in the request body.
-	apitest.New().Debug().
-		Mocks(mockEmptyResponseBody).
+	apitest.New().Mocks(mockEmptyResponseBody).
 		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
@@ -238,8 +228,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Wrong request method.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
+	apitest.New().HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Post(callbackGithub).
 		Query("state", testSecret).
 		Query("code", "test code").
@@ -247,8 +236,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 		Status(http.StatusUnauthorized).
 		End()
 	// Incorrect secret code.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
+	apitest.New().HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", "not a secret").
 		Query("code", "test code").
@@ -256,8 +244,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 		Status(http.StatusUnauthorized).
 		End()
 	// Empty exchange code.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
+	apitest.New().HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Query("state", testSecret).
 		Query("code", "").
@@ -265,8 +252,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 		Status(http.StatusUnauthorized).
 		End()
 	// Request with empty body content.
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
+	apitest.New().HandlerFunc(auth.OAuth2Callback(logger, db, tm, authConfig, testSecret)).
 		Get(callbackGithub).
 		Expect(t).
 		Status(http.StatusUnauthorized).
@@ -276,8 +262,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 }
 
 func TestOAuth2Logout(t *testing.T) {
-	apitest.New().Debug().
-		HandlerFunc(auth.OAuth2Logout()).
+	apitest.New().HandlerFunc(auth.OAuth2Logout()).
 		Get(auth.Logout).
 		// Make sure an outdated auth cookie with a correct name does not break API.
 		Cookie(auth.CookieName, "empty").


### PR DESCRIPTION
Resolves #814.