### PR TITLE
Fix flaky tests that use MockClient

### DIFF
--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -545,11 +545,9 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 }
 
 func TestUpdateCourseVisibility(t *testing.T) {
-	db, cleanup, _, _ := testQuickFeedService(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-
 	logger := qtest.Logger(t)
-
 	tm, err := auth.NewTokenManager(db)
 	if err != nil {
 		t.Fatal(err)
@@ -562,13 +560,10 @@ func TestUpdateCourseVisibility(t *testing.T) {
 		interceptor.NewAccessControlInterceptor(tm),
 		interceptor.NewTokenInterceptor(tm),
 	)
-	shutdown, client := MockQuickFeedClient(t, db, interceptors)
-
+	client := MockClient(t, db, interceptors)
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	teacher := qtest.CreateAdminUser(t, db, "fake")
-
 	user := qtest.CreateFakeUser(t, db, 2)
 	userCookie, err := tm.NewAuthCookie(user.ID)
 	if err != nil {

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -30,12 +30,11 @@ func TestAccessControl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewAccessControlInterceptor(tm),
 	))
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	courseAdmin := qtest.CreateAdminUser(t, db, "fake")
 	groupStudent := qtest.CreateNamedUser(t, db, 2, "group student")

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -23,12 +23,11 @@ func TestRefreshTokens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewTokenInterceptor(tm),
 	))
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	f := func(t *testing.T, id uint64) string {
 		cookie, err := tm.NewAuthCookie(id)

--- a/web/interceptor/user_auth_test.go
+++ b/web/interceptor/user_auth_test.go
@@ -23,11 +23,10 @@ func TestUserVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown, client := web.MockQuickFeedClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 	))
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	adminUser := qtest.CreateFakeUser(t, db, 1)
 	student := qtest.CreateFakeUser(t, db, 56)

