### PR TITLE
Remove GetTeam

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -354,34 +354,6 @@ func (s *GithubSCM) DeleteTeam(ctx context.Context, opt *TeamOptions) error {
 	return err
 }
 
-// GetTeam implements the SCM interface
-func (s *GithubSCM) GetTeam(ctx context.Context, opt *TeamOptions) (scmTeam *Team, err error) {
-	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetTeam",
-			Message: fmt.Sprintf("%+v", opt),
-		}
-	}
-	var team *github.Team
-	if opt.TeamID < 1 {
-		slug := slug.Make(opt.TeamName)
-		team, _, err = s.client.Teams.GetTeamBySlug(ctx, opt.Organization, slug)
-		if err != nil {
-			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by slug '%s': %w", slug, err)
-		}
-	} else {
-		team, _, err = s.client.Teams.GetTeamByID(ctx, int64(opt.OrganizationID), int64(opt.TeamID))
-		if err != nil {
-			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by ID '%d': %w", opt.TeamID, err)
-		}
-	}
-	return &Team{
-		ID:           uint64(team.GetID()),
-		Name:         team.GetName(),
-		Organization: team.Organization.GetLogin(),
-	}, nil
-}
-
 // GetTeams implements the scm interface
 func (s *GithubSCM) GetTeams(ctx context.Context, org *qf.Organization) ([]*Team, error) {
 	if !org.IsValid() {

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -197,26 +197,6 @@ func (s *MockSCM) DeleteTeam(_ context.Context, opt *TeamOptions) error {
 	return nil
 }
 
-// GetTeam implements the SCM interface
-func (s *MockSCM) GetTeam(_ context.Context, opt *TeamOptions) (*Team, error) {
-	if !opt.valid() {
-		return nil, fmt.Errorf("invalid argument: %+v", opt)
-	}
-	if opt.TeamID > 0 {
-		team, ok := s.Teams[opt.TeamID]
-		if !ok {
-			return nil, errors.New("team not found")
-		}
-		return team, nil
-	}
-	for _, team := range s.Teams {
-		if team.Name == opt.TeamName && team.Organization == opt.Organization {
-			return team, nil
-		}
-	}
-	return nil, errors.New("team not found")
-}
-
 // GetTeams implements the SCM interface
 func (s *MockSCM) GetTeams(_ context.Context, org *qf.Organization) ([]*Team, error) {
 	var teams []*Team

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -269,72 +269,120 @@ func TestMockRepositories(t *testing.T) {
 	}
 }
 
-func TestMockTeams(t *testing.T) {
+var mockTeams = []*scm.Team{
+	{
+		ID:           1,
+		Organization: qtest.MockOrg,
+		Name:         "a_team",
+	},
+	{
+		ID:           2,
+		Organization: qtest.MockOrg,
+		Name:         "another_team",
+	},
+	{
+		ID:           3,
+		Organization: qtest.MockOrg,
+		Name:         "best_team",
+	},
+}
+
+func TestMockCreateTeams(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()
-	course := qtest.MockCourses[0]
-	teams := []*scm.Team{
-		{
-			Organization: course.OrganizationName,
-			Name:         "a_team",
-		},
-		{
-			Organization: course.OrganizationName,
-			Name:         "another_team",
-		},
-		{
-			Organization: course.OrganizationName,
-			Name:         "best_team",
-		},
-	}
-	for _, team := range teams {
-		wantTeam, err := s.CreateTeam(ctx, &scm.NewTeamOptions{
+	for _, team := range mockTeams {
+		newTeam, err := s.CreateTeam(ctx, &scm.NewTeamOptions{
 			Organization: team.Organization,
 			TeamName:     team.Name,
 		})
 		if err != nil {
 			t.Error(err)
 		}
-		team.ID = wantTeam.ID
-		opts := []*scm.TeamOptions{
-			{
-				TeamID:         team.ID,
-				OrganizationID: course.OrganizationID,
-			},
-			{
-				TeamName:     team.Name,
-				Organization: team.Organization,
-			},
+		if _, ok := s.Teams[newTeam.ID]; !ok {
+			t.Errorf("expected new team %d", newTeam.ID)
 		}
-		for _, opt := range opts {
-			gotTeam, err := s.GetTeam(ctx, opt)
-			if err != nil {
-				t.Error(err)
-			}
-			if diff := cmp.Diff(wantTeam, gotTeam); diff != "" {
-				t.Errorf("Expected same team, got (-sub +want):\n%s", diff)
+	}
+	if len(s.Teams) != len(mockTeams) {
+		t.Fatalf("expected %d teams created, got %d", len(mockTeams), len(s.Teams))
+	}
+}
+
+func TestMockDeleteTeams(t *testing.T) {
+	s := scm.NewMockSCMClient()
+	ctx := context.Background()
+	for _, team := range mockTeams {
+		s.Teams[team.ID] = team
+	}
+	tests := []struct {
+		name      string
+		opt       *scm.TeamOptions
+		wantTeams []uint64
+		wantErr   bool
+	}{
+		{
+			"delete team 2",
+			&scm.TeamOptions{
+				TeamID:         2,
+				OrganizationID: 1,
+			},
+			[]uint64{1, 3},
+			false,
+		},
+		{
+			"delete team 1",
+			&scm.TeamOptions{
+				TeamID:         1,
+				OrganizationID: 1,
+			},
+			[]uint64{3},
+			false,
+		},
+		{
+			"invalid opt, missing organization info",
+			&scm.TeamOptions{
+				TeamID:   3,
+				TeamName: mockTeams[2].Name,
+			},
+			[]uint64{3},
+			true,
+		},
+		{
+			"invalid opt, missing team info",
+			&scm.TeamOptions{
+				Organization:   qtest.MockOrg,
+				OrganizationID: 1,
+			},
+			[]uint64{3},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		if err := s.DeleteTeam(ctx, tt.opt); (err != nil) != tt.wantErr {
+			t.Errorf("%s: expected error %v, got = %v, ", tt.name, tt.wantErr, err)
+		}
+		for _, teamID := range tt.wantTeams {
+			if _, ok := s.Teams[teamID]; !ok {
+				t.Errorf("%s: expected team %d in remaining teams", tt.name, teamID)
 			}
 		}
 	}
-	if err := s.DeleteTeam(ctx, &scm.TeamOptions{
-		TeamID:         2,
-		OrganizationID: course.OrganizationID,
-	}); err != nil {
-		t.Error(err)
+}
+
+func TestMockGetTeams(t *testing.T) {
+	s := scm.NewMockSCMClient()
+	ctx := context.Background()
+	for _, team := range mockTeams {
+		s.Teams[team.ID] = team
 	}
-	wantTeams := []*scm.Team{teams[0], teams[2]}
-	courseTeams, err := s.GetTeams(ctx, &qf.Organization{
-		ID:   course.OrganizationID,
-		Name: course.OrganizationName,
+	gotTeams, err := s.GetTeams(ctx, &qf.Organization{
+		ID:   1,
+		Name: qtest.MockOrg,
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("expected teams in mock organization")
 	}
-	sort.Slice(courseTeams, func(i, j int) bool {
-		return courseTeams[i].ID < courseTeams[j].ID
-	})
-	if diff := cmp.Diff(wantTeams, courseTeams); diff != "" {
-		t.Errorf("Expected same teams, got (-sub +want):\n%s", diff)
+	if len(gotTeams) != len(mockTeams) {
+		t.Fatalf("expected %d teams, got %d", len(mockTeams), len(gotTeams))
 	}
 }
 

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -32,8 +32,6 @@ type SCM interface {
 	CreateTeam(context.Context, *NewTeamOptions) (*Team, error)
 	// Delete team.
 	DeleteTeam(context.Context, *TeamOptions) error
-	// Get a single team by ID or name.
-	GetTeam(context.Context, *TeamOptions) (*Team, error)
 	// Fetch all teams for organization.
 	GetTeams(context.Context, *qf.Organization) ([]*Team, error)
 	// Add repo to team.


### PR DESCRIPTION
- removed unused scm method `GetTeam`
- split mock test for team methods into two separate tests for `CreateTeam` and `DeleteTeam`

Resolves #865.