### PR TITLE
Fix missing error returns

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -211,7 +211,7 @@ func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) (
 // DeleteRepository implements the SCM interface.
 func (s *GithubSCM) DeleteRepository(ctx context.Context, opt *RepositoryOptions) error {
 	if !opt.valid() {
-		s.logger.Errorf("DeleteRepository got invalid RepositoryOptions: %+v", opt)
+		return fmt.Errorf("invalid argument: %+v", opt)
 	}
 
 	// if ID provided, get path and owner from github

--- a/web/courses.go
+++ b/web/courses.go
@@ -164,6 +164,7 @@ func (s *QuickFeedService) revokeTeacherStatus(ctx context.Context, sc scm.SCM, 
 	course, user := enrolled.GetCourse(), enrolled.GetUser()
 	err := revokeTeacherStatus(ctx, sc, course.GetOrganizationName(), user.GetLogin())
 	if err != nil {
+		// log error, but continue to update enrollment; we can manually revoke teacher access later
 		s.logger.Errorf("Failed to revoke %s teacher status for %q: %v", course.Code, user.Login, err)
 	}
 	return s.db.UpdateEnrollment(&qf.Enrollment{


### PR DESCRIPTION
There was one case where we only log an error and continue.
There was also on case that was missing a comment; we want to log
the error, but still want to continue with database updates.

Fixes #406

