### PR TITLE
Remove unused scm methods GetRepository and GetTeams, update scm tool

### DIFF
--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-github/v45/github"
 	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/internal/qlog"
 	"github.com/quickfeed/quickfeed/qf"
@@ -335,14 +336,14 @@ func deleteTeams(client *scm.GithubSCM) cli.ActionFunc {
 				return err
 			}
 
-			teams, err := (*client).GetTeams(ctx, &qf.Organization{Name: c.String("namespace")})
+			teams, _, err := (*client).Client().Teams.ListTeams(ctx, c.String("namespace"), &github.ListOptions{})
 			if err != nil {
 				return err
 			}
 
 			for _, team := range teams {
 				var errs []error
-				if err := (*client).DeleteTeam(ctx, &scm.TeamOptions{TeamName: team.Name, Organization: c.String("namespace")}); err != nil {
+				if err := (*client).DeleteTeam(ctx, &scm.TeamOptions{TeamName: *team.Name, Organization: c.String("namespace")}); err != nil {
 					errs = append(errs, err)
 				} else {
 					fmt.Println("Deleted team", team.Name)

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -43,7 +43,7 @@ import (
 // % scm get user
 
 func main() {
-	var client scm.SCM
+	var client scm.GithubSCM
 
 	app := cli.NewApp()
 	app.Name = "scm"
@@ -173,7 +173,7 @@ func main() {
 	}
 }
 
-func before(client *scm.SCM) cli.BeforeFunc {
+func before(client *scm.GithubSCM) cli.BeforeFunc {
 	return func(c *cli.Context) (err error) {
 		provider := c.String("provider")
 		accessToken := os.Getenv(c.String("token"))
@@ -182,7 +182,7 @@ func before(client *scm.SCM) cli.BeforeFunc {
 			return err
 		}
 		if accessToken != "" {
-			*client, err = scm.NewSCMClient(logger.Sugar(), accessToken)
+			*client = *scm.NewGithubSCMClient(logger.Sugar(), accessToken)
 			return
 		}
 
@@ -205,12 +205,12 @@ func before(client *scm.SCM) cli.BeforeFunc {
 		if accessToken == "" {
 			return fmt.Errorf("access token not found in database for provider %s", provider)
 		}
-		*client, err = scm.NewSCMClient(logger.Sugar(), accessToken)
+		*client = *scm.NewGithubSCMClient(logger.Sugar(), accessToken)
 		return
 	}
 }
 
-func deleteRepositories(client *scm.SCM) cli.ActionFunc {
+func deleteRepositories(client *scm.GithubSCM) cli.ActionFunc {
 	ctx := context.Background()
 
 	return func(c *cli.Context) error {
@@ -257,7 +257,7 @@ func deleteRepositories(client *scm.SCM) cli.ActionFunc {
 	}
 }
 
-func getRepositories(client *scm.SCM) cli.ActionFunc {
+func getRepositories(client *scm.GithubSCM) cli.ActionFunc {
 	ctx := context.Background()
 
 	return func(c *cli.Context) error {
@@ -282,16 +282,16 @@ func getRepositories(client *scm.SCM) cli.ActionFunc {
 			fmt.Println(s)
 			return nil
 		}
-		repo, err := (*client).GetRepository(ctx, &scm.RepositoryOptions{Path: c.String("name"), Owner: c.String("namespace")})
+		repo, _, err := (*client).Client().Repositories.Get(ctx, c.String("namespace"), c.String("name"))
 		if err != nil {
 			return err
 		}
-		fmt.Println("Found repository ", repo.HTMLURL)
+		fmt.Println("Found repository ", *repo.HTMLURL)
 		return nil
 	}
 }
 
-func createTeam(client *scm.SCM) cli.ActionFunc {
+func createTeam(client *scm.GithubSCM) cli.ActionFunc {
 	ctx := context.Background()
 
 	return func(c *cli.Context) error {
@@ -318,7 +318,7 @@ func createTeam(client *scm.SCM) cli.ActionFunc {
 	}
 }
 
-func deleteTeams(client *scm.SCM) cli.ActionFunc {
+func deleteTeams(client *scm.GithubSCM) cli.ActionFunc {
 	ctx := context.Background()
 
 	return func(c *cli.Context) error {

--- a/scm/github.go
+++ b/scm/github.go
@@ -709,6 +709,11 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	return nil
 }
 
+// Client returns GitHub client.
+func (s *GithubSCM) Client() *github.Client {
+	return s.client
+}
+
 func toRepository(repo *github.Repository) *Repository {
 	return &Repository{
 		ID:      uint64(repo.GetID()),

--- a/scm/github.go
+++ b/scm/github.go
@@ -330,54 +330,6 @@ func (s *GithubSCM) DeleteTeam(ctx context.Context, opt *TeamOptions) error {
 	return err
 }
 
-// GetTeam implements the SCM interface
-func (s *GithubSCM) GetTeam(ctx context.Context, opt *TeamOptions) (scmTeam *Team, err error) {
-	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetTeam",
-			Message: fmt.Sprintf("%+v", opt),
-		}
-	}
-	var team *github.Team
-	if opt.TeamID < 1 {
-		slug := slug.Make(opt.TeamName)
-		team, _, err = s.client.Teams.GetTeamBySlug(ctx, opt.Organization, slug)
-		if err != nil {
-			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by slug '%s': %w", slug, err)
-		}
-	} else {
-		team, _, err = s.client.Teams.GetTeamByID(ctx, int64(opt.OrganizationID), int64(opt.TeamID))
-		if err != nil {
-			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by ID '%d': %w", opt.TeamID, err)
-		}
-	}
-	return &Team{
-		ID:           uint64(team.GetID()),
-		Name:         team.GetName(),
-		Organization: team.Organization.GetLogin(),
-	}, nil
-}
-
-// GetTeams implements the scm interface
-func (s *GithubSCM) GetTeams(ctx context.Context, org *qf.Organization) ([]*Team, error) {
-	if !org.IsValid() {
-		return nil, ErrMissingFields{
-			Method:  "GetTeams",
-			Message: fmt.Sprintf("%+v", org),
-		}
-	}
-	gitTeams, _, err := s.client.Teams.ListTeams(ctx, org.Name, &github.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("GetTeams: failed to list GitHub teams: %w", err)
-	}
-	var teams []*Team
-	for _, gitTeam := range gitTeams {
-		newTeam := &Team{ID: uint64(gitTeam.GetID()), Name: gitTeam.GetName(), Organization: gitTeam.Organization.GetLogin()}
-		teams = append(teams, newTeam)
-	}
-	return teams, nil
-}
-
 // AddTeamMember implements the scm interface
 func (s *GithubSCM) AddTeamMember(ctx context.Context, opt *TeamMembershipOptions) error {
 	if !opt.valid() {

--- a/scm/github.go
+++ b/scm/github.go
@@ -330,6 +330,34 @@ func (s *GithubSCM) DeleteTeam(ctx context.Context, opt *TeamOptions) error {
 	return err
 }
 
+// GetTeam implements the SCM interface
+func (s *GithubSCM) GetTeam(ctx context.Context, opt *TeamOptions) (scmTeam *Team, err error) {
+	if !opt.valid() {
+		return nil, ErrMissingFields{
+			Method:  "GetTeam",
+			Message: fmt.Sprintf("%+v", opt),
+		}
+	}
+	var team *github.Team
+	if opt.TeamID < 1 {
+		slug := slug.Make(opt.TeamName)
+		team, _, err = s.client.Teams.GetTeamBySlug(ctx, opt.Organization, slug)
+		if err != nil {
+			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by slug '%s': %w", slug, err)
+		}
+	} else {
+		team, _, err = s.client.Teams.GetTeamByID(ctx, int64(opt.OrganizationID), int64(opt.TeamID))
+		if err != nil {
+			return nil, fmt.Errorf("GetTeam: failed to get GitHub team by ID '%d': %w", opt.TeamID, err)
+		}
+	}
+	return &Team{
+		ID:           uint64(team.GetID()),
+		Name:         team.GetName(),
+		Organization: team.Organization.GetLogin(),
+	}, nil
+}
+
 // GetTeams implements the scm interface
 func (s *GithubSCM) GetTeams(ctx context.Context, org *qf.Organization) ([]*Team, error) {
 	if !org.IsValid() {

--- a/scm/github.go
+++ b/scm/github.go
@@ -146,30 +146,6 @@ func (s *GithubSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 	return toRepository(repo), nil
 }
 
-// GetRepository implements the SCM interface.
-func (s *GithubSCM) GetRepository(ctx context.Context, opt *RepositoryOptions) (*Repository, error) {
-	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetRepository",
-			Message: fmt.Sprintf("%+v", opt),
-		}
-	}
-	var repo *github.Repository
-	var err error
-	// if ID is set, get by ID
-	if opt.ID > 0 {
-		repo, _, err = s.client.Repositories.GetByID(ctx, int64(opt.ID))
-	} else {
-		// otherwise get by repo name and owner (usually owner = organization name)
-		repo, _, err = s.client.Repositories.Get(ctx, opt.Owner, opt.Path)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("GetRepository failed to fetch repository %d, and path %s: %w", opt.ID, opt.Path, err)
-	}
-
-	return toRepository(repo), nil
-}
-
 // GetRepositories implements the SCM interface.
 func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) ([]*Repository, error) {
 	if !org.IsValid() {
@@ -261,13 +237,13 @@ func (s *GithubSCM) UpdateRepoAccess(ctx context.Context, repo *Repository, user
 
 // RepositoryIsEmpty implements the SCM interface
 func (s *GithubSCM) RepositoryIsEmpty(ctx context.Context, opt *RepositoryOptions) bool {
-	repo, err := s.GetRepository(ctx, opt)
+	_, _, err := s.client.Repositories.Get(ctx, opt.Owner, opt.Path)
 	if err != nil {
 		return false
 	}
 
 	// test to check how repo commits look like
-	_, _, err = s.client.Repositories.ListCommits(ctx, repo.Owner, repo.Path, nil)
+	_, _, err = s.client.Repositories.ListCommits(ctx, opt.Owner, opt.Path, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "Git Repository is empty") {
 			return true

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -113,26 +113,6 @@ func (s *MockSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryOpt
 	return repo, nil
 }
 
-// GetRepository implements the SCM interface.
-func (s *MockSCM) GetRepository(_ context.Context, opt *RepositoryOptions) (*Repository, error) {
-	if !opt.valid() {
-		return nil, fmt.Errorf("invalid argument: %+v", opt)
-	}
-	if opt.ID > 0 {
-		repo, ok := s.Repositories[opt.ID]
-		if !ok {
-			return nil, errors.New("repository not found")
-		}
-		return repo, nil
-	}
-	for _, repo := range s.Repositories {
-		if repo.Path == opt.Path && repo.Owner == opt.Owner {
-			return repo, nil
-		}
-	}
-	return nil, errors.New("repository not found")
-}
-
 // GetRepositories implements the SCM interface.
 func (s *MockSCM) GetRepositories(_ context.Context, org *qf.Organization) ([]*Repository, error) {
 	var repos []*Repository
@@ -157,11 +137,11 @@ func (s *MockSCM) DeleteRepository(_ context.Context, opt *RepositoryOptions) er
 }
 
 // UpdateRepoAccess implements the SCM interface.
-func (s *MockSCM) UpdateRepoAccess(ctx context.Context, repo *Repository, _, _ string) error {
+func (s *MockSCM) UpdateRepoAccess(_ context.Context, repo *Repository, _, _ string) error {
 	if !repo.valid() {
 		return fmt.Errorf("invalid argument: %+v", repo)
 	}
-	_, err := s.GetRepository(ctx, &RepositoryOptions{
+	_, err := s.getRepository(&RepositoryOptions{
 		ID:    repo.ID,
 		Path:  repo.Path,
 		Owner: repo.Owner,
@@ -309,7 +289,7 @@ func (s *MockSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue, e
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
 		return nil, errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Repository,
 		Owner: opt.Organization,
 	}); err != nil {
@@ -338,7 +318,7 @@ func (s *MockSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue, e
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
 		return nil, errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Repository,
 		Owner: opt.Organization,
 	}); err != nil {
@@ -365,7 +345,7 @@ func (s *MockSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, issueNum
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
 		return nil, errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Path,
 		Owner: opt.Owner,
 	}); err != nil {
@@ -386,7 +366,7 @@ func (s *MockSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Iss
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
 		return nil, errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Path,
 		Owner: opt.Owner,
 	}); err != nil {
@@ -409,7 +389,7 @@ func (s *MockSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, issue
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
 		return errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Path,
 		Owner: opt.Owner,
 	}); err != nil {
@@ -426,7 +406,7 @@ func (s *MockSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) erro
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
 		return errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Path,
 		Owner: opt.Owner,
 	}); err != nil {
@@ -448,7 +428,7 @@ func (s *MockSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptio
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
 		return 0, errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Repository,
 		Owner: opt.Organization,
 	}); err != nil {
@@ -470,7 +450,7 @@ func (s *MockSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOptio
 	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
 		return errors.New("organization not found")
 	}
-	if _, err := s.GetRepository(ctx, &RepositoryOptions{
+	if _, err := s.getRepository(&RepositoryOptions{
 		Path:  opt.Repository,
 		Owner: opt.Organization,
 	}); err != nil {
@@ -527,4 +507,25 @@ func generateID[T any](data map[uint64]T) uint64 {
 		_, ok = data[id]
 	}
 	return id
+}
+
+// getRepository imitates the check done by GitHub when performing API calls that depend on
+// existence of a certain repository.
+func (s *MockSCM) getRepository(opt *RepositoryOptions) (*Repository, error) {
+	if !opt.valid() {
+		return nil, fmt.Errorf("invalid argument: %+v", opt)
+	}
+	if opt.ID > 0 {
+		repo, ok := s.Repositories[opt.ID]
+		if !ok {
+			return nil, errors.New("repository not found")
+		}
+		return repo, nil
+	}
+	for _, repo := range s.Repositories {
+		if repo.Path == opt.Path && repo.Owner == opt.Owner {
+			return repo, nil
+		}
+	}
+	return nil, errors.New("repository not found")
 }

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -177,17 +177,6 @@ func (s *MockSCM) DeleteTeam(_ context.Context, opt *TeamOptions) error {
 	return nil
 }
 
-// GetTeams implements the SCM interface
-func (s *MockSCM) GetTeams(_ context.Context, org *qf.Organization) ([]*Team, error) {
-	var teams []*Team
-	for _, team := range s.Teams {
-		if team.Organization == org.Name {
-			teams = append(teams, team)
-		}
-	}
-	return teams, nil
-}
-
 // AddTeamMember implements the scm interface
 func (s *MockSCM) AddTeamMember(_ context.Context, opt *TeamMembershipOptions) error {
 	if !opt.valid() {

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -229,13 +229,9 @@ func TestMockRepositories(t *testing.T) {
 		if err := s.UpdateRepoAccess(ctx, repo, "", ""); err != nil {
 			t.Error(err)
 		}
-		gotRepo, err := s.GetRepository(ctx, &scm.RepositoryOptions{
-			ID:    repo.ID,
-			Path:  repo.Path,
-			Owner: repo.Owner,
-		})
-		if err != nil {
-			t.Error(err)
+		gotRepo, ok := s.Repositories[repo.ID]
+		if !ok {
+			t.Errorf("expected repository %s to be found", repo.Path)
 		}
 		if diff := cmp.Diff(repo, gotRepo, cmpopts.IgnoreFields(scm.Repository{}, "HTMLURL")); diff != "" {
 			t.Errorf("Expected same repository, got (-sub +want):\n%s", diff)

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -364,24 +364,6 @@ func TestMockDeleteTeams(t *testing.T) {
 	}
 }
 
-func TestMockGetTeams(t *testing.T) {
-	s := scm.NewMockSCMClient()
-	ctx := context.Background()
-	for _, team := range mockTeams {
-		s.Teams[team.ID] = team
-	}
-	gotTeams, err := s.GetTeams(ctx, &qf.Organization{
-		ID:   1,
-		Name: qtest.MockOrg,
-	})
-	if err != nil {
-		t.Fatal("expected teams in mock organization")
-	}
-	if len(gotTeams) != len(mockTeams) {
-		t.Fatalf("expected %d teams, got %d", len(mockTeams), len(gotTeams))
-	}
-}
-
 func TestAddRemoveMockTeamMembers(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -18,8 +18,6 @@ type SCM interface {
 	GetOrganization(context.Context, *GetOrgOptions) (*qf.Organization, error)
 	// Create a new repository.
 	CreateRepository(context.Context, *CreateRepositoryOptions) (*Repository, error)
-	// Get repository by ID or name
-	GetRepository(context.Context, *RepositoryOptions) (*Repository, error)
 	// Get repositories within organization.
 	GetRepositories(context.Context, *qf.Organization) ([]*Repository, error)
 	// Delete repository.

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -30,8 +30,6 @@ type SCM interface {
 	CreateTeam(context.Context, *NewTeamOptions) (*Team, error)
 	// Delete team.
 	DeleteTeam(context.Context, *TeamOptions) error
-	// Fetch all teams for organization.
-	GetTeams(context.Context, *qf.Organization) ([]*Team, error)
 	// Add repo to team.
 	AddTeamRepo(context.Context, *AddTeamRepoOptions) error
 	// AddTeamMember adds a member to a team.


### PR DESCRIPTION
- removed unused scm methods `GetRepository`, `GetTeams`
- scm tool now uses `GithubSCM` instead of the general `SCM` client to enable access to GitHub API directly when necessary

Resolves #873.