### PR TITLE
serivce.Close() and CloseBy() now use internalRemove()

### DIFF
--- a/web/stream/service.go
+++ b/web/stream/service.go
@@ -90,8 +90,8 @@ func (s *Service[K, V]) internalRemove(id K) {
 func (s *Service[K, V]) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, stream := range s.streams {
-		stream.Close()
+	for id := range s.streams {
+		s.internalRemove(id)
 	}
 }
 
@@ -99,7 +99,5 @@ func (s *Service[K, V]) Close() {
 func (s *Service[K, V]) CloseBy(id K) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if stream, ok := s.streams[id]; ok {
-		stream.Close()
-	}
+	s.internalRemove(id)
 }


### PR DESCRIPTION
- Added the ability change the key type for the streams map
- Specify type of stream ID in tests
- Removed unused service
- Modified map based struct Service[T, V] -> Service[K, V]
- Update doc comment for `service.CloseBy()`
- Delete streams from service map when closing stream(s)
