### PR TITLE
Support concurrent handling of push events

### DIFF
--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -119,7 +119,7 @@ func (r RunData) clone(ctx context.Context, sc scm.SCM, dstDir string) error {
 		Branch:       r.BranchName,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to clone %q repository: %w", r.Repo.Name(), err)
+		return fmt.Errorf("failed to clone %s/%s repository: %w", r.Course.GetOrganizationName(), r.Repo.Name(), err)
 	}
 
 	// Clone the course's tests and assignments repositories if they are missing.

--- a/internal/qtest/mock_data.go
+++ b/internal/qtest/mock_data.go
@@ -38,11 +38,11 @@ var MockCourses = []*qf.Course{
 	{
 		Name:             "Hyped Systems",
 		CourseCreatorID:  1,
-		Code:             "DATx20",
-		Year:             2020,
+		Code:             "QF104",
+		Year:             2022,
 		Tag:              "Fall",
 		Provider:         "fake",
 		OrganizationID:   4,
-		OrganizationName: "DATx20-2020",
+		OrganizationName: "qf104-2022",
 	},
 }

--- a/testdata/courses/qf104-2022/assignments/lab1/sequence/fibonacci.go
+++ b/testdata/courses/qf104-2022/assignments/lab1/sequence/fibonacci.go
@@ -1,0 +1,7 @@
+package sequence
+
+// fibonacci(n) returns the n-th Fibonacci number, and is defined by the
+// recurrence relation F_n = F_n-1 + F_n-2, with seed values F_0=0 and F_1=1.
+func fibonacci(n uint) uint {
+	return 0
+}

--- a/testdata/courses/qf104-2022/assignments/lab2/sequence/triangular.go
+++ b/testdata/courses/qf104-2022/assignments/lab2/sequence/triangular.go
@@ -1,0 +1,25 @@
+package sequence
+
+// triangular(n) returns the n-th Triangular number, and is defined by the
+// recurrence relation F_n = n + F_n-1 where F_0=0 and F_1=1
+//
+// Visualization of numbers:
+// n = 1:    n = 2:     n = 3:      n = 4:    etc...
+//
+//	o         o          o           o
+//	         o o        o o         o o
+//	                   o o o       o o o
+//	                              o o o o
+func triangularRecurrence(n uint) uint {
+	return 0
+}
+
+// Direct mathematical solution:
+
+func triangularFormula(n uint) uint {
+	return 0
+}
+
+func triangular(n uint) uint {
+	return 0
+}

--- a/testdata/courses/qf104-2022/meling-labs/lab1/sequence/fibonacci.go
+++ b/testdata/courses/qf104-2022/meling-labs/lab1/sequence/fibonacci.go
@@ -1,0 +1,13 @@
+package sequence
+
+// fibonacci(n) returns the n-th Fibonacci number, and is defined by the
+// recurrence relation F_n = F_n-1 + F_n-2, with seed values F_0=0 and F_1=1.
+func fibonacci(n uint) uint {
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return 1
+	}
+	return fibonacci(n-1) + fibonacci(n-2)
+}

--- a/testdata/courses/qf104-2022/meling-labs/lab2/sequence/triangular.go
+++ b/testdata/courses/qf104-2022/meling-labs/lab2/sequence/triangular.go
@@ -1,0 +1,35 @@
+package sequence
+
+// triangular(n) returns the n-th Triangular number, and is defined by the
+// recurrence relation F_n = n + F_n-1 where F_0=0 and F_1=1
+//
+// Visualization of numbers:
+// n = 1:    n = 2:     n = 3:      n = 4:    etc...
+//
+//	o         o          o           o
+//	         o o        o o         o o
+//	                   o o o       o o o
+//	                              o o o o
+func triangularRecurrence(n uint) uint {
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return 1
+	}
+	return n + triangular(n-1)
+}
+
+// Direct mathematical solution:
+
+func triangularFormula(n uint) uint {
+	return (n * (n + 1)) / 2
+}
+
+func triangular(n uint) uint {
+	sum := uint(0)
+	for i := uint(1); i <= n; i++ {
+		sum += i
+	}
+	return sum
+}

