### PR TITLE
Fix rebuild from dockerfile on update in tests repo

### DIFF
--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -63,7 +63,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, sc scm
 		updateGradingCriteria(logger, db, assignment)
 	}
 
-	if dockerfile != "" && dockerfile != course.Dockerfile {
+	if course.HasUpdatedDockerfile(dockerfile) {
 		// The course's Dockerfile was added or updated in the tests repository
 		course.Dockerfile = dockerfile
 		// Rebuild the Docker image for the course tagged with the course code
@@ -73,7 +73,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, sc scm
 		}
 		// Update the course's Dockerfile in the database
 		if err := db.UpdateCourse(course); err != nil {
-			logger.Debugf("Failed to update Dockerfile for course %s: %s", course.GetCode(), err)
+			logger.Errorf("Failed to update Dockerfile for course %s: %v", course.GetCode(), err)
 			return
 		}
 	}

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -11,6 +11,8 @@ type Job struct {
 	// Image names the image to use to run the job.
 	Image string
 	// Dockerfile contents.
+	// If empty, the image is assumed to exist.
+	// If non-empty, the image is built from this Dockerfile.
 	Dockerfile string
 	// BindDir is the directory to bind to the container's /quickfeed directory.
 	BindDir string

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -112,6 +112,25 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.Containe
 		// image name should be specified in a run.sh file in the tests repository
 		return nil, fmt.Errorf("no image name specified for '%s'", job.Name)
 	}
+	if job.Dockerfile != "" {
+		d.logger.Infof("Removing image '%s' for '%s' prior to rebuild", job.Image, job.Name)
+		resp, err := d.client.ImageRemove(ctx, job.Image, types.ImageRemoveOptions{Force: true})
+		if err != nil {
+			d.logger.Debugf("Expected error (continuing): %v", err)
+			// continue because we may not have an image to remove
+		}
+		for _, r := range resp {
+			d.logger.Infof("Removed image '%s' for '%s'", r.Deleted, job.Name)
+		}
+
+		d.logger.Infof("Trying to build image: '%s' from Dockerfile", job.Image)
+		// Log first line of Dockerfile
+		d.logger.Infof("[%s] Dockerfile: %s ...", job.Image, job.Dockerfile[:strings.Index(job.Dockerfile, "\n")+1])
+		if err := d.buildImage(ctx, job); err != nil {
+			return nil, err
+		}
+	}
+
 	var hostConfig *container.HostConfig
 	if job.BindDir != "" {
 		hostConfig = &container.HostConfig{
@@ -125,9 +144,6 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.Containe
 		}
 	}
 
