### PR TITLE
Update scm test helper.

### DIFF
--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFetchAssignments(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s := scm.GetTestSCM(t)
+	s, _ := scm.GetTestUserAndSCM(t)
 
 	course := &qf.Course{
 		Name:             "QuickFeed Test Course",

--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFetchAssignments(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, _ := scm.GetTestUserAndSCM(t)
+	s, _ := scm.GetTestSCM(t)
 
 	course := &qf.Course{
 		Name:             "QuickFeed Test Course",

--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -16,7 +16,7 @@ import (
 // behind newly created issues on the user repositories for manual inspection.
 func TestSynchronizeTasksWithIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, _ := scm.GetTestUserAndSCM(t)
+	s, _ := scm.GetTestSCM(t)
 
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()

--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -16,7 +16,7 @@ import (
 // behind newly created issues on the user repositories for manual inspection.
 func TestSynchronizeTasksWithIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s := scm.GetTestSCM(t)
+	s, _ := scm.GetTestUserAndSCM(t)
 
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()

--- a/ci/run_tests_clone_test.go
+++ b/ci/run_tests_clone_test.go
@@ -17,8 +17,7 @@ func init() {
 
 func TestCloneAndCopyRunTests(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfUserName := scm.GetTestUser(t)
-	sc := scm.GetTestSCM(t)
+	sc, qfUserName := scm.GetTestUserAndSCM(t)
 
 	dstDir := t.TempDir()
 

--- a/ci/run_tests_clone_test.go
+++ b/ci/run_tests_clone_test.go
@@ -17,7 +17,7 @@ func init() {
 
 func TestCloneAndCopyRunTests(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	sc, qfUserName := scm.GetTestUserAndSCM(t)
+	sc, qfUserName := scm.GetTestSCM(t)
 
 	dstDir := t.TempDir()
 

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -47,7 +47,7 @@ func testRunData(t *testing.T) *ci.RunData {
 
 	qfTestOrg := scm.GetTestOrganization(t)
 	// Only used to fetch the user's GitHub login (user name)
-	_, userName := scm.GetTestUserAndSCM(t)
+	_, userName := scm.GetTestSCM(t)
 
 	repo := qf.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	courseID := uint64(1)
@@ -82,7 +82,7 @@ func TestRunTests(t *testing.T) {
 	ctx, cancel := runData.Assignment.WithTimeout(2 * time.Minute)
 	defer cancel()
 
-	scmClient, _ := scm.GetTestUserAndSCM(t)
+	scmClient, _ := scm.GetTestSCM(t)
 	results, err := runData.RunTests(ctx, qtest.Logger(t), scmClient, runner)
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestRunTestsTimeout(t *testing.T) {
 	// Note that this timeout value is susceptible to variation
 	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
 	defer cancel()
-	scmClient, _ := scm.GetTestUserAndSCM(t)
+	scmClient, _ := scm.GetTestSCM(t)
 	results, err := runData.RunTests(ctx, qtest.Logger(t), scmClient, runner)
 	if err != nil {
 		t.Fatal(err)

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -47,7 +47,7 @@ func testRunData(t *testing.T) *ci.RunData {
 
 	qfTestOrg := scm.GetTestOrganization(t)
 	// Only used to fetch the user's GitHub login (user name)
-	userName := scm.GetTestUser(t)
+	_, userName := scm.GetTestUserAndSCM(t)
 
 	repo := qf.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	courseID := uint64(1)
@@ -82,7 +82,7 @@ func TestRunTests(t *testing.T) {
 	ctx, cancel := runData.Assignment.WithTimeout(2 * time.Minute)
 	defer cancel()
 
-	scmClient := scm.GetTestSCM(t)
+	scmClient, _ := scm.GetTestUserAndSCM(t)
 	results, err := runData.RunTests(ctx, qtest.Logger(t), scmClient, runner)
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestRunTestsTimeout(t *testing.T) {
 	// Note that this timeout value is susceptible to variation
 	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
 	defer cancel()
-	scmClient := scm.GetTestSCM(t)
+	scmClient, _ := scm.GetTestUserAndSCM(t)
 	results, err := runData.RunTests(ctx, qtest.Logger(t), scmClient, runner)
 	if err != nil {
 		t.Fatal(err)

--- a/scm/env_helper.go
+++ b/scm/env_helper.go
@@ -17,7 +17,7 @@ func GetTestOrganization(t *testing.T) string {
 	return qfTestOrg
 }
 
-func GetTestUserAndSCM(t *testing.T) (SCM, string) {
+func GetTestSCM(t *testing.T) (SCM, string) {
 	t.Helper()
 	accessToken := GetAccessToken(t)
 	scmClient := NewGithubSCMClient(qtest.Logger(t), accessToken)

--- a/scm/env_helper.go
+++ b/scm/env_helper.go
@@ -37,13 +37,3 @@ func GetAccessToken(t *testing.T) string {
 	}
 	return accessToken
 }
-
-func GetWebHookServer(t *testing.T) string {
-	t.Helper()
-	serverURL := os.Getenv("QF_WEBHOOK_SERVER")
-	if len(serverURL) < 1 {
-		qfTestOrg := GetTestOrganization(t)
-		t.Skipf("This test requires that 'QF_WEBHOOK_SERVER' is set and that you have access to the '%v' GitHub organization", qfTestOrg)
-	}
-	return serverURL
-}

--- a/scm/fetcher_test.go
+++ b/scm/fetcher_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestClone(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s := scm.GetTestSCM(t)
-	userName := scm.GetTestUser(t)
+	s, userName := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()
@@ -84,7 +83,7 @@ func appendToFile(filename, text string) (err error) {
 // The third clone is actually a fast-forward pull.
 func TestCloneTwice(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s := scm.GetTestSCM(t)
+	s, _ := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()
@@ -151,8 +150,7 @@ func TestCloneTwice(t *testing.T) {
 
 func TestCloneBranch(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s := scm.GetTestSCM(t)
-	userName := scm.GetTestUser(t)
+	s, userName := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()

--- a/scm/fetcher_test.go
+++ b/scm/fetcher_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestClone(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, userName := scm.GetTestUserAndSCM(t)
+	s, userName := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()
@@ -83,7 +83,7 @@ func appendToFile(filename, text string) (err error) {
 // The third clone is actually a fast-forward pull.
 func TestCloneTwice(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, _ := scm.GetTestUserAndSCM(t)
+	s, _ := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()
@@ -150,7 +150,7 @@ func TestCloneTwice(t *testing.T) {
 
 func TestCloneBranch(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, userName := scm.GetTestUserAndSCM(t)
+	s, userName := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	dstDir := t.TempDir()

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -28,8 +28,7 @@ const (
 
 func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{
 		Name:     qfTestOrg,
 		Username: qfTestUser,
@@ -50,8 +49,7 @@ func TestGetOrganization(t *testing.T) {
 // Test case for Creating new Issue on a git Repository
 func TestCreateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	issue, cleanup := createIssue(t, s, qfTestOrg, qf.StudentRepoName(qfTestUser))
 	defer cleanup()
@@ -64,8 +62,7 @@ func TestCreateIssue(t *testing.T) {
 // NOTE: This test only works if the given repository has no previous issues
 func TestGetIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -97,8 +94,7 @@ func TestGetIssues(t *testing.T) {
 
 func TestGetIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -122,8 +118,7 @@ func TestGetIssue(t *testing.T) {
 // Test case for Updating existing Issue in a git Repository
 func TestUpdateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 
@@ -162,8 +157,7 @@ func TestRequestReviewers(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 	repo := qf.StudentRepoName(qfTestUser)
 
 	testReqReviewersBranch := "test-request-reviewers"
@@ -218,8 +212,7 @@ func githubTestClient(t *testing.T) *github.Client {
 
 func TestCreateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	body := "Test"
 	opt := &scm.IssueCommentOptions{
@@ -240,8 +233,7 @@ func TestCreateIssueComment(t *testing.T) {
 
 func TestUpdateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	body := "Issue Comment"
 	opt := &scm.IssueCommentOptions{
@@ -276,8 +268,7 @@ func TestFeedbackCommentFormat(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	opt := &scm.IssueCommentOptions{
 		Organization: qfTestOrg,

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -28,7 +28,7 @@ const (
 
 func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{
 		Name:     qfTestOrg,
 		Username: qfTestUser,
@@ -49,7 +49,7 @@ func TestGetOrganization(t *testing.T) {
 // Test case for Creating new Issue on a git Repository
 func TestCreateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	issue, cleanup := createIssue(t, s, qfTestOrg, qf.StudentRepoName(qfTestUser))
 	defer cleanup()
@@ -62,7 +62,7 @@ func TestCreateIssue(t *testing.T) {
 // NOTE: This test only works if the given repository has no previous issues
 func TestGetIssues(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -94,7 +94,7 @@ func TestGetIssues(t *testing.T) {
 
 func TestGetIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
@@ -118,7 +118,7 @@ func TestGetIssue(t *testing.T) {
 // Test case for Updating existing Issue in a git Repository
 func TestUpdateIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 
@@ -157,7 +157,7 @@ func TestRequestReviewers(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 	repo := qf.StudentRepoName(qfTestUser)
 
 	testReqReviewersBranch := "test-request-reviewers"
@@ -212,7 +212,7 @@ func githubTestClient(t *testing.T) *github.Client {
 
 func TestCreateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	body := "Test"
 	opt := &scm.IssueCommentOptions{
@@ -233,7 +233,7 @@ func TestCreateIssueComment(t *testing.T) {
 
 func TestUpdateIssueComment(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	body := "Issue Comment"
 	opt := &scm.IssueCommentOptions{
@@ -268,7 +268,7 @@ func TestFeedbackCommentFormat(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	opt := &scm.IssueCommentOptions{
 		Organization: qfTestOrg,

--- a/scm/githubv4_test.go
+++ b/scm/githubv4_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDeleteIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	repo, err := s.GetRepository(ctx, &scm.RepositoryOptions{
@@ -72,7 +72,7 @@ func TestDeleteAllIssues(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	s, qfTestUser := scm.GetTestUserAndSCM(t)
+	s, qfTestUser := scm.GetTestSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{

--- a/scm/githubv4_test.go
+++ b/scm/githubv4_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestDeleteIssue(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	repo, err := s.GetRepository(ctx, &scm.RepositoryOptions{
@@ -73,8 +72,7 @@ func TestDeleteAllIssues(t *testing.T) {
 		t.SkipNow()
 	}
 	qfTestOrg := scm.GetTestOrganization(t)
-	qfTestUser := scm.GetTestUser(t)
-	s := scm.GetTestSCM(t)
+	s, qfTestUser := scm.GetTestUserAndSCM(t)
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{


### PR DESCRIPTION
Updating `scm.GetTestUser` to use access token and return a test username and test SCM client.

Resolves #856.