--- a/web/quickfeed_helper_web.go
+++ b/web/quickfeed_helper_web.go
@@ -1,11 +1,9 @@
 package web
 
 import (
-	"context"
-	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/quickfeed/quickfeed/ci"
@@ -13,9 +11,6 @@ import (
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf/qfconnect"
 	"github.com/quickfeed/quickfeed/scm"
-	"go.uber.org/zap"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 // testQuickFeedService is a clone of the same function in quickfeed_helper_test.go.
@@ -28,48 +23,22 @@ func testQuickFeedService(t *testing.T) (database.Database, func(), scm.SCM, *Qu
 	return db, cleanup, sc, NewQuickFeedService(logger, db, mgr, BaseHookOptions{}, &ci.Local{})
 }
 
-// MockQuickFeedClient returns a QuickFeed client for invoking RPCs.
-func MockQuickFeedClient(t *testing.T, db database.Database, opts connect.Option) (func(context.Context), qfconnect.QuickFeedServiceClient) {
+// MockClient returns a QuickFeed client for invoking RPCs.
+func MockClient(t *testing.T, db database.Database, opts connect.Option) qfconnect.QuickFeedServiceClient {
 	t.Helper()
+	_, mgr := scm.MockSCMManager(t)
 	logger := qtest.Logger(t)
+	qfService := NewQuickFeedService(logger.Desugar(), db, mgr, BaseHookOptions{}, &ci.Local{})
 
 	if opts == nil {
 		opts = connect.WithInterceptors()
 	}
-	shutdown := MockQuickFeedServer(t, logger, db, opts)
-
-	const serverURL = "http://127.0.0.1:8081"
-	return func(ctx context.Context) {
-		shutdown(ctx)
-	}, qfconnect.NewQuickFeedServiceClient(http.DefaultClient, serverURL)
-}
-
-// MockQuickFeedServer is a test helper that starts a QuickFeed server in a goroutine, with the given options, typically interceptors.
-// The returned function must be called to shut down the server and the end of a test.
-func MockQuickFeedServer(t *testing.T, logger *zap.SugaredLogger, db database.Database, opts connect.Option) func(context.Context) {
-	t.Helper()
-	_, mgr := scm.MockSCMManager(t)
-	qfService := NewQuickFeedService(logger.Desugar(), db, mgr, BaseHookOptions{}, &ci.Local{})
-
 	router := http.NewServeMux()
 	router.Handle(qfconnect.NewQuickFeedServiceHandler(qfService, opts))
-	muxServer := &http.Server{
-		Handler:           h2c.NewHandler(router, &http2.Server{}),
-		Addr:              "127.0.0.1:8081",
-		ReadHeaderTimeout: 3 * time.Second, // to prevent Slowloris (CWE-400)
-	}
+	server := httptest.NewUnstartedServer(router)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
 
-	go func() {
-		if err := muxServer.ListenAndServe(); err != nil {
-			if !errors.Is(err, http.ErrServerClosed) {
-				t.Errorf("Server exited with unexpected error: %v", err)
-			}
-			return
-		}
-	}()
-	return func(ctx context.Context) {
-		if err := muxServer.Shutdown(ctx); err != nil {
-			t.Fatal(err)
-		}
-	}
+	return qfconnect.NewQuickFeedServiceClient(server.Client(), server.URL)
 }

--- a/web/thirdparty_auth_test.go
+++ b/web/thirdparty_auth_test.go
@@ -37,7 +37,7 @@ func TestThirdPartyAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shutdown, client := MockQuickFeedClient(t, db, connect.WithInterceptors(
+	client := MockClient(t, db, connect.WithInterceptors(
 		interceptor.NewMetricsInterceptor(),
 		interceptor.NewValidationInterceptor(logger),
 		interceptor.NewUserInterceptor(logger, tm),
@@ -45,7 +45,6 @@ func TestThirdPartyAuth(t *testing.T) {
 		interceptor.NewTokenInterceptor(tm),
 	))
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	request := connect.NewRequest(&qf.CourseUserRequest{
 		CourseCode: "DAT320",

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -17,9 +17,8 @@ import (
 func TestGetUsers(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	shutdown, client := MockQuickFeedClient(t, db, nil)
+	client := MockClient(t, db, nil)
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	unexpectedUsers, err := client.GetUsers(ctx, &connect.Request[qf.Void]{Msg: &qf.Void{}})
 	if err == nil && unexpectedUsers != nil && len(unexpectedUsers.Msg.GetUsers()) > 0 {
@@ -62,9 +61,8 @@ var allUsers = []struct {
 func TestGetEnrollmentsByCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	shutdown, client := MockQuickFeedClient(t, db, nil)
+	client := MockClient(t, db, nil)
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	var users []*qf.User
 	for _, u := range allUsers {
@@ -144,9 +142,8 @@ func TestGetEnrollmentsByCourse(t *testing.T) {
 func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	shutdown, client := MockQuickFeedClient(t, db, nil)
+	client := MockClient(t, db, nil)
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	var users []*qf.User
 	for _, u := range allUsers {
@@ -236,12 +233,10 @@ func TestUpdateUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	shutdown, client := MockQuickFeedClient(t, db, connect.WithInterceptors(
+	client := MockClient(t, db, connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 	))
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	firstAdminUser := qtest.CreateFakeUser(t, db, 1)
 	nonAdminUser := qtest.CreateFakeUser(t, db, 11)
@@ -303,9 +298,8 @@ func TestUpdateUserFailures(t *testing.T) {
 	t.Skip("TODO: Needs to be rewritten as a client-server test to verify (with interceptors) that the server is actually enforcing the rules")
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	shutdown, client := MockQuickFeedClient(t, db, nil)
+	client := MockClient(t, db, nil)
 	ctx := context.Background()
-	defer shutdown(ctx)
 
 	wantAdminUser := qtest.CreateFakeUser(t, db, 1)
 	qtest.CreateFakeUser(t, db, 11)


### PR DESCRIPTION
This fixes the MockClient to set up a httptest.Server that the client uses directly, avoiding issues with ListenAndServer() and Shutdown().

Fixes #877