-	// Log first line of Dockerfile
-	d.logger.Infof("[%s] Dockerfile: %s ...", job.Image, job.Dockerfile[:strings.Index(job.Dockerfile, "\n")+1])
-
 	create := func() (container.ContainerCreateCreatedBody, error) {
 		return d.client.ContainerCreate(ctx, &container.Config{
 			Image: job.Image,
@@ -140,17 +156,9 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.Containe
 	resp, err := create()
 	if err != nil {
 		d.logger.Infof("Image '%s' not yet available for '%s': %v", job.Image, job.Name, err)
-
-		if job.Dockerfile != "" {
-			d.logger.Infof("Trying to build image: '%s' from Dockerfile", job.Image)
-			if err := d.buildImage(ctx, job); err != nil {
-				return nil, err
-			}
-		} else {
-			d.logger.Infof("Trying to pull image: '%s' from docker.io", job.Image)
-			if err := d.pullImage(ctx, job.Image); err != nil {
-				return nil, err
-			}
+		d.logger.Infof("Trying to pull image: '%s' from remote repository", job.Image)
+		if err := d.pullImage(ctx, job.Image); err != nil {
+			return nil, err
 		}
 		// try to create the container again
 		resp, err = create()

--- a/ci/docker_test.go
+++ b/ci/docker_test.go
@@ -232,6 +232,58 @@ func TestDockerBuild(t *testing.T) {
 	}
 }
 
+func TestDockerBuildRebuild(t *testing.T) {
+	if !docker {
+		t.SkipNow()
+	}
+
+	const (
+		script     = `echo -n "hello world"`
+		script2    = `echo -n "hello quickfeed"`
+		wantOut    = "hello world"
+		wantOut2   = "hello quickfeed"
+		image      = "dat320:latest"
+		image2     = "golang:latest"
+		dockerfile = `FROM golang:latest
+RUN apt update && apt install -y git bash build-essential && rm -rf /var/lib/apt/lists/*
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
+WORKDIR /quickfeed`
+		dockerfile2 = `FROM golang:latest
+RUN apt update && apt install -y git bash build-essential && rm -rf /var/lib/apt/lists/*
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.42.1
+WORKDIR /quickfeed`
+	)
+
+	docker, closeFn := dockerClient(t)
+	defer closeFn()
+
+	out, err := docker.Run(context.Background(), &ci.Job{
+		Name:       t.Name() + "-" + qtest.RandomString(t),
+		Image:      image,
+		Dockerfile: dockerfile,
+		Commands:   []string{script},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != wantOut {
+		t.Errorf("docker.Run(%#v) = %#v, want %#v", script, out, wantOut)
+	}
+
+	out2, err := docker.Run(context.Background(), &ci.Job{
+		Name:       t.Name() + "-" + qtest.RandomString(t),
+		Image:      image,
+		Dockerfile: dockerfile2,
+		Commands:   []string{script2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out2 != wantOut2 {
+		t.Errorf("docker.Run(%#v) = %#v, want %#v", script2, out2, wantOut2)
+	}
+}
+
 func TestDockerRunAsNonRoot(t *testing.T) {
 	if !docker {
 		t.SkipNow()
@@ -269,7 +321,6 @@ go test -v
 WORKDIR /quickfeed
 `
 	)
-	deleteDockerImages(t, image)
 
 	docker, closeFn := dockerClient(t)
 	defer closeFn()

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -33,12 +33,11 @@ func (r *RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
 		}
 	}
 	return &Job{
-		Name:       r.String(),
-		Image:      image,
-		Dockerfile: r.Course.Dockerfile,
-		BindDir:    destDir,
-		Env:        r.EnvVarsFn(secret, destDir),
-		Commands:   commands,
+		Name:     r.String(),
+		Image:    image,
+		BindDir:  destDir,
+		Env:      r.EnvVarsFn(secret, destDir),
+		Commands: commands,
 	}, nil
 }
 

--- a/database/gormdb_course_test.go
+++ b/database/gormdb_course_test.go
@@ -241,6 +241,7 @@ func TestGormDBUpdateCourse(t *testing.T) {
 		Year:           2017,
 		Tag:            "Spring",
 		Provider:       "github",
+		Dockerfile:     "Dockerfile1",
 		OrganizationID: 1234,
 	}
 	wantCourse := &qf.Course{
@@ -249,14 +250,14 @@ func TestGormDBUpdateCourse(t *testing.T) {
 		Year:           2018,
 		Tag:            "Autumn",
 		Provider:       "gitlab",
+		Dockerfile:     "Another Dockerfile1",
 		OrganizationID: 12345,
 	}
 
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	remoteID := &qf.RemoteIdentity{Provider: course.Provider, RemoteID: 10, AccessToken: "token"}
-	admin := qtest.CreateUserFromRemoteIdentity(t, db, remoteID)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	qtest.CreateCourse(t, db, admin, course)
 
 	wantCourse.ID = course.ID
@@ -304,7 +305,7 @@ func TestGormDBGetCourseByOrganization(t *testing.T) {
 	}
 }
 
-func TestGormDBCourseUniqueContraint(t *testing.T) {
+func TestGormDBCourseUniqueConstraint(t *testing.T) {
 	// Test that a course with the same organization ID or code and year cannot be created.
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()

--- a/qf/course.go
+++ b/qf/course.go
@@ -6,6 +6,12 @@ import (
 	"github.com/quickfeed/quickfeed/internal/env"
 )
 
+// HasUpdatedDockerfile returns true if the given dockerfile is different
+// from the course's previous Dockerfile.
+func (course *Course) HasUpdatedDockerfile(dockerfile string) bool {
+	return dockerfile != "" && dockerfile != course.Dockerfile
+}
+
 func (course *Course) CloneDir() string {
 	return filepath.Join(env.RepositoryPath(), course.GetOrganizationName())
 }


### PR DESCRIPTION
This fixes the issue with rebuilding dockerfiles on changes;
we basically remove an existing image and build it again.

That is, we rebuild the image when updating in the repository:
 tests/scripts/Dockerfile

And when RunTests() is called on updates due to push events etc
we do not rebuild the image, but assume that it has already been
built or can be pulled from a remote repository.

Fixes #834