--- a/testdata/courses/qf104-2022/tests/lab1/sequence/fibonacci_ag_test.go
+++ b/testdata/courses/qf104-2022/tests/lab1/sequence/fibonacci_ag_test.go
@@ -1,0 +1,42 @@
+package sequence
+
+import (
+	"testing"
+)
+
+func init() {
+	// Reduce max score by 1 since the first test-case ({0, 0}) always passes, which gave free points.
+	scores.Add(TestFibonacciAG, len(fibonacciTestsAG)-1, 5)
+}
+
+var fibonacciTestsAG = []struct {
+	in, want uint
+}{
+	{0, 0},
+	{1, 1},
+	{2, 1},
+	{3, 2},
+	{4, 3},
+	{5, 5},
+	{6, 8},
+	{7, 13},
+	{8, 21},
+	{9, 34},
+	{10, 55},
+	{12, 144},
+	{16, 987},
+	{20, 6765},
+}
+
+func TestFibonacciAG(t *testing.T) {
+	sc := scores.Max()
+	defer sc.Print(t)
+
+	for _, ft := range fibonacciTestsAG {
+		got := fibonacci(ft.in)
+		if got != ft.want {
+			t.Errorf("fibonacci(%d) = %d, want %d", ft.in, got, ft.want)
+			sc.Dec()
+		}
+	}
+}

--- a/testdata/courses/qf104-2022/tests/lab1/sequence/main_test.go
+++ b/testdata/courses/qf104-2022/tests/lab1/sequence/main_test.go
@@ -1,0 +1,23 @@
+package sequence
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/kit/score"
+)
+
+var scores = score.NewRegistry()
+
+func TestMain(m *testing.M) {
+	scores.PrintTestInfo()
+	if os.Getenv("SCORE_INIT") != "" {
+		os.Exit(0)
+	}
+	exitCode := m.Run()
+	if err := scores.Validate(); err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(exitCode)
+}

--- a/testdata/courses/qf104-2022/tests/lab2/sequence/main_test.go
+++ b/testdata/courses/qf104-2022/tests/lab2/sequence/main_test.go
@@ -1,0 +1,23 @@
+package sequence
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/kit/score"
+)
+
+var scores = score.NewRegistry()
+
+func TestMain(m *testing.M) {
+	scores.PrintTestInfo()
+	if os.Getenv("SCORE_INIT") != "" {
+		os.Exit(0)
+	}
+	exitCode := m.Run()
+	if err := scores.Validate(); err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(exitCode)
+}

