### PR TITLE
Remove scm error `ErrMissingFields`

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -43,10 +43,7 @@ func NewGithubSCMClient(logger *zap.SugaredLogger, token string) *GithubSCM {
 // GetOrganization implements the SCM interface.
 func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOptions) (*qf.Organization, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetOrganization",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	var orgNameOrID string
 	var gitOrg *github.Organization
@@ -109,10 +106,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 // GetRepositories implements the SCM interface.
 func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) ([]*Repository, error) {
 	if !org.IsValid() {
-		return nil, ErrMissingFields{
-			Method:  "GetRepositories",
-			Message: fmt.Sprintf("%+v", org),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", org)
 	}
 	var path string
 	if org.Name != "" {
@@ -162,10 +156,7 @@ func (s *GithubSCM) RepositoryIsEmpty(ctx context.Context, opt *RepositoryOption
 // UpdateTeamMembers implements the SCM interface
 func (s *GithubSCM) UpdateTeamMembers(ctx context.Context, opt *UpdateTeamOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "UpdateTeamMembers",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 
 	// find current team members
@@ -215,10 +206,7 @@ func (s *GithubSCM) UpdateTeamMembers(ctx context.Context, opt *UpdateTeamOption
 // CreateIssue implements the SCM interface
 func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "CreateIssue",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	newIssue := &github.IssueRequest{
 		Title:     &opt.Title,
@@ -244,10 +232,7 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 // UpdateIssue implements the SCM interface
 func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "UpdateIssue",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 
 	issueReq := &github.IssueRequest{
@@ -273,10 +258,7 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 // GetIssue implements the SCM interface
 func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number int) (*Issue, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetIssue",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
 	if err != nil {
@@ -292,10 +274,7 @@ func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number
 // GetIssues implements the SCM interface
 func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Issue, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "GetIssues",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
 	if err != nil {
@@ -316,10 +295,7 @@ func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*I
 // RequestReviewers implements the SCM interface
 func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "RequestReviewers",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	reviewersRequest := github.ReviewersRequest{
 		Reviewers: opt.Reviewers,
@@ -337,10 +313,7 @@ func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersO
 // CreateIssueComment implements the SCM interface
 func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptions) (int64, error) {
 	if !opt.valid() {
-		return 0, ErrMissingFields{
-			Method:  "CreateIssueComment",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return 0, fmt.Errorf("missing fields: %+v", opt)
 	}
 	createdComment, _, err := s.client.Issues.CreateComment(ctx, opt.Organization, opt.Repository, opt.Number, &github.IssueComment{Body: &opt.Body})
 	if err != nil {
@@ -356,10 +329,7 @@ func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOpt
 // UpdateIssueComment implements the SCM interface
 func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "UpdateIssueComment",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	if _, _, err := s.client.Issues.EditComment(ctx, opt.Organization, opt.Repository, opt.CommentID, &github.IssueComment{Body: &opt.Body}); err != nil {
 		return ErrFailedSCM{
@@ -374,10 +344,7 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 // CreateCourse creates repositories and teams for a new course.
 func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repository, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "CreateCourse",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	// Get and check the organization's suitability for the course
 	org, err := s.GetOrganization(ctx, &OrganizationOptions{ID: opt.OrganizationID, NewCourse: true})
@@ -439,10 +406,7 @@ func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Re
 // UpdateEnrollment updates organization and team membership and creates user repositories.
 func (s *GithubSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentOptions) (*Repository, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "UpdateEnrollment",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	org, err := s.GetOrganization(ctx, &OrganizationOptions{
 		Name: opt.Organization,
@@ -476,10 +440,7 @@ func (s *GithubSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentO
 // RejectEnrollment removes user's repository and revokes user's membership in the course organization.
 func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "RejectEnrollment",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	org, err := s.GetOrganization(ctx, &OrganizationOptions{ID: opt.OrganizationID})
 	if err != nil {
@@ -494,10 +455,7 @@ func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentO
 // DemoteTeacherToStudent removes user from teachers team, revokes owner status in the organization.
 func (s *GithubSCM) DemoteTeacherToStudent(ctx context.Context, opt *UpdateEnrollmentOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "UpdateEnrollment",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	if _, err := s.client.Teams.RemoveTeamMembershipBySlug(ctx, opt.Organization, TeachersTeam, opt.User); err != nil {
 		return err
@@ -514,10 +472,7 @@ func (s *GithubSCM) DemoteTeacherToStudent(ctx context.Context, opt *UpdateEnrol
 // CreateGroup creates team and repository for a new group.
 func (s *GithubSCM) CreateGroup(ctx context.Context, opt *TeamOptions) (*Repository, *Team, error) {
 	if !opt.valid() {
-		return nil, nil, ErrMissingFields{
-			Method:  "CreateGroup",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 	orgOptions := &OrganizationOptions{Name: opt.Organization}
 	org, err := s.GetOrganization(ctx, orgOptions)
@@ -550,10 +505,7 @@ func (s *GithubSCM) CreateGroup(ctx context.Context, opt *TeamOptions) (*Reposit
 // DeleteGroup deletes group's repository and team.
 func (s *GithubSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
 	if !opt.valid() {
-		return ErrMissingFields{
-			Method:  "DeleteGroup",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	if err := s.deleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
 		return err
@@ -565,10 +517,7 @@ func (s *GithubSCM) DeleteGroup(ctx context.Context, opt *GroupOptions) error {
 // createRepository creates a new repository or returns an existing repository with the given name.
 func (s *GithubSCM) createRepository(ctx context.Context, opt *CreateRepositoryOptions) (*Repository, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "CreateRepository",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 
 	// check that repo does not already exist for this user or group
@@ -600,7 +549,7 @@ func (s *GithubSCM) createRepository(ctx context.Context, opt *CreateRepositoryO
 // deleteRepository deletes repository by name or ID.
 func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions) error {
 	if !opt.valid() {
-		return fmt.Errorf("invalid argument: %+v", opt)
+		return fmt.Errorf("missing fields: %+v", opt)
 	}
 
 	// if ID provided, get path and owner from github
@@ -630,10 +579,7 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions
 // createTeam creates a new GitHub team.
 func (s *GithubSCM) createTeam(ctx context.Context, opt *TeamOptions) (*Team, error) {
 	if !opt.valid() {
-		return nil, ErrMissingFields{
-			Method:  "CreateTeam",
-			Message: fmt.Sprintf("%+v", opt),
-		}
+		return nil, fmt.Errorf("missing fields: %+v", opt)
 	}
 
 	// check that the team name does not already exist for this organization

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -91,17 +91,6 @@ func (e ErrNotSupported) Error() string {
 	return "method " + e.Method + " not supported by " + e.SCM + " SCM"
 }
 
-// ErrMissingFields is returned when scm struct validation fails.
-// This error only used for development/debugging and never goes to frontend user.
-type ErrMissingFields struct {
-	Message string
-	Method  string
-}
-
-func (e ErrMissingFields) Error() string {
-	return "github method " + e.Method + " called with missing required fields: " + e.Message
-}
-
 // ErrFailedSCM is returned to provide detailed information
 // to user about source of the error and possible solution
 type ErrFailedSCM struct {


### PR DESCRIPTION
Replacing `ErrMissingFields` in the `scm` package with simple error messages to reduce unnecessary complexity and improve maintainability. 

This PR is based on #909.

Resolves #910.