### PR TITLE
Fix showdown in tests

### DIFF
--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -4,13 +4,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"net/http"
 	"os"
 	"testing"
 
 	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/qf"
-	"github.com/quickfeed/quickfeed/qf/qfconnect"
 )
 
 // TestDB returns a test database and close function.
@@ -195,12 +193,4 @@ func AssignmentsWithTasks(courseID uint64) []*qf.Assignment {
 			},
 		},
 	}
-}
-
-func QuickFeedClient(url string) qfconnect.QuickFeedServiceClient {
-	serverUrl := url
-	if serverUrl == "" {
-		serverUrl = "http://127.0.0.1:8081"
-	}
-	return qfconnect.NewQuickFeedServiceClient(http.DefaultClient, serverUrl)
 }

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -30,12 +30,12 @@ func TestAccessControl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown := web.MockQuickFeedServer(t, logger, db, connect.WithInterceptors(
+	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewAccessControlInterceptor(tm),
 	))
-
-	client := qtest.QuickFeedClient("")
+	ctx := context.Background()
+	defer shutdown(ctx)
 
 	courseAdmin := qtest.CreateAdminUser(t, db, "fake")
 	groupStudent := qtest.CreateNamedUser(t, db, 2, "group student")
@@ -84,7 +84,6 @@ func TestAccessControl(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
 	f := func(t *testing.T, id uint64) string {
 		cookie, err := tm.NewAuthCookie(id)
 		if err != nil {
@@ -361,7 +360,6 @@ func TestAccessControl(t *testing.T) {
 			checkAccess(t, "UpdateUser", err, tt.wantCode, tt.wantAccess)
 		})
 	}
-	shutdown(ctx)
 }
 
 func requestWithCookie[T any](message *T, cookie string) *connect.Request[T] {

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -23,14 +23,13 @@ func TestRefreshTokens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown := web.MockQuickFeedServer(t, logger, db, connect.WithInterceptors(
+	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewTokenInterceptor(tm),
 	))
-
-	client := qtest.QuickFeedClient("")
-
 	ctx := context.Background()
+	defer shutdown(ctx)
+
 	f := func(t *testing.T, id uint64) string {
 		cookie, err := tm.NewAuthCookie(id)
 		if err != nil {
@@ -128,5 +127,4 @@ func TestRefreshTokens(t *testing.T) {
 	if tm.UpdateRequired(adminClaims) {
 		t.Error("Admin should not be in the token update list")
 	}
-	shutdown(ctx)
 }

--- a/web/interceptor/user_auth_test.go
+++ b/web/interceptor/user_auth_test.go
@@ -23,11 +23,11 @@ func TestUserVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown := web.MockQuickFeedServer(t, logger, db, connect.WithInterceptors(
+	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 	))
-
-	client := qtest.QuickFeedClient("")
+	ctx := context.Background()
+	defer shutdown(ctx)
 
 	adminUser := qtest.CreateFakeUser(t, db, 1)
 	student := qtest.CreateFakeUser(t, db, 56)
@@ -52,7 +52,6 @@ func TestUserVerifier(t *testing.T) {
 		{code: 0, cookie: studentCookie.String(), wantUser: student},
 	}
 
-	ctx := context.Background()
 	for _, user := range userTest {
 		gotUser, err := client.GetUser(ctx, requestWithCookie(&qf.Void{}, user.cookie))
 		if err != nil {
@@ -77,5 +76,4 @@ func TestUserVerifier(t *testing.T) {
 			}
 		}
 	}
-	shutdown(ctx)
 }

--- a/web/quickfeed_helper_test.go
+++ b/web/quickfeed_helper_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
@@ -32,7 +33,8 @@ func MockQuickFeedClient(t *testing.T, db database.Database, opts connect.Option
 	}
 	shutdown := web.MockQuickFeedServer(t, logger, db, opts)
 
+	const serverURL = "http://127.0.0.1:8081"
 	return func(ctx context.Context) {
 		shutdown(ctx)
-	}, qtest.QuickFeedClient("")
+	}, qfconnect.NewQuickFeedServiceClient(http.DefaultClient, serverURL)
 }

--- a/web/thirdparty_auth_test.go
+++ b/web/thirdparty_auth_test.go
@@ -44,13 +44,14 @@ func TestThirdPartyAuth(t *testing.T) {
 		interceptor.NewAccessControlInterceptor(tm),
 		interceptor.NewTokenInterceptor(tm),
 	))
+	ctx := context.Background()
+	defer shutdown(ctx)
 
 	request := connect.NewRequest(&qf.CourseUserRequest{
 		CourseCode: "DAT320",
 		CourseYear: 2021,
 		UserLogin:  userName,
 	})
-	ctx := context.Background()
 	// request.Header().Set(auth.Cookie, firstAdminCookie.String())
 	userInfo, err := client.GetUserByCourse(ctx, request)
 	check(t, err)
@@ -60,7 +61,6 @@ func TestThirdPartyAuth(t *testing.T) {
 	if userInfo.Msg.Login != user.Login {
 		t.Errorf("expected user login %s, got %s", user.Login, userInfo.Msg.Login)
 	}
-	shutdown(ctx)
 }
 
 func fillDatabase(t *testing.T, db database.Database) {


### PR DESCRIPTION
When mocking a client in a test we must ensure that shutdown(ctx)
is always called before a test ends; otherwise we may risk that a
failing test doesn't call shutdown(ctx), potentially triggering
another test to fail as well.

Fixes #861