--- a/testdata/courses/qf104-2022/tests/lab2/sequence/triangular_ag_test.go
+++ b/testdata/courses/qf104-2022/tests/lab2/sequence/triangular_ag_test.go
@@ -1,0 +1,98 @@
+package sequence
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func init() {
+	// Reduce max score by 1 since the first test-case ({0, 0}) always passes, which gave free points.
+	max, weight := len(triangularTestsAG)-1, 5
+	scores.Add(TestTriangularAG, max, weight)
+	scores.Add(TestTriangularRecurrenceAG, max, weight)
+	scores.Add(TestTriangularFormulaAG, max, weight)
+	// Here is alternative strategy using subtests
+	for name := range funcs {
+		scores.AddSub(TestTriangularSubTestAG, name, max, weight)
+	}
+}
+
+var funcs = map[string]func(uint) uint{
+	"triangular":           triangular,
+	"triangularRecurrence": triangularRecurrence,
+	"triangularFormula":    triangularFormula,
+}
+
+var triangularTestsAG = []struct {
+	in, want uint
+}{
+	{0, 0},
+	{1, 1},
+	{2, 3},
+	{3, 6},
+	{4, 10},
+	{5, 15},
+	{6, 21},
+	{7, 28},
+	{8, 36},
+	{9, 45},
+	{10, 55},
+	{20, 210},
+	{42, 903},
+	{56, 1596},
+	{62, 1953},
+	{75, 2850},
+	{90, 4095},
+}
+
+func TestTriangularAG(t *testing.T) {
+	sc := scores.Max()
+	defer sc.Print(t)
+
+	for _, test := range triangularTestsAG {
+		if diff := cmp.Diff(test.want, triangular(test.in)); diff != "" {
+			sc.Dec()
+			t.Errorf("triangular(%d): (-want +got):\n%s", test.in, diff)
+		}
+	}
+}
+
+func TestTriangularRecurrenceAG(t *testing.T) {
+	sc := scores.Max()
+	defer sc.Print(t)
+
+	for _, test := range triangularTestsAG {
+		if diff := cmp.Diff(test.want, triangularRecurrence(test.in)); diff != "" {
+			sc.Dec()
+			t.Errorf("triangularRecurrence(%d): (-want +got):\n%s", test.in, diff)
+		}
+	}
+}
+
+func TestTriangularFormulaAG(t *testing.T) {
+	sc := scores.Max()
+	defer sc.Print(t)
+
+	for _, test := range triangularTestsAG {
+		if diff := cmp.Diff(test.want, triangularFormula(test.in)); diff != "" {
+			sc.Dec()
+			t.Errorf("triangularFormula(%d): (-want +got):\n%s", test.in, diff)
+		}
+	}
+}
+
+func TestTriangularSubTestAG(t *testing.T) {
+	for name, fn := range funcs {
+		t.Run(name, func(t *testing.T) {
+			sc := scores.MaxByName(t.Name())
+			defer sc.Print(t)
+			for _, test := range triangularTestsAG {
+				if diff := cmp.Diff(test.want, fn(test.in)); diff != "" {
+					sc.Dec()
+					t.Errorf("%s(%d): (-want +got):\n%s", name, test.in, diff)
+				}
+			}
+		})
+	}
+}

--- a/testdata/courses/qf104-2022/tests/scripts/Dockerfile
+++ b/testdata/courses/qf104-2022/tests/scripts/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.19-alpine
+
+# Install bash and git (and build-base to get gcc)
+# (this is required when building FROM: golang:alpine)
+RUN apk update && apk add --no-cache git bash build-base docker openrc
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
+
+WORKDIR /quickfeed

