### PR TITLE
Move PullRequestPush handling to pull_request.go

### DIFF
--- a/web/hooks/pull_request.go
+++ b/web/hooks/pull_request.go
@@ -20,7 +20,7 @@ import (
 // If successful, it then finds the relevant task, and uses it to retrieve the relevant task score.
 // If a passing score is reached, it assigns reviewers to the pull request.
 // It also uses the test results and task to generate a feedback comment for the pull request.
-func (wh GitHubWebHook) handlePullRequestPush(payload *github.PushEvent, results *score.Results, assignment *qf.Assignment, course *qf.Course, repo *qf.Repository) {
+func (wh GitHubWebHook) handlePullRequestPush(ctx context.Context, scmClient scm.SCM, payload *github.PushEvent, results *score.Results, assignment *qf.Assignment, course *qf.Course, repo *qf.Repository) {
 	wh.logger.Debugf("Attempting to find pull request for ref: %s, in repository: %s",
 		payload.GetRef(), payload.GetRepo().GetFullName())
 
@@ -30,13 +30,6 @@ func (wh GitHubWebHook) handlePullRequestPush(payload *github.PushEvent, results
 		return
 	}
 	taskSum := results.TaskSum(taskName)
-
-	ctx := context.Background()
-	scmClient, err := wh.scmMgr.GetOrCreateSCM(ctx, wh.logger, course.OrganizationName)
-	if err != nil {
-		wh.logger.Errorf("Failed to create SCM Client: %v", err)
-		return
-	}
 
 	// We assign reviewers to a pull request when the tests associated with it score above the assignment score limit
 	// We do not assign reviewers if the pull request has already been assigned reviewers

--- a/web/hooks/pull_request.go
+++ b/web/hooks/pull_request.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -8,9 +9,97 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v45/github"
+	"github.com/quickfeed/quickfeed/assignments"
+	"github.com/quickfeed/quickfeed/kit/score"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
 	"gorm.io/gorm"
 )
+
+// handlePullRequestPush attempts to find a pull request associated with a non-default branch push event.
+// If successful, it then finds the relevant task, and uses it to retrieve the relevant task score.
+// If a passing score is reached, it assigns reviewers to the pull request.
+// It also uses the test results and task to generate a feedback comment for the pull request.
+func (wh GitHubWebHook) handlePullRequestPush(payload *github.PushEvent, results *score.Results, assignment *qf.Assignment, course *qf.Course, repo *qf.Repository) {
+	wh.logger.Debugf("Attempting to find pull request for ref: %s, in repository: %s",
+		payload.GetRef(), payload.GetRepo().GetFullName())
+
+	pullRequest, taskName, err := wh.handlePullRequestPushPayload(payload)
+	if err != nil {
+		wh.logger.Errorf("Failed to retrieve pull request data from push payload: %v", err)
+		return
+	}
+	taskSum := results.TaskSum(taskName)
+
+	ctx := context.Background()
+	sc, err := wh.scmMgr.GetOrCreateSCM(ctx, wh.logger, course.OrganizationName)
+	if err != nil {
+		wh.logger.Errorf("Failed to create SCM Client: %v", err)
+		return
+	}
+
+	// We assign reviewers to a pull request when the tests associated with it score above the assignment score limit
+	// We do not assign reviewers if the pull request has already been assigned reviewers
+	scoreLimit := assignment.GetScoreLimit()
+	if taskSum >= scoreLimit && !pullRequest.HasReviewers() {
+		wh.logger.Debugf("Assigning reviewers to pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
+		if err := assignments.AssignReviewers(ctx, sc, wh.db, course, repo, pullRequest); err != nil {
+			wh.logger.Errorf("Failed to assign reviewers to pull request: %v", err)
+			return
+		}
+	}
+
+	// Create a test results feedback comment on the pull request
+	opt := &scm.IssueCommentOptions{
+		Organization: course.GetOrganizationName(),
+		Repository:   repo.Name(),
+		Body:         results.MarkdownComment(taskName, scoreLimit),
+		Number:       int(pullRequest.GetNumber()),
+	}
+	wh.logger.Debugf("Creating feedback comment on pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
+	if !pullRequest.HasFeedbackComment() {
+		commentID, err := sc.CreateIssueComment(ctx, opt)
+		if err != nil {
+			wh.logger.Errorf("Failed to create feedback comment for pull request #%d, in repository", pullRequest.GetNumber(), repo.Name())
+			return
+		}
+		pullRequest.ScmCommentID = uint64(commentID)
+		if err := wh.db.UpdatePullRequest(pullRequest); err != nil {
+			wh.logger.Errorf("Failed to update pull request: %v", err)
+			return
+		}
+	} else {
+		opt.CommentID = int64(pullRequest.GetScmCommentID())
+		if err := sc.UpdateIssueComment(ctx, opt); err != nil {
+			wh.logger.Errorf("Failed to update feedback comment for pull request #%d, in repository", pullRequest.GetNumber(), repo.Name())
+			return
+		}
+	}
+	wh.logger.Debugf("Successfully handled push to pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
+}
+
+// handlePullRequestPushPayload retrieves the pull request and task name associated with it from an event payload.
+func (wh GitHubWebHook) handlePullRequestPushPayload(payload *github.PushEvent) (*qf.PullRequest, string, error) {
+	pullRequest, err := wh.db.GetPullRequest(&qf.PullRequest{
+		SourceBranch:    branchName(payload.GetRef()),
+		ScmRepositoryID: uint64(payload.GetRepo().GetID()),
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// This can happen if someone pushes to a branch group assignment, without having a PR created for it
+			// If this happens, QF should not do anything
+			return nil, "", fmt.Errorf("no pull request found for ref: %s", payload.GetRef())
+		}
+		return nil, "", fmt.Errorf("failed to get pull request from database: %v", err)
+	}
+	associatedTask, err := wh.getTask(pullRequest.GetTaskID())
+	if err != nil {
+		// A pull request should always have a task association
+		// If not, something must have gone wrong elsewhere
+		return nil, "", fmt.Errorf("failed to get task from the database: %w", err)
+	}
+	return pullRequest, associatedTask.GetName(), nil
+}
 
 func (wh GitHubWebHook) handlePullRequestReview(payload *github.PullRequestReviewEvent) {
 	wh.logger.Debugf("Received review event for pull request #%d: %q in %s",
@@ -146,7 +235,6 @@ func (wh GitHubWebHook) createPullRequest(payload *github.PullRequestEvent, asso
 		SourceBranch:    payload.GetPullRequest().GetHead().GetRef(),
 		Number:          uint64(payload.GetNumber()),
 	}
-
 	if err = wh.db.CreatePullRequest(pullRequest); err != nil {
 		wh.logger.Errorf("Failed to create pull request data-record for repository %s: %v", payload.GetRepo().GetFullName(), err)
 		return

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -133,7 +133,7 @@ func (wh GitHubWebHook) runAssignmentTests(scmClient scm.SCM, assignment *qf.Ass
 	if !isDefaultBranch(payload) {
 		// Attempt to find the pull request for the branch, if it exists,
 		// and then assign reviewers to it, if the branch task score is higher than the assignment score limit
-		wh.handlePullRequestPush(ctx, scmClient, payload, results, assignment, course, repo)
+		wh.handlePullRequestPush(ctx, scmClient, payload, results, runData)
 	}
 }
 

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -2,18 +2,14 @@ package hooks
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/quickfeed/quickfeed/assignments"
 	"github.com/quickfeed/quickfeed/ci"
-	"github.com/quickfeed/quickfeed/kit/score"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
-	"gorm.io/gorm"
 )
 
 func (wh GitHubWebHook) handlePush(payload *github.PushEvent) {
@@ -79,91 +75,6 @@ func (wh GitHubWebHook) handlePush(payload *github.PushEvent) {
 	default:
 		wh.logger.Debug("Nothing to do for this push event")
 	}
-}
-
-// handlePullRequestPush attempts to find a pull request associated with a non-default branch push event.
-// If successful, it then finds the relevant task, and uses it to retrieve the relevant task score.
-// If a passing score is reached, it assigns reviewers to the pull request.
-// It also uses the test results and task to generate a feedback comment for the pull request.
-func (wh GitHubWebHook) handlePullRequestPush(payload *github.PushEvent, results *score.Results, assignment *qf.Assignment, course *qf.Course, repo *qf.Repository) {
-	wh.logger.Debugf("Attempting to find pull request for ref: %s, in repository: %s",
-		payload.GetRef(), payload.GetRepo().GetFullName())
-
-	pullRequest, taskName, err := wh.handlePullRequestPushPayload(payload)
-	if err != nil {
-		wh.logger.Errorf("Failed to retrieve pull request data from push payload: %v", err)
-		return
-	}
-	taskSum := results.TaskSum(taskName)
-
-	ctx := context.Background()
-	sc, err := wh.scmMgr.GetOrCreateSCM(ctx, wh.logger, course.OrganizationName)
-	if err != nil {
-		wh.logger.Errorf("Failed to create SCM Client: %v", err)
-		return
-	}
-
-	// We assign reviewers to a pull request when the tests associated with it score above the assignment score limit
-	// We do not assign reviewers if the pull request has already been assigned reviewers
-	scoreLimit := assignment.GetScoreLimit()
-	if taskSum >= scoreLimit && !pullRequest.HasReviewers() {
-		wh.logger.Debugf("Assigning reviewers to pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
-		if err := assignments.AssignReviewers(ctx, sc, wh.db, course, repo, pullRequest); err != nil {
-			wh.logger.Errorf("Failed to assign reviewers to pull request: %v", err)
-			return
-		}
-	}
-
-	// Create a test results feedback comment on the pull request
-	opt := &scm.IssueCommentOptions{
-		Organization: course.GetOrganizationName(),
-		Repository:   repo.Name(),
-		Body:         results.MarkdownComment(taskName, scoreLimit),
-		Number:       int(pullRequest.GetNumber()),
-	}
-	wh.logger.Debugf("Creating feedback comment on pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
-	if !pullRequest.HasFeedbackComment() {
-		commentID, err := sc.CreateIssueComment(ctx, opt)
-		if err != nil {
-			wh.logger.Errorf("Failed to create feedback comment for pull request #%d, in repository", pullRequest.GetNumber(), repo.Name())
-			return
-		}
-		pullRequest.ScmCommentID = uint64(commentID)
-		if err := wh.db.UpdatePullRequest(pullRequest); err != nil {
-			wh.logger.Errorf("Failed to update pull request: %v", err)
-			return
-		}
-	} else {
-		opt.CommentID = int64(pullRequest.GetScmCommentID())
-		if err := sc.UpdateIssueComment(ctx, opt); err != nil {
-			wh.logger.Errorf("Failed to update feedback comment for pull request #%d, in repository", pullRequest.GetNumber(), repo.Name())
-			return
-		}
-	}
-	wh.logger.Debugf("Successfully handled push to pull request #%d, in repository: %s", pullRequest.GetNumber(), repo.Name())
-}
-
-// handlePullRequestPushPayload retrieves the pull request and task name associated with it from an event payload.
-func (wh GitHubWebHook) handlePullRequestPushPayload(payload *github.PushEvent) (*qf.PullRequest, string, error) {
-	pullRequest, err := wh.db.GetPullRequest(&qf.PullRequest{
-		SourceBranch:    branchName(payload.GetRef()),
-		ScmRepositoryID: uint64(payload.GetRepo().GetID()),
-	})
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// This can happen if someone pushes to a branch group assignment, without having a PR created for it
-			// If this happens, QF should not do anything
-			return nil, "", fmt.Errorf("no pull request found for ref: %s", payload.GetRef())
-		}
-		return nil, "", fmt.Errorf("failed to get pull request from database: %v", err)
-	}
-	associatedTask, err := wh.getTask(pullRequest.GetTaskID())
-	if err != nil {
-		// A pull request should always have a task association
-		// If not, something must have gone wrong elsewhere
-		return nil, "", fmt.Errorf("failed to get task from the database: %w", err)
-	}
-	return pullRequest, associatedTask.GetName(), nil
 }
 
 // extractAssignments extracts information from the push payload from github

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -133,7 +133,7 @@ func (wh GitHubWebHook) runAssignmentTests(scmClient scm.SCM, assignment *qf.Ass
 	if !isDefaultBranch(payload) {
 		// Attempt to find the pull request for the branch, if it exists,
 		// and then assign reviewers to it, if the branch task score is higher than the assignment score limit
-		wh.handlePullRequestPush(payload, results, assignment, course, repo)
+		wh.handlePullRequestPush(ctx, scmClient, payload, results, assignment, course, repo)
 	}
 }
 


### PR DESCRIPTION
Fixes #837

- Moved handlePullRequestPush to pull_request.go
- Renamed sc to scmClient in handlePullRequestPush
- Renamed sc to scmClient in handlePush, runAssignmentTests
- Pass ctx and scmClient into handlePullRequestPush
- Pass ci.RunData to handlePullRequestPush
