### PR TITLE
Reorganize SCM validators

### DIFF
--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -127,7 +127,7 @@ func PopulateDatabaseWithInitialData(t *testing.T, db database.Database, sc scm.
 	t.Helper()
 
 	ctx := context.Background()
-	org, err := sc.GetOrganization(ctx, &scm.GetOrgOptions{Name: course.OrganizationName})
+	org, err := sc.GetOrganization(ctx, &scm.OrganizationOptions{Name: course.OrganizationName})
 	if err != nil {
 		return err
 	}

--- a/scm/github.go
+++ b/scm/github.go
@@ -461,6 +461,12 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 
 // CreateCourse creates repositories and teams for a new course.
 func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repository, error) {
+	if !opt.valid() {
+		return nil, ErrMissingFields{
+			Method:  "CreateCourse",
+			Message: fmt.Sprintf("%+v", opt),
+		}
+	}
 	// Get and check the organization's suitability for the course
 	org, err := s.GetOrganization(ctx, &GetOrgOptions{ID: opt.OrganizationID, NewCourse: true})
 	if err != nil {

--- a/scm/github.go
+++ b/scm/github.go
@@ -495,7 +495,7 @@ func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentO
 func (s *GithubSCM) DemoteTeacherToStudent(ctx context.Context, opt *UpdateEnrollmentOptions) error {
 	if !opt.valid() {
 		return ErrMissingFields{
-			Method:  "UpdateEnrollment",
+			Method:  "DemoteTeacherToStudent",
 			Message: fmt.Sprintf("%+v", opt),
 		}
 	}

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -30,7 +30,7 @@ const (
 func TestGetOrganization(t *testing.T) {
 	qfTestOrg := scm.GetTestOrganization(t)
 	s, qfTestUser := scm.GetTestSCM(t)
-	org, err := s.GetOrganization(context.Background(), &scm.GetOrgOptions{
+	org, err := s.GetOrganization(context.Background(), &scm.OrganizationOptions{
 		Name:     qfTestOrg,
 		Username: qfTestUser,
 	})

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -78,54 +78,6 @@ var (
 	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
 )
 
-// Validators //
-
-func (opt GetOrgOptions) valid() bool {
-	return opt.ID != 0 || opt.Name != ""
-}
-
-func (opt UpdateEnrollmentOptions) valid() bool {
-	return opt.Organization != "" && opt.User != ""
-}
-
-func (opt *RejectEnrollmentOptions) valid() bool {
-	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
-		opt.User != ""
-}
-
-func (opt UpdateTeamOptions) valid() bool {
-	return opt.TeamID > 0 && opt.OrganizationID > 0
-}
-
-func (opt CreateRepositoryOptions) valid() bool {
-	return opt.Organization != "" && opt.Path != ""
-}
-
-func (opt TeamOptions) valid() bool {
-	return opt.TeamName != "" && opt.Organization != ""
-}
-
-func (opt RepositoryOptions) valid() bool {
-	return opt.ID > 0 || (opt.Path != "" && opt.Owner != "")
-}
-
-func (opt *IssueOptions) valid() bool {
-	return opt.Organization != "" && opt.Repository != "" && opt.Title != "" && opt.Body != ""
-}
-
-func (opt RequestReviewersOptions) valid() bool {
-	return opt.Organization != "" && opt.Repository != "" &&
-		opt.Number > 0 && len(opt.Reviewers) != 0
-}
-
-func (opt IssueCommentOptions) valid() bool {
-	return opt.Organization != "" && opt.Repository != "" && opt.Body != ""
-}
-
-func (opt InvitationOptions) valid() bool {
-	return opt.Login != "" && opt.Owner != "" && opt.Token != ""
-}
-
 // Errors //
 
 // ErrNotSupported is returned when the source code management solution used

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -355,6 +355,9 @@ func (*MockSCM) AcceptInvitations(_ context.Context, _ *InvitationOptions) error
 
 // CreateCourse creates repositories and teams for a new course.
 func (s *MockSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repository, error) {
+	if !opt.valid() {
+		return nil, fmt.Errorf("invalid argument: %v", opt)
+	}
 	org, err := s.GetOrganization(ctx, &GetOrgOptions{ID: opt.OrganizationID, NewCourse: true})
 	if err != nil {
 		return nil, err

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -43,7 +43,7 @@ func NewMockSCMClient() *MockSCM {
 
 // Clone copies the repository in testdata to the given destination path.
 func (s MockSCM) Clone(ctx context.Context, opt *CloneOptions) (string, error) {
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{
 		Name: opt.Organization,
 	}); err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func (s MockSCM) Clone(ctx context.Context, opt *CloneOptions) (string, error) {
 }
 
 // GetOrganization implements the SCM interface.
-func (s *MockSCM) GetOrganization(ctx context.Context, opt *GetOrgOptions) (*qf.Organization, error) {
+func (s *MockSCM) GetOrganization(ctx context.Context, opt *OrganizationOptions) (*qf.Organization, error) {
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %+v", opt)
 	}
@@ -90,7 +90,7 @@ func (s *MockSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryOpt
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %+v", opt)
 	}
-	org, err := s.GetOrganization(ctx, &GetOrgOptions{
+	org, err := s.GetOrganization(ctx, &OrganizationOptions{
 		Name: opt.Organization,
 	})
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *MockSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue, e
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Organization}); err != nil {
 		return nil, errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -186,7 +186,7 @@ func (s *MockSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue, e
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Organization}); err != nil {
 		return nil, errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -213,7 +213,7 @@ func (s *MockSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, issueNum
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Owner}); err != nil {
 		return nil, errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -234,7 +234,7 @@ func (s *MockSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Iss
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Owner}); err != nil {
 		return nil, errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -257,7 +257,7 @@ func (s *MockSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, issue
 	if !opt.valid() {
 		return fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Owner}); err != nil {
 		return errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -274,7 +274,7 @@ func (s *MockSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) erro
 	if !opt.valid() {
 		return fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Owner}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Owner}); err != nil {
 		return errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -296,7 +296,7 @@ func (s *MockSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptio
 	if !opt.valid() {
 		return 0, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Organization}); err != nil {
 		return 0, errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -318,7 +318,7 @@ func (s *MockSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOptio
 	if !opt.valid() {
 		return fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{Name: opt.Organization}); err != nil {
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{Name: opt.Organization}); err != nil {
 		return errors.New("organization not found")
 	}
 	if _, err := s.getRepository(&RepositoryOptions{
@@ -358,7 +358,7 @@ func (s *MockSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repo
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	org, err := s.GetOrganization(ctx, &GetOrgOptions{ID: opt.OrganizationID, NewCourse: true})
+	org, err := s.GetOrganization(ctx, &OrganizationOptions{ID: opt.OrganizationID, NewCourse: true})
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (s *MockSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentOpt
 	if !opt.valid() {
 		return nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	org, err := s.GetOrganization(ctx, &GetOrgOptions{
+	org, err := s.GetOrganization(ctx, &OrganizationOptions{
 		Name: opt.Organization,
 	})
 	if err != nil {
@@ -418,7 +418,6 @@ func (s *MockSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentOpt
 			Organization: org.Name,
 			Path:         qf.StudentRepoName(opt.User),
 			Private:      true,
-			Owner:        org.Name,
 		})
 	}
 	return nil, nil
@@ -429,7 +428,7 @@ func (s *MockSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentOpt
 	if !opt.valid() {
 		return fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{
 		ID: opt.OrganizationID,
 	}); err != nil {
 		return errors.New("organization not found")
@@ -448,7 +447,7 @@ func (s *MockSCM) CreateGroup(ctx context.Context, opt *TeamOptions) (*Repositor
 	if !opt.valid() {
 		return nil, nil, fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{
 		Name: opt.Organization,
 	}); err != nil {
 		return nil, nil, errors.New("organization not found")
@@ -473,7 +472,7 @@ func (s *MockSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
 	if !opt.valid() {
 		return fmt.Errorf("invalid argument: %v", opt)
 	}
-	if _, err := s.GetOrganization(ctx, &GetOrgOptions{
+	if _, err := s.GetOrganization(ctx, &OrganizationOptions{
 		ID: opt.OrganizationID,
 	}); err != nil {
 		return errors.New("organization not found")

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -124,10 +124,10 @@ func TestMockOrganizations(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()
 	for _, course := range qtest.MockCourses {
-		if _, err := s.GetOrganization(ctx, &scm.GetOrgOptions{ID: course.OrganizationID}); err != nil {
+		if _, err := s.GetOrganization(ctx, &scm.OrganizationOptions{ID: course.OrganizationID}); err != nil {
 			t.Error(err)
 		}
-		if _, err := s.GetOrganization(ctx, &scm.GetOrgOptions{Name: course.OrganizationName}); err != nil {
+		if _, err := s.GetOrganization(ctx, &scm.OrganizationOptions{Name: course.OrganizationName}); err != nil {
 			t.Error(err)
 		}
 	}
@@ -144,7 +144,7 @@ func TestMockOrganizations(t *testing.T) {
 	}
 
 	for _, org := range invalidOrgs {
-		if _, err := s.GetOrganization(ctx, &scm.GetOrgOptions{ID: org.id, Name: org.name}); err == nil {
+		if _, err := s.GetOrganization(ctx, &scm.OrganizationOptions{ID: org.id, Name: org.name}); err == nil {
 			t.Errorf("expected error: %s", org.err)
 		}
 	}
@@ -181,7 +181,6 @@ func TestMockRepositories(t *testing.T) {
 		r, err := s.CreateRepository(ctx, &scm.CreateRepositoryOptions{
 			Organization: repo.Owner,
 			Path:         repo.Path,
-			Owner:        repo.Owner,
 			Permission:   "read",
 		})
 		if err != nil {

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -107,7 +107,7 @@ func TestMockClone(t *testing.T) {
 	dstDir := t.TempDir()
 	s := scm.NewMockSCMClient()
 	ctx := context.Background()
-	cloneTests := []struct {
+	tests := []struct {
 		name     string
 		opt      *scm.CloneOptions
 		wantPath string
@@ -153,7 +153,7 @@ func TestMockClone(t *testing.T) {
 			wantErr:  true,
 		},
 	}
-	for _, tt := range cloneTests {
+	for _, tt := range tests {
 		path, err := s.Clone(ctx, tt.opt)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%s: expected error %v, got = %v, ", tt.name, tt.wantErr, err)
@@ -282,61 +282,61 @@ func TestMockCreateIssue(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"correct options",
-			&scm.IssueOptions{
+			name: "correct options",
+			opt: &scm.IssueOptions{
 				Organization: qtest.MockOrg,
 				Repository:   issue.Repository,
 				Title:        issue.Title,
 				Body:         issue.Body,
 				Assignee:     &issue.Assignee,
 			},
-			issue,
-			false,
+			wantIssue: issue,
+			wantErr:   false,
 		},
 		{
-			"incorrect organization",
-			&scm.IssueOptions{
+			name: "incorrect organization",
+			opt: &scm.IssueOptions{
 				Organization: "another-organization",
 				Repository:   issue.Repository,
 				Title:        issue.Title,
 				Body:         issue.Body,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 		{
-			"missing repository",
-			&scm.IssueOptions{
+			name: "missing repository",
+			opt: &scm.IssueOptions{
 				Organization: qtest.MockOrg,
 				Title:        issue.Title,
 				Body:         issue.Body,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 		{
-			"missing title",
-			&scm.IssueOptions{
+			name: "missing title",
+			opt: &scm.IssueOptions{
 				Organization: qtest.MockOrg,
 				Repository:   issue.Repository,
 				Body:         issue.Body,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 		{
-			"missing body",
-			&scm.IssueOptions{
+			name: "missing body",
+			opt: &scm.IssueOptions{
 				Organization: qtest.MockOrg,
 				Repository:   issue.Repository,
 				Title:        issue.Title,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -370,8 +370,8 @@ func TestMockUpdateIssue(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"correct issue, no updates",
-			&scm.IssueOptions{
+			name: "correct issue, no updates",
+			opt: &scm.IssueOptions{
 				Number:       issue.Number,
 				Organization: qtest.MockOrg,
 				Repository:   issue.Repository,
@@ -380,12 +380,12 @@ func TestMockUpdateIssue(t *testing.T) {
 				State:        issue.Status,
 				Assignee:     &issue.Assignee,
 			},
-			issue,
-			false,
+			wantIssue: issue,
+			wantErr:   false,
 		},
 		{
-			"correct issue, update title and body",
-			&scm.IssueOptions{
+			name: "correct issue, update title and body",
+			opt: &scm.IssueOptions{
 				Number:       issue.Number,
 				Organization: qtest.MockOrg,
 				Repository:   issue.Repository,
@@ -394,7 +394,7 @@ func TestMockUpdateIssue(t *testing.T) {
 				State:        issue.Status,
 				Assignee:     &issue.Assignee,
 			},
-			&scm.Issue{
+			wantIssue: &scm.Issue{
 				ID:         issue.ID,
 				Number:     issue.Number,
 				Title:      "New Title",
@@ -403,11 +403,11 @@ func TestMockUpdateIssue(t *testing.T) {
 				Status:     issue.Status,
 				Assignee:   issue.Assignee,
 			},
-			false,
+			wantErr: false,
 		},
 		{
-			"incorrect organization",
-			&scm.IssueOptions{
+			name: "incorrect organization",
+			opt: &scm.IssueOptions{
 				Number:       issue.Number,
 				Organization: "some-org",
 				Repository:   issue.Repository,
@@ -416,12 +416,12 @@ func TestMockUpdateIssue(t *testing.T) {
 				State:        issue.Status,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 		{
-			"invalid opts",
-			&scm.IssueOptions{
+			name: "invalid opts",
+			opt: &scm.IssueOptions{
 				Number:       issue.Number,
 				Organization: qtest.MockOrg,
 				Title:        issue.Title,
@@ -429,8 +429,8 @@ func TestMockUpdateIssue(t *testing.T) {
 				State:        issue.Status,
 				Assignee:     &issue.Assignee,
 			},
-			nil,
-			true,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 	}
 
@@ -464,34 +464,34 @@ func TestMockGetIssue(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"correct issue",
-			&scm.RepositoryOptions{
+			name: "correct issue",
+			opt: &scm.RepositoryOptions{
 				Path:  issue.Repository,
 				Owner: qtest.MockOrg,
 			},
-			issue.Number,
-			issue,
-			false,
+			number:    issue.Number,
+			wantIssue: issue,
+			wantErr:   false,
 		},
 		{
-			"incorrect issue number",
-			&scm.RepositoryOptions{
+			name: "incorrect issue number",
+			opt: &scm.RepositoryOptions{
 				Path:  issue.Repository,
 				Owner: qtest.MockOrg,
 			},
-			13,
-			nil,
-			true,
+			number:    13,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 		{
-			"incorrect organization name",
-			&scm.RepositoryOptions{
+			name: "incorrect organization name",
+			opt: &scm.RepositoryOptions{
 				Path:  issue.Repository,
 				Owner: "some-org",
 			},
-			issue.Number,
-			nil,
-			true,
+			number:    issue.Number,
+			wantIssue: nil,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -533,40 +533,40 @@ func TestMockGetIssues(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			"issues for 'test-labs' repo",
-			&scm.RepositoryOptions{
+			name: "issues for 'test-labs' repo",
+			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
 				Path:  mockIssues[0].Repository,
 			},
-			[]*scm.Issue{mockIssues[0], mockIssues[1]},
-			false,
+			wantIssues: []*scm.Issue{mockIssues[0], mockIssues[1]},
+			wantErr:    false,
 		},
 		{
-			"issues for 'user-labs' repo",
-			&scm.RepositoryOptions{
+			name: "issues for 'user-labs' repo",
+			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
 				Path:  mockIssues[2].Repository,
 			},
-			[]*scm.Issue{mockIssues[2]},
-			false,
+			wantIssues: []*scm.Issue{mockIssues[2]},
+			wantErr:    false,
 		},
 		{
-			"incorrect repository",
-			&scm.RepositoryOptions{
+			name: "incorrect repository",
+			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
 				Path:  "unknown-labs",
 			},
-			nil,
-			true,
+			wantIssues: nil,
+			wantErr:    true,
 		},
 		{
-			"incorrect organization",
-			&scm.RepositoryOptions{
+			name: "incorrect organization",
+			opt: &scm.RepositoryOptions{
 				Owner: "some-org",
 				Path:  mockIssues[0].Repository,
 			},
-			nil,
-			true,
+			wantIssues: nil,
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -631,46 +631,46 @@ func TestMockDeleteIssues(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			"delete all issues for 'user-labs' repo (issue 3)",
-			&scm.RepositoryOptions{
+			name: "delete all issues for 'user-labs' repo (issue 3)",
+			opt: &scm.RepositoryOptions{
 				Path:  qf.StudentRepoName(user),
 				Owner: course.OrganizationName,
 			},
-			map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1]},
-			false,
+			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1]},
+			wantErr:    false,
 		},
 		{
-			"delete all issues for 'test-labs' repo (issues 1 and 2)",
-			&scm.RepositoryOptions{
+			name: "delete all issues for 'test-labs' repo (issues 1 and 2)",
+			opt: &scm.RepositoryOptions{
 				Path:  "test-labs",
 				Owner: course.OrganizationName,
 			},
-			map[uint64]*scm.Issue{3: mockIssues[2]},
-			false,
+			wantIssues: map[uint64]*scm.Issue{3: mockIssues[2]},
+			wantErr:    false,
 		},
 		{
-			"missing repository, nothing deleted",
-			&scm.RepositoryOptions{
+			name: "missing repository, nothing deleted",
+			opt: &scm.RepositoryOptions{
 				Owner: course.OrganizationName,
 				Path:  "some-labs",
 			},
-			map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
-			true,
+			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
+			wantErr:    true,
 		},
 		{
-			"incorrect organization name",
-			&scm.RepositoryOptions{
+			name: "incorrect organization name",
+			opt: &scm.RepositoryOptions{
 				Owner: "organization",
 				Path:  "test-labs",
 			},
-			map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
-			true,
+			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
+			wantErr:    true,
 		},
 		{
-			"invalid opt",
-			&scm.RepositoryOptions{},
-			map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
-			true,
+			name:       "invalid opt",
+			opt:        &scm.RepositoryOptions{},
+			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -706,100 +706,100 @@ func TestMockCreateIssueComment(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			"comment 1 for issue 1",
-			&scm.IssueCommentOptions{
+			name: "comment 1 for issue 1",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName("test"),
 				Body:         "Comment",
 				Number:       1,
 			},
-			1,
-			false,
+			wantNumber: 1,
+			wantErr:    false,
 		},
 		{
-			"comment 2 for issue 1",
-			&scm.IssueCommentOptions{
+			name: "comment 2 for issue 1",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName("test"),
 				Body:         "Comment",
 				Number:       1,
 			},
-			2,
-			false,
+			wantNumber: 2,
+			wantErr:    false,
 		},
 		{
-			"comment 1 for issue 2",
-			&scm.IssueCommentOptions{
+			name: "comment 1 for issue 2",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName("test"),
 				Body:         "Comment",
 				Number:       2,
 			},
-			3,
-			false,
+			wantNumber: 3,
+			wantErr:    false,
 		},
 		{
-			"comment 2 for issue 2",
-			&scm.IssueCommentOptions{
+			name: "comment 2 for issue 2",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName("test"),
 				Body:         "Comment",
 				Number:       2,
 			},
-			4,
-			false,
+			wantNumber: 4,
+			wantErr:    false,
 		},
 		{
-			"invalid opts, missing organization",
-			&scm.IssueCommentOptions{
+			name: "invalid opts, missing organization",
+			opt: &scm.IssueCommentOptions{
 				Repository: qf.StudentRepoName("test"),
 				Body:       "Comment",
 				Number:     1,
 			},
-			0,
-			true,
+			wantNumber: 0,
+			wantErr:    true,
 		},
 		{
-			"invalid opts, missing repository",
-			&scm.IssueCommentOptions{
+			name: "invalid opts, missing repository",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Body:         "Comment",
 				Number:       1,
 			},
-			0,
-			true,
+			wantNumber: 0,
+			wantErr:    true,
 		},
 		{
-			"invalid opts, missing comment body",
-			&scm.IssueCommentOptions{
+			name: "invalid opts, missing comment body",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName(user),
 				Number:       1,
 			},
-			0,
-			true,
+			wantNumber: 0,
+			wantErr:    true,
 		},
 		{
-			"incorrect organization name",
-			&scm.IssueCommentOptions{
+			name: "incorrect organization name",
+			opt: &scm.IssueCommentOptions{
 				Organization: "organization",
 				Repository:   qf.StudentRepoName(user),
 				Body:         "Comment",
 				Number:       1,
 			},
-			0,
-			true,
+			wantNumber: 0,
+			wantErr:    true,
 		},
 		{
-			"incorrect issue number",
-			&scm.IssueCommentOptions{
+			name: "incorrect issue number",
+			opt: &scm.IssueCommentOptions{
 				Organization: qtest.MockOrg,
 				Repository:   qf.StudentRepoName(user),
 				Body:         "Comment",
 				Number:       5,
 			},
-			0,
-			true,
+			wantNumber: 0,
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -828,40 +828,40 @@ func TestMockUpdateIssueComment(t *testing.T) {
 	}
 	tests := []struct {
 		name        string
-		issueNimber int
+		issueNumber int
 		commentID   int64
 		wantErr     bool
 	}{
 		{
-			"update issue 1",
-			1,
-			1,
-			false,
+			name:        "update issue 1",
+			issueNumber: 1,
+			commentID:   1,
+			wantErr:     false,
 		},
 		{
-			"update issue 2",
-			1,
-			2,
-			false,
+			name:        "update issue 2",
+			issueNumber: 1,
+			commentID:   2,
+			wantErr:     false,
 		},
 		{
-			"incorrect issue number",
-			5,
-			1,
-			true,
+			name:        "incorrect issue number",
+			issueNumber: 5,
+			commentID:   1,
+			wantErr:     true,
 		},
 		{
-			"incorrect issue comment ID",
-			1,
-			4,
-			true,
+			name:        "incorrect issue comment ID",
+			issueNumber: 1,
+			commentID:   4,
+			wantErr:     true,
 		},
 	}
 	for _, tt := range tests {
 		if err := s.UpdateIssueComment(ctx, &scm.IssueCommentOptions{
 			Organization: qtest.MockOrg,
 			Repository:   mockRepos[0].Path,
-			Number:       tt.issueNimber,
+			Number:       tt.issueNumber,
 			CommentID:    tt.commentID,
 			Body:         "Updated",
 		}); (err != nil) != tt.wantErr {
@@ -900,41 +900,41 @@ func TestMockCreateCourse(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"invalid opt, missing org ID",
-			&scm.CourseOptions{
+			name: "invalid opt, missing org ID",
+			opt: &scm.CourseOptions{
 				CourseCreator: user,
 			},
-			0,
-			map[uint64]*scm.Team{},
-			true,
+			wantRepos: 0,
+			wantTeams: map[uint64]*scm.Team{},
+			wantErr:   true,
 		},
 		{
-			"invalid opt, missing user",
-			&scm.CourseOptions{
+			name: "invalid opt, missing user",
+			opt: &scm.CourseOptions{
 				OrganizationID: 1,
 			},
-			0,
-			map[uint64]*scm.Team{},
-			true,
+			wantRepos: 0,
+			wantTeams: map[uint64]*scm.Team{},
+			wantErr:   true,
 		},
 		{
-			"incorrect organization ID",
-			&scm.CourseOptions{
+			name: "incorrect organization ID",
+			opt: &scm.CourseOptions{
 				OrganizationID: 123,
 				CourseCreator:  user,
 			},
-			0,
-			map[uint64]*scm.Team{},
-			true,
+			wantRepos: 0,
+			wantTeams: map[uint64]*scm.Team{},
+			wantErr:   true,
 		},
 		{
-			"correct arguments",
-			&scm.CourseOptions{
+			name: "correct arguments",
+			opt: &scm.CourseOptions{
 				OrganizationID: 1,
 				CourseCreator:  user,
 			},
-			len(wantRepos),
-			map[uint64]*scm.Team{
+			wantRepos: len(wantRepos),
+			wantTeams: map[uint64]*scm.Team{
 				1: {
 					ID:           1,
 					Name:         scm.TeachersTeam,
@@ -946,7 +946,7 @@ func TestMockCreateCourse(t *testing.T) {
 					Organization: qtest.MockOrg,
 				},
 			},
-			false,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -980,41 +980,41 @@ func TestMockUpdateEnrollment(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"invalid opt, missing course",
-			&scm.UpdateEnrollmentOptions{
+			name: "invalid opt, missing course",
+			opt: &scm.UpdateEnrollmentOptions{
 				User:   user,
 				Status: qf.Enrollment_STUDENT,
 			},
-			map[uint64]*scm.Repository{},
-			true,
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   true,
 		},
 		{
-			"invalid opt, missing user name",
-			&scm.UpdateEnrollmentOptions{
+			name: "invalid opt, missing user name",
+			opt: &scm.UpdateEnrollmentOptions{
 				Organization: qtest.MockOrg,
 				Status:       qf.Enrollment_STUDENT,
 			},
-			map[uint64]*scm.Repository{},
-			true,
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   true,
 		},
 		{
-			"enroll teacher, no new repos",
-			&scm.UpdateEnrollmentOptions{
+			name: "enroll teacher, no new repos",
+			opt: &scm.UpdateEnrollmentOptions{
 				Organization: qtest.MockOrg,
 				User:         user,
 				Status:       qf.Enrollment_TEACHER,
 			},
-			map[uint64]*scm.Repository{},
-			false,
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   false,
 		},
 		{
-			"enroll student, new repo added",
-			&scm.UpdateEnrollmentOptions{
+			name: "enroll student, new repo added",
+			opt: &scm.UpdateEnrollmentOptions{
 				Organization: qtest.MockOrg,
 				User:         user,
 				Status:       qf.Enrollment_STUDENT,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: {
 					ID:    1,
 					Path:  qf.StudentRepoName(user),
@@ -1022,7 +1022,7 @@ func TestMockUpdateEnrollment(t *testing.T) {
 					OrgID: 1,
 				},
 			},
-			false,
+			wantErr: false,
 		},
 	}
 
@@ -1055,41 +1055,41 @@ func TestMockRejectEnrollment(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"invalid options, missing repo ID",
-			&scm.RejectEnrollmentOptions{
+			name: "invalid options, missing repo ID",
+			opt: &scm.RejectEnrollmentOptions{
 				OrganizationID: 1,
 				User:           user,
 			},
-			map[uint64]*scm.Repository{1: repo},
-			true,
+			wantRepos: map[uint64]*scm.Repository{1: repo},
+			wantErr:   true,
 		},
 		{
-			"invalid options, missing organization ID",
-			&scm.RejectEnrollmentOptions{
+			name: "invalid options, missing organization ID",
+			opt: &scm.RejectEnrollmentOptions{
 				RepositoryID: 1,
 				User:         user,
 			},
-			map[uint64]*scm.Repository{1: repo},
-			true,
+			wantRepos: map[uint64]*scm.Repository{1: repo},
+			wantErr:   true,
 		},
 		{
-			"invalid options, missing user login",
-			&scm.RejectEnrollmentOptions{
+			name: "invalid options, missing user login",
+			opt: &scm.RejectEnrollmentOptions{
 				RepositoryID:   1,
 				OrganizationID: 1,
 			},
-			map[uint64]*scm.Repository{1: repo},
-			true,
+			wantRepos: map[uint64]*scm.Repository{1: repo},
+			wantErr:   true,
 		},
 		{
-			"valid options, must remove repository",
-			&scm.RejectEnrollmentOptions{
+			name: "valid options, must remove repository",
+			opt: &scm.RejectEnrollmentOptions{
 				OrganizationID: 1,
 				RepositoryID:   1,
 				User:           user,
 			},
-			map[uint64]*scm.Repository{},
-			false,
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -1129,64 +1129,64 @@ func TestMockCreateGroup(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"invalid opts, missing organization",
-			&scm.TeamOptions{
+			name: "invalid opts, missing organization",
+			opt: &scm.TeamOptions{
 				TeamName: "test-team",
 			},
-			nil,
-			nil,
-			map[uint64]*scm.Team{},
-			map[uint64]*scm.Repository{},
-			true,
+			wantTeam:  nil,
+			wantRepo:  nil,
+			wantTeams: map[uint64]*scm.Team{},
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   true,
 		},
 		{
-			"invalid opts, missing team name",
-			&scm.TeamOptions{
+			name: "invalid opts, missing team name",
+			opt: &scm.TeamOptions{
 				Organization: qtest.MockOrg,
 			},
-			nil,
-			nil,
-			map[uint64]*scm.Team{},
-			map[uint64]*scm.Repository{},
-			true,
+			wantTeam:  nil,
+			wantRepo:  nil,
+			wantTeams: map[uint64]*scm.Team{},
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   true,
 		},
 		{
-			"organization does not exist",
-			&scm.TeamOptions{
+			name: "organization does not exist",
+			opt: &scm.TeamOptions{
 				Organization: "some-org",
 				TeamName:     "team",
 			},
-			nil,
-			nil,
-			map[uint64]*scm.Team{},
-			map[uint64]*scm.Repository{},
-			true,
+			wantTeam:  nil,
+			wantRepo:  nil,
+			wantTeams: map[uint64]*scm.Team{},
+			wantRepos: map[uint64]*scm.Repository{},
+			wantErr:   true,
 		},
 		{
-			"add a new group",
-			&scm.TeamOptions{
+			name: "add a new group",
+			opt: &scm.TeamOptions{
 				Organization: qtest.MockOrg,
 				TeamName:     mockTeams[0].Name,
 				Users:        []string{user},
 			},
-			mockTeams[0],
-			teamRepos[0],
-			map[uint64]*scm.Team{1: mockTeams[0]},
-			map[uint64]*scm.Repository{1: teamRepos[0]},
-			false,
+			wantTeam:  mockTeams[0],
+			wantRepo:  teamRepos[0],
+			wantTeams: map[uint64]*scm.Team{1: mockTeams[0]},
+			wantRepos: map[uint64]*scm.Repository{1: teamRepos[0]},
+			wantErr:   false,
 		},
 		{
-			"add another group",
-			&scm.TeamOptions{
+			name: "add another group",
+			opt: &scm.TeamOptions{
 				Organization: qtest.MockOrg,
 				TeamName:     mockTeams[1].Name,
 				Users:        []string{user},
 			},
-			mockTeams[1],
-			teamRepos[1],
-			map[uint64]*scm.Team{1: mockTeams[0], 2: mockTeams[1]},
-			map[uint64]*scm.Repository{1: teamRepos[0], 2: teamRepos[1]},
-			false,
+			wantTeam:  mockTeams[1],
+			wantRepo:  teamRepos[1],
+			wantTeams: map[uint64]*scm.Team{1: mockTeams[0], 2: mockTeams[1]},
+			wantRepos: map[uint64]*scm.Repository{1: teamRepos[0], 2: teamRepos[1]},
+			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -1244,87 +1244,87 @@ func TestMockDeleteGroup(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			"invalid opt, missing organization",
-			&scm.GroupOptions{
+			name: "invalid opt, missing organization",
+			opt: &scm.GroupOptions{
 				TeamID:       1,
 				RepositoryID: 2,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: repositories[0],
 				2: repositories[1],
 			},
-			map[uint64]*scm.Team{
+			wantTeams: map[uint64]*scm.Team{
 				1: mockTeams[0],
 				2: mockTeams[1],
 				3: mockTeams[2],
 			},
-			true,
+			wantErr: true,
 		},
 		{
-			"invalid opt, missing team ID",
-			&scm.GroupOptions{
+			name: "invalid opt, missing team ID",
+			opt: &scm.GroupOptions{
 				OrganizationID: 1,
 				RepositoryID:   1,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: repositories[0],
 				2: repositories[1],
 			},
-			map[uint64]*scm.Team{
+			wantTeams: map[uint64]*scm.Team{
 				1: mockTeams[0],
 				2: mockTeams[1],
 				3: mockTeams[2],
 			},
-			true,
+			wantErr: true,
 		},
 		{
-			"invalid opt, missing repo ID",
-			&scm.GroupOptions{
+			name: "invalid opt, missing repo ID",
+			opt: &scm.GroupOptions{
 				OrganizationID: 1,
 				TeamID:         1,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: repositories[0],
 				2: repositories[1],
 			},
-			map[uint64]*scm.Team{
+			wantTeams: map[uint64]*scm.Team{
 				1: mockTeams[0],
 				2: mockTeams[1],
 				3: mockTeams[2],
 			},
-			true,
+			wantErr: true,
 		},
 		{
-			"incorrect organization ID",
-			&scm.GroupOptions{
+			name: "incorrect organization ID",
+			opt: &scm.GroupOptions{
 				OrganizationID: 1,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: repositories[0],
 				2: repositories[1],
 			},
-			map[uint64]*scm.Team{
+			wantTeams: map[uint64]*scm.Team{
 				1: mockTeams[0],
 				2: mockTeams[1],
 				3: mockTeams[2],
 			},
-			true,
+			wantErr: true,
 		},
 		{
-			"correct opt, delete group repo with ID 2, team ID 1",
-			&scm.GroupOptions{
+			name: "correct opt, delete group repo with ID 2, team ID 1",
+			opt: &scm.GroupOptions{
 				OrganizationID: 1,
 				TeamID:         1,
 				RepositoryID:   2,
 			},
-			map[uint64]*scm.Repository{
+			wantRepos: map[uint64]*scm.Repository{
 				1: repositories[0],
 			},
-			map[uint64]*scm.Team{
+			wantTeams: map[uint64]*scm.Team{
 				2: mockTeams[1],
 				3: mockTeams[2],
 			},
-			false,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -13,7 +13,7 @@ import (
 // i.e., GitHub.
 type SCM interface {
 	// Gets an organization.
-	GetOrganization(context.Context, *GetOrgOptions) (*qf.Organization, error)
+	GetOrganization(context.Context, *OrganizationOptions) (*qf.Organization, error)
 	// Create a new repository.
 	CreateRepository(context.Context, *CreateRepositoryOptions) (*Repository, error)
 	// Get repositories within organization.
@@ -91,42 +91,6 @@ func newSCMAppClient(ctx context.Context, logger *zap.SugaredLogger, config *Con
 	return nil, errors.New("invalid provider: " + provider)
 }
 
-// UpdateEnrollmentOptions contain information about enrollment.
-type UpdateEnrollmentOptions struct {
-	Organization string
-	User         string
-	Status       qf.Enrollment_UserStatus
-}
-
-// RejectEnrollmentOptions contain information about enrollment.
-type RejectEnrollmentOptions struct {
-	OrganizationID uint64
-	RepositoryID   uint64
-	User           string
-}
-
-// GroupOptions contain information about group.
-type GroupOptions struct {
-	OrganizationID uint64
-	RepositoryID   uint64
-	TeamID         uint64
-}
-
-func (opt *GroupOptions) valid() bool {
-	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
-		opt.TeamID > 0
-}
-
-// GetOrgOptions contain information about organization.
-type GetOrgOptions struct {
-	ID   uint64
-	Name string
-	// Username field is used to filter organizations
-	// where the given user has a certain role.
-	Username  string
-	NewCourse bool // Get organization for a new course
-}
-
 // Repository represents a git remote repository.
 type Repository struct {
 	ID      uint64
@@ -135,37 +99,6 @@ type Repository struct {
 	HTMLURL string // Repository website.
 	OrgID   uint64
 	Size    uint64
-}
-
-// RepositoryOptions is used to fetch a single repository by ID or name.
-// Either ID or both Path and Owner fields must be set.
-type RepositoryOptions struct {
-	ID    uint64
-	Path  string
-	Owner string
-}
-
-// CreateRepositoryOptions contains information on how a repository should be created.
-type CreateRepositoryOptions struct {
-	Organization string
-	Path         string
-	Private      bool
-	Owner        string // The owner of an organization's repo is always the organization itself.
-	Permission   string // Default permission level for the given repo. Can be "read", "write", "admin", "none".
-}
-
-// TeamOptions used when creating a new team
-type TeamOptions struct {
-	Organization string
-	TeamName     string
-	Users        []string
-}
-
-// UpdateTeamOptions used when updating team members.
-type UpdateTeamOptions struct {
-	OrganizationID uint64
-	TeamID         uint64
-	Users          []string
 }
 
 // Team represents a git Team
@@ -189,34 +122,4 @@ type Issue struct {
 	Assignee   string
 	Status     string
 	Number     int
-}
-
-// IssueOptions contains information for creating or updating an Issue.
-type IssueOptions struct {
-	Organization string
-	Repository   string
-	Title        string
-	Body         string
-	State        string
-	Labels       *[]string
-	Assignee     *string
-	Assignees    *[]string
-	Number       int
-}
-
-// RequestReviewersOptions contains information on how to create or edit a pull request comment.
-type IssueCommentOptions struct {
-	Organization string
-	Repository   string
-	Body         string
-	Number       int
-	CommentID    int64
-}
-
-// RequestReviewersOptions contains information on how to assign reviewers to a pull request.
-type RequestReviewersOptions struct {
-	Organization string
-	Repository   string
-	Number       int
-	Reviewers    []string // Reviewers is a slice of github usernames
 }

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -91,12 +91,6 @@ func newSCMAppClient(ctx context.Context, logger *zap.SugaredLogger, config *Con
 	return nil, errors.New("invalid provider: " + provider)
 }
 
-// CourseOptions contain information about new course.
-type CourseOptions struct {
-	OrganizationID uint64
-	CourseCreator  string
-}
-
 // UpdateEnrollmentOptions contain information about enrollment.
 type UpdateEnrollmentOptions struct {
 	Organization string

--- a/scm/scm_invite.go
+++ b/scm/scm_invite.go
@@ -6,3 +6,7 @@ type InvitationOptions struct {
 	Owner string // Name of the organization.
 	Token string // Access token for the user.
 }
+
+func (opt InvitationOptions) valid() bool {
+	return opt.Login != "" && opt.Owner != "" && opt.Token != ""
+}

--- a/scm/scm_options.go
+++ b/scm/scm_options.go
@@ -1,5 +1,7 @@
 package scm
 
+import "github.com/quickfeed/quickfeed/qf"
+
 // CourseOptions contain information about new course.
 type CourseOptions struct {
 	OrganizationID uint64
@@ -8,4 +10,142 @@ type CourseOptions struct {
 
 func (opt CourseOptions) valid() bool {
 	return opt.OrganizationID > 0 && opt.CourseCreator != ""
+}
+
+// GroupOptions contain information about group.
+type GroupOptions struct {
+	OrganizationID uint64
+	RepositoryID   uint64
+	TeamID         uint64
+}
+
+func (opt *GroupOptions) valid() bool {
+	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
+		opt.TeamID > 0
+}
+
+// UpdateEnrollmentOptions contain information about enrollment.
+type UpdateEnrollmentOptions struct {
+	Organization string
+	User         string
+	Status       qf.Enrollment_UserStatus
+}
+
+func (opt UpdateEnrollmentOptions) valid() bool {
+	return opt.Organization != "" && opt.User != ""
+}
+
+// RejectEnrollmentOptions contain information about enrollment.
+type RejectEnrollmentOptions struct {
+	OrganizationID uint64
+	RepositoryID   uint64
+	User           string
+}
+
+func (opt *RejectEnrollmentOptions) valid() bool {
+	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
+		opt.User != ""
+}
+
+// OrganizationOptions contain information about organization.
+type OrganizationOptions struct {
+	ID   uint64
+	Name string
+	// Username field is used to filter organizations
+	// where the given user has a certain role.
+	Username  string
+	NewCourse bool // Get organization for a new course
+}
+
+func (opt OrganizationOptions) valid() bool {
+	return opt.ID != 0 || opt.Name != ""
+}
+
+// RepositoryOptions is used to fetch a single repository by ID or name.
+// Either ID or both Path and Owner fields must be set.
+type RepositoryOptions struct {
+	ID    uint64
+	Path  string
+	Owner string
+}
+
+func (opt RepositoryOptions) valid() bool {
+	return opt.ID > 0 || (opt.Path != "" && opt.Owner != "")
+}
+
+// CreateRepositoryOptions contains information on how a repository should be created.
+type CreateRepositoryOptions struct {
+	Organization string
+	Path         string
+	Private      bool
+	Permission   string // Default permission level for the given repo. Can be "read", "write", "admin", "none".
+}
+
+func (opt CreateRepositoryOptions) valid() bool {
+	return opt.Organization != "" && opt.Path != ""
+}
+
+// TeamOptions used when creating a new team
+type TeamOptions struct {
+	Organization string
+	TeamName     string
+	Users        []string
+}
+
+func (opt TeamOptions) valid() bool {
+	return opt.TeamName != "" && opt.Organization != ""
+}
+
+// UpdateTeamOptions used when updating team members.
+type UpdateTeamOptions struct {
+	OrganizationID uint64
+	TeamID         uint64
+	Users          []string
+}
+
+func (opt UpdateTeamOptions) valid() bool {
+	return opt.TeamID > 0 && opt.OrganizationID > 0
+}
+
+// IssueOptions contains information for creating or updating an Issue.
+type IssueOptions struct {
+	Organization string
+	Repository   string
+	Title        string
+	Body         string
+	State        string
+	Labels       *[]string
+	Assignee     *string
+	Assignees    *[]string
+	Number       int
+}
+
+func (opt *IssueOptions) valid() bool {
+	return opt.Organization != "" && opt.Repository != "" && opt.Title != "" && opt.Body != ""
+}
+
+// RequestReviewersOptions contains information on how to create or edit a pull request comment.
+type IssueCommentOptions struct {
+	Organization string
+	Repository   string
+	Body         string
+	Number       int
+	CommentID    int64
+}
+
+func (opt IssueCommentOptions) valid() bool {
+	return opt.Organization != "" && opt.Repository != "" && opt.Body != ""
+}
+
+// RequestReviewersOptions contains information on how to assign reviewers to a pull request.
+type RequestReviewersOptions struct {
+	Organization string
+	Repository   string
+	Number       int
+	Reviewers    []string // Reviewers is a slice of github usernames
+}
+
+func (opt RequestReviewersOptions) valid() bool {
+	return opt.Organization != "" && opt.Repository != "" &&
+		opt.Number > 0 && len(opt.Reviewers) != 0
 }

--- a/scm/scm_options.go
+++ b/scm/scm_options.go
@@ -1,0 +1,11 @@
+package scm
+
+// CourseOptions contain information about new course.
+type CourseOptions struct {
+	OrganizationID uint64
+	CourseCreator  string
+}
+
+func (opt CourseOptions) valid() bool {
+	return opt.OrganizationID > 0 && opt.CourseCreator != ""
+}

--- a/scm/scm_options.go
+++ b/scm/scm_options.go
@@ -20,8 +20,7 @@ type GroupOptions struct {
 }
 
 func (opt *GroupOptions) valid() bool {
-	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
-		opt.TeamID > 0
+	return opt.OrganizationID > 0 && opt.RepositoryID > 0 && opt.TeamID > 0
 }
 
 // UpdateEnrollmentOptions contain information about enrollment.
@@ -43,8 +42,7 @@ type RejectEnrollmentOptions struct {
 }
 
 func (opt *RejectEnrollmentOptions) valid() bool {
-	return opt.OrganizationID > 0 && opt.RepositoryID > 0 &&
-		opt.User != ""
+	return opt.OrganizationID > 0 && opt.RepositoryID > 0 && opt.User != ""
 }
 
 // OrganizationOptions contain information about organization.
@@ -146,6 +144,5 @@ type RequestReviewersOptions struct {
 }
 
 func (opt RequestReviewersOptions) valid() bool {
-	return opt.Organization != "" && opt.Repository != "" &&
-		opt.Number > 0 && len(opt.Reviewers) != 0
+	return opt.Organization != "" && opt.Repository != "" && opt.Number > 0 && len(opt.Reviewers) != 0
 }

--- a/web/courses.go
+++ b/web/courses.go
@@ -368,7 +368,7 @@ func (s *QuickFeedService) updateCourse(ctx context.Context, sc scm.SCM, request
 		return err
 	}
 	// ensure the organization exists
-	org, err := sc.GetOrganization(ctx, &scm.GetOrgOptions{ID: request.OrganizationID})
+	org, err := sc.GetOrganization(ctx, &scm.OrganizationOptions{ID: request.OrganizationID})
 	if err != nil {
 		return err
 	}

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -20,7 +20,7 @@ func TestCreateAndGetCourse(t *testing.T) {
 
 	client, tm, _ := MockClientWithUser(t, db)
 
-	admin := qtest.CreateFakeUser(t, db, 1)
+	admin := qtest.CreateAdminUser(t, db, "fake")
 	cookie := Cookie(t, tm, admin)
 
 	wantCourse := qtest.MockCourses[0]
@@ -51,7 +51,7 @@ func TestCreateAndGetCourses(t *testing.T) {
 
 	client, tm, _ := MockClientWithUser(t, db)
 
-	admin := qtest.CreateFakeUser(t, db, 1)
+	admin := qtest.CreateAdminUser(t, db, "fake")
 	cookie := Cookie(t, tm, admin)
 
 	for _, wantCourse := range qtest.MockCourses {
@@ -83,7 +83,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 
 	client, tm, mockSCM := MockClientWithUser(t, db)
 
-	admin := qtest.CreateFakeUser(t, db, 1)
+	admin := qtest.CreateAdminUser(t, db, "fake")
 	cookie := Cookie(t, tm, admin)
 
 	ctx := context.Background()

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -18,7 +18,7 @@ func TestCreateAndGetCourse(t *testing.T) {
 
 	client, tm, _ := MockClientWithUser(t, db)
 
-	admin := qtest.CreateAdminUser(t, db, "fake")
+	admin := qtest.CreateNamedUser(t, db, 1, "admin")
 	cookie := Cookie(t, tm, admin)
 
 	wantCourse := qtest.MockCourses[0]
@@ -49,7 +49,7 @@ func TestCreateAndGetCourses(t *testing.T) {
 
 	client, tm, _ := MockClientWithUser(t, db)
 
-	admin := qtest.CreateAdminUser(t, db, "fake")
+	admin := qtest.CreateNamedUser(t, db, 1, "admin")
 	cookie := Cookie(t, tm, admin)
 
 	for _, wantCourse := range qtest.MockCourses {
@@ -81,7 +81,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 
 	client, tm := MockClientWithUserAndCourse(t, db)
 
-	admin := qtest.CreateAdminUser(t, db, "fake")
+	admin := qtest.CreateNamedUser(t, db, 1, "admin")
 	cookie := Cookie(t, tm, admin)
 
 	ctx := context.Background()

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -26,7 +26,7 @@ func TestCreateAndGetCourse(t *testing.T) {
 	wantCourse := qtest.MockCourses[0]
 	createdCourse, err := client.CreateCourse(context.Background(), qtest.RequestWithCookie(wantCourse, cookie))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	gotCourse, err := client.GetCourse(context.Background(), qtest.RequestWithCookie(&qf.CourseRequest{
@@ -87,7 +87,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 	cookie := Cookie(t, tm, admin)
 
 	ctx := context.Background()
-	organization, err := mockSCM.GetOrganization(ctx, &scm.GetOrgOptions{ID: 1, NewCourse: true})
+	organization, err := mockSCM.GetOrganization(ctx, &scm.OrganizationOptions{ID: 1, NewCourse: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -403,7 +403,7 @@ func TestDeleteGroup(t *testing.T) {
 		OrganizationName: "test",
 		ID:               1,
 	}
-	admin := qtest.CreateFakeUser(t, db, 1)
+	admin := qtest.CreateAdminUser(t, db, "fake")
 
 	ctx := context.Background()
 	if _, err := client.CreateCourse(ctx, qtest.RequestWithCookie(&testCourse, Cookie(t, tm, admin))); err != nil {

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -37,7 +37,7 @@ func TestRefreshTokens(t *testing.T) {
 		return cookie.String()
 	}
 
-	admin := qtest.CreateFakeUser(t, db, 1)
+	admin := qtest.CreateAdminUser(t, db, "fake")
 	user := qtest.CreateFakeUser(t, db, 56)
 	adminCookie := f(t, admin.ID)
 	userCookie := f(t, user.ID)

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -113,7 +113,7 @@ func (s *QuickFeedService) CreateCourse(ctx context.Context, in *connect.Request
 		if ok, parsedErr := parseSCMError(err); ok {
 			return nil, parsedErr
 		}
-		return nil, err //connect.NewError(connect.CodeInvalidArgument, errors.New("failed to create course"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("failed to create course"))
 	}
 	return connect.NewResponse(course), nil
 }

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -576,7 +576,7 @@ func (s *QuickFeedService) GetOrganization(ctx context.Context, in *connect.Requ
 		s.logger.Errorf("GetOrganization failed: could not create scm client for organization %s: %v", in.Msg.GetOrgName(), err)
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
-	org, err := scmClient.GetOrganization(ctx, &scm.GetOrgOptions{Name: in.Msg.GetOrgName(), Username: usr.GetLogin(), NewCourse: true})
+	org, err := scmClient.GetOrganization(ctx, &scm.OrganizationOptions{Name: in.Msg.GetOrgName(), Username: usr.GetLogin(), NewCourse: true})
 	if err != nil {
 		s.logger.Errorf("GetOrganization failed: %v", err)
 		if ctxErr := ctxErr(ctx); ctxErr != nil {

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -113,7 +113,7 @@ func (s *QuickFeedService) CreateCourse(ctx context.Context, in *connect.Request
 		if ok, parsedErr := parseSCMError(err); ok {
 			return nil, parsedErr
 		}
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("failed to create course"))
+		return nil, err //connect.NewError(connect.CodeInvalidArgument, errors.New("failed to create course"))
 	}
 	return connect.NewResponse(course), nil
 }


### PR DESCRIPTION
SCM "options" types and corresponding `valid()` methods were defined in different places of the `scm` package. It made it easy to forget to update validators when introducing changes to the "options" interfaces. 
This PR puts validation methods close to the corresponding interface definitions. It also adds a missing validation check and updates the affected tests.

Closes #908.