### PR TITLE
Restructure DeleteGroup.

### DIFF
--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -308,7 +308,7 @@ func createTeam(client *scm.GithubSCM) cli.ActionFunc {
 		if len(users) < 1 {
 			return cli.NewExitError("team user names must be provided (comma separated)", 3)
 		}
-		opt := &scm.NewTeamOptions{
+		opt := &scm.TeamOptions{
 			Organization: c.String("namespace"),
 			TeamName:     c.String("team"),
 			Users:        users,

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -238,7 +238,7 @@ func deleteRepositories(client *scm.GithubSCM) cli.ActionFunc {
 
 			for _, repo := range repos {
 				var errs []error
-				if err := (*client).DeleteRepository(ctx, &scm.RepositoryOptions{ID: repo.ID}); err != nil {
+				if _, err := (*client).Client().Repositories.Delete(ctx, repo.Owner, repo.Path); err != nil {
 					errs = append(errs, err)
 				} else {
 					fmt.Println("Deleted repository", repo.HTMLURL)
@@ -249,8 +249,7 @@ func deleteRepositories(client *scm.GithubSCM) cli.ActionFunc {
 			}
 			return nil
 		}
-		err := (*client).DeleteRepository(ctx, &scm.RepositoryOptions{Path: c.String("name"), Owner: c.String("namespace")})
-		if err != nil {
+		if _, err := (*client).Client().Repositories.Delete(ctx, c.String("namespace"), c.String("name")); err != nil {
 			return err
 		}
 		fmt.Println("Deleted repository ", c.String("name"), " on organization ", c.String("namespace"))

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -342,7 +342,7 @@ func deleteTeams(client *scm.GithubSCM) cli.ActionFunc {
 
 			for _, team := range teams {
 				var errs []error
-				if err := (*client).DeleteTeam(ctx, &scm.TeamOptions{TeamName: *team.Name, Organization: c.String("namespace")}); err != nil {
+				if _, err := (*client).Client().Teams.DeleteTeamBySlug(ctx, c.String("namespace"), *team.Name); err != nil {
 					errs = append(errs, err)
 				} else {
 					fmt.Println("Deleted team", *team.Name)
@@ -360,7 +360,8 @@ func deleteTeams(client *scm.GithubSCM) cli.ActionFunc {
 			fmt.Println("Canceled")
 			return err
 		}
-		return (*client).DeleteTeam(ctx, &scm.TeamOptions{TeamName: teamName})
+		_, err := (*client).Client().Teams.DeleteTeamBySlug(ctx, c.String("namespace"), teamName)
+		return err
 	}
 }
 

--- a/scm/github.go
+++ b/scm/github.go
@@ -199,7 +199,7 @@ func (s *GithubSCM) RepositoryIsEmpty(ctx context.Context, opt *RepositoryOption
 }
 
 // CreateTeam implements the SCM interface.
-func (s *GithubSCM) CreateTeam(ctx context.Context, opt *NewTeamOptions) (*Team, error) {
+func (s *GithubSCM) CreateTeam(ctx context.Context, opt *TeamOptions) (*Team, error) {
 	if !opt.valid() || opt.TeamName == "" || opt.Organization == "" {
 		return nil, ErrMissingFields{
 			Method:  "CreateTeam",
@@ -497,7 +497,7 @@ func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Re
 	}
 
 	// Create teacher team with course creator
-	teamOpt := &NewTeamOptions{
+	teamOpt := &TeamOptions{
 		Organization: org.Name,
 		TeamName:     TeachersTeam,
 		Users:        []string{opt.CourseCreator},
@@ -507,7 +507,7 @@ func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Re
 	}
 
 	// Create student team without any members
-	studOpt := &NewTeamOptions{Organization: org.Name, TeamName: StudentsTeam}
+	studOpt := &TeamOptions{Organization: org.Name, TeamName: StudentsTeam}
 	if _, err = s.CreateTeam(ctx, studOpt); err != nil {
 		return nil, fmt.Errorf("failed to create students team: %w", err)
 	}
@@ -591,7 +591,7 @@ func (s *GithubSCM) DemoteTeacherToStudent(ctx context.Context, opt *UpdateEnrol
 }
 
 // CreateGroup creates team and repository for a new group.
-func (s *GithubSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Repository, *Team, error) {
+func (s *GithubSCM) CreateGroup(ctx context.Context, opt *TeamOptions) (*Repository, *Team, error) {
 	if !opt.valid() {
 		return nil, nil, ErrMissingFields{
 			Method:  "CreateGroup",

--- a/scm/github.go
+++ b/scm/github.go
@@ -684,6 +684,12 @@ func (s *GithubSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Repo
 
 // DeleteGroup deletes group's repository and team.
 func (s *GithubSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
+	if !opt.valid() {
+		return ErrMissingFields{
+			Method:  "DeleteGroup",
+			Message: fmt.Sprintf("%+v", opt),
+		}
+	}
 	if err := s.DeleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
 		return err
 	}

--- a/scm/github.go
+++ b/scm/github.go
@@ -682,6 +682,14 @@ func (s *GithubSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Repo
 	return repo, team, nil
 }
 
+// DeleteGroup deletes group's repository and team.
+func (s *GithubSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
+	if err := s.DeleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
+		return err
+	}
+	return s.DeleteTeam(ctx, &TeamOptions{TeamID: opt.TeamID, OrganizationID: opt.OrganizationID})
+}
+
 // createStudentRepo creates {username}-labs repository and provides pull/push access to it for the given student.
 func (s *GithubSCM) createStudentRepo(ctx context.Context, organization string, login string) (*Repository, error) {
 	// create repo, or return existing repo if it already exists

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -102,11 +102,6 @@ func (opt CreateRepositoryOptions) valid() bool {
 }
 
 func (opt TeamOptions) valid() bool {
-	return opt.TeamName != "" && opt.Organization != "" ||
-		opt.TeamID > 0 && opt.OrganizationID > 0
-}
-
-func (opt NewTeamOptions) valid() bool {
 	return opt.TeamName != "" && opt.Organization != ""
 }
 

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -487,6 +487,11 @@ func (s *MockSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Reposi
 	return repo, team, nil
 }
 
+// DeleteGroup deletes repository and team for a group.
+func (s *MockSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
+	return nil
+}
+
 // teamExists checks teams by ID, or by team and organization name.
 func (s *MockSCM) teamExists(id uint64, team, org string) bool {
 	if id > 0 {

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -141,15 +141,6 @@ func (s *MockSCM) CreateTeam(_ context.Context, opt *NewTeamOptions) (*Team, err
 	return newTeam, nil
 }
 
-// DeleteTeam implements the SCM interface.
-func (s *MockSCM) DeleteTeam(_ context.Context, opt *TeamOptions) error {
-	if !opt.valid() {
-		return fmt.Errorf("invalid argument: %+v", opt)
-	}
-	delete(s.Teams, opt.TeamID)
-	return nil
-}
-
 // UpdateTeamMembers implements the SCM interface.
 func (s *MockSCM) UpdateTeamMembers(_ context.Context, opt *UpdateTeamOptions) error {
 	if !opt.valid() {
@@ -485,11 +476,8 @@ func (s *MockSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
 		return errors.New("organization not found")
 	}
 	delete(s.Repositories, opt.RepositoryID)
-	teamOpt := &TeamOptions{
-		TeamID:         opt.TeamID,
-		OrganizationID: opt.OrganizationID,
-	}
-	return s.DeleteTeam(ctx, teamOpt)
+	delete(s.Teams, opt.TeamID)
+	return nil
 }
 
 // teamExists checks teams by ID, or by team and organization name.

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -122,18 +122,6 @@ func (s *MockSCM) GetRepositories(_ context.Context, org *qf.Organization) ([]*R
 	return repos, nil
 }
 
-// DeleteRepository implements the SCM interface.
-func (s *MockSCM) DeleteRepository(_ context.Context, opt *RepositoryOptions) error {
-	if !opt.valid() {
-		return fmt.Errorf("invalid argument: %+v", opt)
-	}
-	if _, ok := s.Repositories[opt.ID]; !ok {
-		return errors.New("repository not found")
-	}
-	delete(s.Repositories, opt.ID)
-	return nil
-}
-
 // RepositoryIsEmpty implements the SCM interface
 func (*MockSCM) RepositoryIsEmpty(_ context.Context, _ *RepositoryOptions) bool {
 	return false
@@ -452,9 +440,8 @@ func (s *MockSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentOpt
 	}); err != nil {
 		return errors.New("organization not found")
 	}
-	return s.DeleteRepository(ctx, &RepositoryOptions{
-		ID: opt.RepositoryID,
-	})
+	delete(s.Repositories, opt.RepositoryID)
+	return nil
 }
 
 // DemoteTeacherToStudent implements the SCM interface.
@@ -497,9 +484,7 @@ func (s *MockSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
 	}); err != nil {
 		return errors.New("organization not found")
 	}
-	if err := s.DeleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
-		return err
-	}
+	delete(s.Repositories, opt.RepositoryID)
 	teamOpt := &TeamOptions{
 		TeamID:         opt.TeamID,
 		OrganizationID: opt.OrganizationID,

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -489,7 +489,22 @@ func (s *MockSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Reposi
 
 // DeleteGroup deletes repository and team for a group.
 func (s *MockSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
-	return nil
+	if !opt.valid() {
+		return fmt.Errorf("invalid argument: %v", opt)
+	}
+	if _, err := s.GetOrganization(ctx, &GetOrgOptions{
+		ID: opt.OrganizationID,
+	}); err != nil {
+		return errors.New("organization not found")
+	}
+	if err := s.DeleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
+		return err
+	}
+	teamOpt := &TeamOptions{
+		TeamID:         opt.TeamID,
+		OrganizationID: opt.OrganizationID,
+	}
+	return s.DeleteTeam(ctx, teamOpt)
 }
 
 // teamExists checks teams by ID, or by team and organization name.

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -128,7 +128,7 @@ func (*MockSCM) RepositoryIsEmpty(_ context.Context, _ *RepositoryOptions) bool 
 }
 
 // CreateTeam implements the SCM interface.
-func (s *MockSCM) CreateTeam(_ context.Context, opt *NewTeamOptions) (*Team, error) {
+func (s *MockSCM) CreateTeam(_ context.Context, opt *TeamOptions) (*Team, error) {
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %+v", opt)
 	}
@@ -381,7 +381,7 @@ func (s *MockSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repo
 		return nil, err
 	}
 	repositories = append(repositories, labRepo)
-	teams := []*NewTeamOptions{
+	teams := []*TeamOptions{
 		{
 			Organization: org.Name,
 			TeamName:     TeachersTeam,
@@ -441,7 +441,7 @@ func (*MockSCM) DemoteTeacherToStudent(_ context.Context, _ *UpdateEnrollmentOpt
 }
 
 // CreateGroup creates team and repository for a new group.
-func (s *MockSCM) CreateGroup(ctx context.Context, opt *NewTeamOptions) (*Repository, *Team, error) {
+func (s *MockSCM) CreateGroup(ctx context.Context, opt *TeamOptions) (*Repository, *Team, error) {
 	if !opt.valid() {
 		return nil, nil, fmt.Errorf("invalid argument: %v", opt)
 	}

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -232,7 +232,7 @@ func TestMockCreateTeams(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()
 	for _, team := range mockTeams {
-		newTeam, err := s.CreateTeam(ctx, &scm.NewTeamOptions{
+		newTeam, err := s.CreateTeam(ctx, &scm.TeamOptions{
 			Organization: team.Organization,
 			TeamName:     team.Name,
 		})
@@ -252,7 +252,7 @@ func TestUpdateMockTeamMembers(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()
 	course := qtest.MockCourses[0]
-	team, err := s.CreateTeam(ctx, &scm.NewTeamOptions{
+	team, err := s.CreateTeam(ctx, &scm.TeamOptions{
 		Organization: course.OrganizationName,
 		TeamName:     "test_team",
 	})
@@ -1115,7 +1115,7 @@ func TestMockCreateGroup(t *testing.T) {
 	}
 	tests := []struct {
 		name      string
-		opt       *scm.NewTeamOptions
+		opt       *scm.TeamOptions
 		wantTeam  *scm.Team
 		wantRepo  *scm.Repository
 		wantTeams map[uint64]*scm.Team
@@ -1124,7 +1124,7 @@ func TestMockCreateGroup(t *testing.T) {
 	}{
 		{
 			"invalid opts, missing organization",
-			&scm.NewTeamOptions{
+			&scm.TeamOptions{
 				TeamName: "test-team",
 			},
 			nil,
@@ -1135,7 +1135,7 @@ func TestMockCreateGroup(t *testing.T) {
 		},
 		{
 			"invalid opts, missing team name",
-			&scm.NewTeamOptions{
+			&scm.TeamOptions{
 				Organization: qtest.MockOrg,
 			},
 			nil,
@@ -1146,7 +1146,7 @@ func TestMockCreateGroup(t *testing.T) {
 		},
 		{
 			"organization does not exist",
-			&scm.NewTeamOptions{
+			&scm.TeamOptions{
 				Organization: "some-org",
 				TeamName:     "team",
 			},
@@ -1158,7 +1158,7 @@ func TestMockCreateGroup(t *testing.T) {
 		},
 		{
 			"add a new group",
-			&scm.NewTeamOptions{
+			&scm.TeamOptions{
 				Organization: qtest.MockOrg,
 				TeamName:     mockTeams[0].Name,
 				Users:        []string{user},
@@ -1171,7 +1171,7 @@ func TestMockCreateGroup(t *testing.T) {
 		},
 		{
 			"add another group",
-			&scm.NewTeamOptions{
+			&scm.TeamOptions{
 				Organization: qtest.MockOrg,
 				TeamName:     mockTeams[1].Name,
 				Users:        []string{user},

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -208,20 +208,6 @@ func TestMockRepositories(t *testing.T) {
 	if diff := cmp.Diff(wantRepos, courseRepos, cmpopts.IgnoreFields(scm.Repository{}, "HTMLURL")); diff != "" {
 		t.Errorf("mismatch repositories (-want +got):\n%s", diff)
 	}
-
-	if err := s.DeleteRepository(ctx, &scm.RepositoryOptions{ID: 3}); err != nil {
-		t.Error(err)
-	}
-	courseRepos, err = s.GetRepositories(ctx, &qf.Organization{ID: course2.OrganizationID})
-	if err != nil {
-		t.Error(err)
-	}
-	if len(courseRepos) > 1 {
-		t.Errorf("expected 1 repository, got %d", len(courseRepos))
-	}
-	if diff := cmp.Diff(repos[3], courseRepos[0], cmpopts.IgnoreFields(scm.Repository{}, "HTMLURL")); diff != "" {
-		t.Errorf("mismatch repositories (-want +got):\n%s", diff)
-	}
 }
 
 var mockTeams = []*scm.Team{

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -248,67 +248,6 @@ func TestMockCreateTeams(t *testing.T) {
 	}
 }
 
-func TestMockDeleteTeams(t *testing.T) {
-	s := scm.NewMockSCMClient()
-	ctx := context.Background()
-	for _, team := range mockTeams {
-		s.Teams[team.ID] = team
-	}
-	tests := []struct {
-		name      string
-		opt       *scm.TeamOptions
-		wantTeams []uint64
-		wantErr   bool
-	}{
-		{
-			"delete team 2",
-			&scm.TeamOptions{
-				TeamID:         2,
-				OrganizationID: 1,
-			},
-			[]uint64{1, 3},
-			false,
-		},
-		{
-			"delete team 1",
-			&scm.TeamOptions{
-				TeamID:         1,
-				OrganizationID: 1,
-			},
-			[]uint64{3},
-			false,
-		},
-		{
-			"invalid opt, missing organization info",
-			&scm.TeamOptions{
-				TeamID:   3,
-				TeamName: mockTeams[2].Name,
-			},
-			[]uint64{3},
-			true,
-		},
-		{
-			"invalid opt, missing team info",
-			&scm.TeamOptions{
-				Organization:   qtest.MockOrg,
-				OrganizationID: 1,
-			},
-			[]uint64{3},
-			true,
-		},
-	}
-	for _, tt := range tests {
-		if err := s.DeleteTeam(ctx, tt.opt); (err != nil) != tt.wantErr {
-			t.Errorf("%s: expected error %v, got = %v, ", tt.name, tt.wantErr, err)
-		}
-		for _, teamID := range tt.wantTeams {
-			if _, ok := s.Teams[teamID]; !ok {
-				t.Errorf("%s: expected team %d in remaining teams", tt.name, teamID)
-			}
-		}
-	}
-}
-
 func TestUpdateMockTeamMembers(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -66,8 +66,10 @@ type SCM interface {
 	RejectEnrollment(context.Context, *RejectEnrollmentOptions) error
 	// DemoteTeacherToStudent removes user from teachers team, revokes owner status in the organization.
 	DemoteTeacherToStudent(context.Context, *UpdateEnrollmentOptions) error
-	// CreateGroup creates group repository and team.
+	// CreateGroup creates repository and team for a new group.
 	CreateGroup(context.Context, *NewTeamOptions) (*Repository, *Team, error)
+	// DeleteGroup deletes group's repository and team.
+	DeleteGroup(context.Context, *GroupOptions) error
 }
 
 // NewSCMClient returns a new provider client implementing the SCM interface.
@@ -106,13 +108,21 @@ type UpdateEnrollmentOptions struct {
 	Status       qf.Enrollment_UserStatus
 }
 
+// RejectEnrollmentOptions contain information about enrollment.
 type RejectEnrollmentOptions struct {
 	OrganizationID uint64
 	RepositoryID   uint64
 	User           string
 }
 
-// GetOrgOptions contains information on the organization to fetch
+// GroupOptions contain information about group.
+type GroupOptions struct {
+	OrganizationID uint64
+	RepositoryID   uint64
+	TeamID         uint64
+}
+
+// GetOrgOptions contain information about organization.
 type GetOrgOptions struct {
 	ID   uint64
 	Name string

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -22,8 +22,6 @@ type SCM interface {
 	RepositoryIsEmpty(context.Context, *RepositoryOptions) bool
 	// Create team.
 	CreateTeam(context.Context, *NewTeamOptions) (*Team, error)
-	// Delete team.
-	DeleteTeam(context.Context, *TeamOptions) error
 	// UpdateTeamMembers adds or removes members of an existing team based on list of users in TeamOptions.
 	UpdateTeamMembers(context.Context, *UpdateTeamOptions) error
 

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -21,7 +21,7 @@ type SCM interface {
 	// Returns true if there are no commits in the given repository
 	RepositoryIsEmpty(context.Context, *RepositoryOptions) bool
 	// Create team.
-	CreateTeam(context.Context, *NewTeamOptions) (*Team, error)
+	CreateTeam(context.Context, *TeamOptions) (*Team, error)
 	// UpdateTeamMembers adds or removes members of an existing team based on list of users in TeamOptions.
 	UpdateTeamMembers(context.Context, *UpdateTeamOptions) error
 
@@ -63,7 +63,7 @@ type SCM interface {
 	// DemoteTeacherToStudent removes user from teachers team, revokes owner status in the organization.
 	DemoteTeacherToStudent(context.Context, *UpdateEnrollmentOptions) error
 	// CreateGroup creates repository and team for a new group.
-	CreateGroup(context.Context, *NewTeamOptions) (*Repository, *Team, error)
+	CreateGroup(context.Context, *TeamOptions) (*Repository, *Team, error)
 	// DeleteGroup deletes group's repository and team.
 	DeleteGroup(context.Context, *GroupOptions) error
 }
@@ -160,17 +160,8 @@ type CreateRepositoryOptions struct {
 	Permission   string // Default permission level for the given repo. Can be "read", "write", "admin", "none".
 }
 
-// TeamOptions contains information about the team and the organization it belongs to.
-// It must include either both IDs or both names for the team and organization/
+// TeamOptions used when creating a new team
 type TeamOptions struct {
-	Organization   string
-	OrganizationID uint64
-	TeamName       string
-	TeamID         uint64
-}
-
-// NewTeamOptions used when creating a new team
-type NewTeamOptions struct {
 	Organization string
 	TeamName     string
 	Users        []string

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -18,8 +18,6 @@ type SCM interface {
 	CreateRepository(context.Context, *CreateRepositoryOptions) (*Repository, error)
 	// Get repositories within organization.
 	GetRepositories(context.Context, *qf.Organization) ([]*Repository, error)
-	// Delete repository.
-	DeleteRepository(context.Context, *RepositoryOptions) error
 	// Returns true if there are no commits in the given repository
 	RepositoryIsEmpty(context.Context, *RepositoryOptions) bool
 	// Create team.

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -122,6 +122,11 @@ type GroupOptions struct {
 	TeamID         uint64
 }
 
+func (opt *GroupOptions) valid() bool {
+	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
+		opt.TeamID > 0
+}
+
 // GetOrgOptions contain information about organization.
 type GetOrgOptions struct {
 	ID   uint64

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -447,13 +447,13 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	// teacher promotes students to teachers, must succeed
 	ctx := auth.WithUserContext(context.Background(), teacher)
 	// Need course teams to update enrollments.
-	if _, err := mockSCM.CreateTeam(ctx, &scm.NewTeamOptions{
+	if _, err := mockSCM.CreateTeam(ctx, &scm.TeamOptions{
 		Organization: qtest.MockOrg,
 		TeamName:     "allstudents",
 	}); err != nil {
 		t.Error(err)
 	}
-	if _, err := mockSCM.CreateTeam(ctx, &scm.NewTeamOptions{
+	if _, err := mockSCM.CreateTeam(ctx, &scm.TeamOptions{
 		Organization: qtest.MockOrg,
 		TeamName:     "allteachers",
 	}); err != nil {

--- a/web/groups.go
+++ b/web/groups.go
@@ -59,7 +59,12 @@ func (s *QuickFeedService) deleteGroup(ctx context.Context, sc scm.SCM, request 
 		s.logger.Debugf("Failed to delete %s repository for %q from database: %v", course.Code, group.Name, err)
 		// continue with other delete operations
 	}
-	return deleteGroupRepoAndTeam(ctx, sc, repo.GetRepositoryID(), group.GetTeamID(), repo.GetOrganizationID())
+	opt := &scm.GroupOptions{
+		OrganizationID: repo.GetOrganizationID(),
+		RepositoryID:   repo.GetRepositoryID(),
+		TeamID:         group.GetTeamID(),
+	}
+	return sc.DeleteGroup(ctx, opt)
 }
 
 // createGroup creates a new group for the given course and users.

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -75,7 +75,7 @@ func (q *QuickFeedService) getCredsForUserSCM(user *qf.User) (string, error) {
 // This function performs several sequential queries and updates on the SCM.
 // Ideally, we should provide corresponding rollbacks, but that is not supported yet.
 func createRepoAndTeam(ctx context.Context, sc scm.SCM, course *qf.Course, group *qf.Group) (*qf.Repository, *scm.Team, error) {
-	opt := &scm.NewTeamOptions{
+	opt := &scm.TeamOptions{
 		Organization: course.OrganizationName,
 		TeamName:     group.GetName(),
 		Users:        group.UserNames(),

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -94,17 +94,6 @@ func createRepoAndTeam(ctx context.Context, sc scm.SCM, course *qf.Course, group
 	return groupRepo, team, nil
 }
 
-// deletes group repository and team
-func deleteGroupRepoAndTeam(ctx context.Context, sc scm.SCM, repositoryID, teamID, orgID uint64) error {
-	if err := sc.DeleteRepository(ctx, &scm.RepositoryOptions{ID: repositoryID}); err != nil {
-		return fmt.Errorf("deleteGroupRepoAndTeam: failed to delete repository: %w", err)
-	}
-	if err := sc.DeleteTeam(ctx, &scm.TeamOptions{TeamID: teamID, OrganizationID: orgID}); err != nil {
-		return fmt.Errorf("deleteGroupRepoAndTeam: failed to delete team: %w", err)
-	}
-	return nil
-}
-
 func updateGroupTeam(ctx context.Context, sc scm.SCM, group *qf.Group, orgID uint64) error {
 	opt := &scm.UpdateTeamOptions{
 		TeamID:         group.TeamID,


### PR DESCRIPTION
- Add a new scm method `DeleteGroup` that deletes the repository and team for a group to replace a helper method in the `web` package
- Remove scm methods `DeleteRepository` and `DeleteTeam` as they are no longer used outside of the scm package
- Update scm tool

TODO: final testing.

Resolves #984.