--- a/testdata/courses/qf104-2022/tests/scripts/run.sh
+++ b/testdata/courses/qf104-2022/tests/scripts/run.sh
@@ -1,0 +1,38 @@
+#image/qf104
+
+start=$SECONDS
+printf "*** Initializing Tests for %s ***\n" "$CURRENT"
+
+# Move to folder with assignment handout code for the current assignment to test.
+cd "$ASSIGNMENTS/$CURRENT"
+# Remove assignment handout tests to avoid interference
+find . -name '*_test.go' -exec rm -rf {} \;
+
+# Copy tests into the base assignments folder for initializing test scores
+cp -r "$TESTS"/* "$ASSIGNMENTS"/
+
+# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
+go get -t github.com/quickfeed/quickfeed/kit/score
+go mod tidy
+# Initialize test scores
+SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
+
+printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
+
+# Move to folder with submitted code for the current assignment to test.
+cd "$SUBMITTED/$CURRENT"
+# Remove student written tests to avoid interference
+find . -name '*_test.go' -exec rm -rf {} \;
+
+# Copy tests into student assignments folder for running tests
+cp -r "$TESTS"/* "$SUBMITTED"/
+
+# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
+go get -t github.com/quickfeed/quickfeed/kit/score
+go mod tidy
+
+printf "\n*** Finished Test Setup in %s seconds ***\n" "$(( SECONDS - start ))"
+start=$SECONDS
+printf "\n*** Running Tests ***\n\n"
+go test -v -timeout 30s ./... 2>&1
+printf "\n*** Finished Running Tests in %s seconds ***\n" "$(( SECONDS - start ))"

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -55,6 +55,9 @@ func (wh GitHubWebHook) Handle() http.HandlerFunc {
 		case *github.PushEvent:
 			// The counting semaphore limits concurrency to maxConcurrentTestRuns.
 			// This should also allow webhook events to return quickly to GitHub, avoiding timeouts.
+			// Note however, if we receive a large number of push events, we may be creating
+			// a large number of goroutines. If this becomes a problem, we can add rate limiting
+			// on the number of goroutines created, by returning a http.StatusTooManyRequests.
 			go func() {
 				wh.sem <- struct{}{} // acquire semaphore
 				wh.handlePush(e)

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -39,6 +39,7 @@ func (wh GitHubWebHook) Handle() http.HandlerFunc {
 		payload, err := github.ValidatePayload(r, []byte(wh.secret))
 		if err != nil {
 			wh.logger.Errorf("Error in request body: %v", err)
+			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		defer r.Body.Close()
@@ -46,6 +47,7 @@ func (wh GitHubWebHook) Handle() http.HandlerFunc {
 		event, err := github.ParseWebHook(github.WebHookType(r), payload)
 		if err != nil {
 			wh.logger.Errorf("Could not parse github webhook: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		wh.logger.Debug(qlog.IndentJson(event))

--- a/web/hooks/github_mock_test.go
+++ b/web/hooks/github_mock_test.go
@@ -1,0 +1,83 @@
+package hooks_test
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/go-github/v45/github"
+	"go.uber.org/zap"
+)
+
+// maxConcurrentTestRuns is the maximum number of concurrent test runs.
+const maxConcurrentTestRuns = 5
+
+// GitHubWebHook holds references and data for handling webhook events.
+type MockWebHook struct {
+	logger                *zap.SugaredLogger
+	secret                string
+	sem                   chan struct{}
+	totalCnt              int32
+	currentConcurrencyCnt int32
+	highestConcurrencyCnt int32
+	lowestConcurrencyCnt  int32
+	wg                    *sync.WaitGroup
+}
+
+// NewMockWebHook creates a new webhook to handle POST requests to the QuickFeed server.
+func NewMockWebHook(logger *zap.SugaredLogger, secret string) *MockWebHook {
+	// counting semaphore: limit concurrent test runs to maxConcurrentTestRuns
+	sem := make(chan struct{}, maxConcurrentTestRuns)
+	wg := &sync.WaitGroup{}
+	return &MockWebHook{logger: logger, secret: secret, sem: sem, wg: wg}
+}
+
+// Handle take POST requests from GitHub, representing Push events
+// associated with course repositories, which then triggers various
+// actions on the QuickFeed backend.
+func (wh *MockWebHook) Handle() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload, err := github.ValidatePayload(r, []byte(wh.secret))
+		if err != nil {
+			wh.logger.Errorf("Error in request body: %v", err)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		defer r.Body.Close()
+
+		event, err := github.ParseWebHook(github.WebHookType(r), payload)
+		if err != nil {
+			wh.logger.Errorf("Could not parse github webhook: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		switch e := event.(type) {
+		case *github.PushEvent:
+			// The counting semaphore limits concurrency to maxConcurrentTestRuns.
+			// This should also allow webhook events to return quickly to GitHub, avoiding timeouts.
+			wh.wg.Add(1)
+			go func() {
+				wh.sem <- struct{}{} // acquire semaphore
+				current := atomic.AddInt32(&wh.currentConcurrencyCnt, 1)
+				if atomic.LoadInt32(&wh.highestConcurrencyCnt) < current {
+					atomic.StoreInt32(&wh.highestConcurrencyCnt, current)
+				}
+				if atomic.LoadInt32(&wh.lowestConcurrencyCnt) > current {
+					atomic.StoreInt32(&wh.lowestConcurrencyCnt, current)
+				}
+				wh.handlePush(e)
+				<-wh.sem // release semaphore
+				atomic.AddInt32(&wh.currentConcurrencyCnt, -1)
+				wh.wg.Done()
+			}()
+		default:
+			wh.logger.Debugf("Ignored event type %s", github.WebHookType(r))
+		}
+	}
+}
+
+func (wh *MockWebHook) handlePush(payload *github.PushEvent) {
+	curCnt := atomic.AddInt32(&wh.totalCnt, 1)
+	wh.logger.Debugf("Received push event on %s / %d", payload.GetRepo().GetName(), curCnt)
+}

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -68,7 +68,7 @@ func TestHandlePush(t *testing.T) {
 }
 
 func TestConcurrentHandlePush(t *testing.T) {
-	const concurrentPushEvents = 100
+	const concurrentPushEvents = 1000
 	wh := NewMockWebHook(qtest.Logger(t), secret)
 	handlerFunc := wh.Handle()
 

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -1,0 +1,129 @@
+package hooks_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/quickfeed/quickfeed/ci"
+	"github.com/quickfeed/quickfeed/internal/env"
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
+	"github.com/quickfeed/quickfeed/web/auth"
+	"github.com/quickfeed/quickfeed/web/hooks"
+	"github.com/steinfletcher/apitest"
+)
+
+func TestHandlePush(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+
+	user := qtest.CreateFakeUser(t, db, 1)
+	repo := &qf.Repository{
+		ID:             1,
+		RepositoryID:   1,
+		OrganizationID: 1,
+		UserID:         user.ID,
+		RepoType:       qf.Repository_USER,
+		HTMLURL:        "https://github.com/qf104-2022/meling-labs",
+	}
+	if err := db.CreateRepository(repo); err != nil {
+		t.Fatal(err)
+	}
+	course := &qf.Course{
+		Name:             "QuickFeed Course 4",
+		Code:             "QF104",
+		Year:             2022,
+		Tag:              "Spring",
+		Provider:         "github",
+		OrganizationID:   1,
+		OrganizationName: "qf104-2022",
+	}
+	qtest.CreateCourse(t, db, user, course)
+
+	lab1 := &qf.Assignment{
+		CourseID:         course.ID,
+		Name:             "lab1",
+		RunScriptContent: "Script for assignment 1",
+		Deadline:         "12.12.2021",
+		AutoApprove:      false,
+		Order:            1,
+		IsGroupLab:       false,
+	}
+
+	lab2 := &qf.Assignment{
+		CourseID:         course.ID,
+		Name:             "lab2",
+		RunScriptContent: "Script for assignment 1",
+		Deadline:         "12.01.2022",
+		AutoApprove:      false,
+		Order:            2,
+		IsGroupLab:       false,
+	}
+
+	for _, a := range []*qf.Assignment{lab1, lab2} {
+		if err := db.CreateAssignment(a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const secret = "secret"
+	env.SetFakeProvider(t)
+	wh := hooks.NewGitHubWebHook(qtest.Logger(t), db, scm.NewSCMManager(nil), &ci.Local{}, secret)
+
+	pushPayload := qlog.IndentJson(pushEvent)
+	signature := hMAC([]byte(pushPayload), []byte(secret))
+
+	apitest.New().
+		// Debug().
+		HandlerFunc(wh.Handle()).
+		Post(auth.Hook).
+		Headers(map[string]string{
+			"Content-Type":    "application/json",
+			"X-Github-Event":  "push",
+			"X-Hub-Signature": "sha256=" + signature,
+		}).
+		Body(pushPayload).
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+
+	// Currently, we need to wait here for wh.handlePush() to finish, since it is running in a goroutine.
+	// TODO(meling) find a more robust way to wait for the goroutine to finish.
+	time.Sleep(2000 * time.Millisecond)
+}
+
+var pushEvent = &github.PushEvent{
+	Ref: github.String("refs/heads/master"),
+	Repo: &github.PushEventRepository{
+		ID:            github.Int64(1),
+		Name:          github.String("meling-labs"),
+		FullName:      github.String("qf104-2022/meling-labs"),
+		DefaultBranch: github.String("master"),
+	},
+	Sender: &github.User{
+		Login: github.String("meling"),
+	},
+	Commits: []*github.HeadCommit{
+		{
+			ID:       github.String("c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"),
+			Message:  github.String("Add a README.md"),
+			Added:    []string{"lab1/README.md"},
+			Removed:  []string{},
+			Modified: []string{"lab2/README.md"},
+		},
+	},
+}
+
+// hMAC returns the HMAC signature for a message provided the secret key and hashFunc.
+func hMAC(message, key []byte) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(message)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -107,17 +107,9 @@ func TestConcurrentHandlePush(t *testing.T) {
 	if wh.totalCnt != concurrentPushEvents {
 		t.Errorf("totalCnt = %d, want %d", wh.totalCnt, concurrentPushEvents)
 	}
-	// At most maxConcurrentTestRuns goroutines should have been executing at the same time.
-	if wh.highestConcurrencyCnt != maxConcurrentTestRuns {
-		t.Errorf("highestConcurrencyCnt = %d, want %d", wh.highestConcurrencyCnt, maxConcurrentTestRuns)
-	}
 	// All goroutines should have completed.
 	if wh.currentConcurrencyCnt != 0 {
 		t.Errorf("currentConcurrencyCnt = %d, want 0", wh.currentConcurrencyCnt)
-	}
-	// All goroutines should have completed.
-	if wh.lowestConcurrencyCnt != 0 {
-		t.Errorf("lowestConcurrencyCnt = %d, want 0", wh.lowestConcurrencyCnt)
 	}
 }
 

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -110,6 +110,13 @@ var pushEvent = &github.PushEvent{
 	Sender: &github.User{
 		Login: github.String("meling"),
 	},
+	HeadCommit: &github.HeadCommit{
+		ID:       github.String("c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"),
+		Message:  github.String("Add a README.md"),
+		Added:    []string{"lab1/README.md"},
+		Removed:  []string{},
+		Modified: []string{"lab2/README.md"},
+	},
 	Commits: []*github.HeadCommit{
 		{
 			ID:       github.String("c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"),

--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -20,7 +21,17 @@ import (
 	"github.com/steinfletcher/apitest"
 )
 
+func loadRunScript(t *testing.T, runScriptPath string) string {
+	t.Helper()
+	b, err := os.ReadFile(runScriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
 func TestHandlePush(t *testing.T) {
+	runScript := loadRunScript(t, "../../testdata/courses/qf104-2022/tests/scripts/run.sh")
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
@@ -50,7 +61,7 @@ func TestHandlePush(t *testing.T) {
 	lab1 := &qf.Assignment{
 		CourseID:         course.ID,
 		Name:             "lab1",
-		RunScriptContent: "Script for assignment 1",
+		RunScriptContent: runScript,
 		Deadline:         "12.12.2021",
 		AutoApprove:      false,
 		Order:            1,
@@ -60,7 +71,7 @@ func TestHandlePush(t *testing.T) {
 	lab2 := &qf.Assignment{
 		CourseID:         course.ID,
 		Name:             "lab2",
-		RunScriptContent: "Script for assignment 1",
+		RunScriptContent: runScript,
 		Deadline:         "12.01.2022",
 		AutoApprove:      false,
 		Order:            2,


### PR DESCRIPTION
This should prevent GitHub timeouts on webhook events, since it will start a new goroutine quickly and block if more than 5 push events arrive concurrently. The Handle() func should still return quickly to GitHub even though handling push events (running tests) takes a while.

Fixes #783

