### PR TITLE
Remove `allstudents` team

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -648,7 +648,7 @@ func (s *GithubSCM) grantPullAccessToCourseRepos(ctx context.Context, org, login
 	return nil
 }
 
-// promoteToTeacher adds user to the organization's "teachers" team, and removes the user from the "students" team.
+// promoteToTeacher adds user to the organization's "teachers" team.
 func (s *GithubSCM) promoteToTeacher(ctx context.Context, org, login string) error {
 	teamMaintainer := &github.TeamAddTeamMembershipOptions{Role: TeamMaintainer}
 	_, _, err := s.client.Teams.AddTeamMembershipBySlug(ctx, org, TeachersTeam, login, teamMaintainer)

--- a/scm/github.go
+++ b/scm/github.go
@@ -581,15 +581,11 @@ func (s *GithubSCM) createTeam(ctx context.Context, opt *TeamOptions) (*Team, er
 			Name: teamName,
 		})
 		if err != nil {
-			if opt.TeamName != TeachersTeam {
-				return nil, ErrFailedSCM{
-					Method:   "CreateTeam",
-					Message:  fmt.Sprintf("failed to create GitHub team %s, make sure it does not already exist", opt.TeamName),
-					GitError: fmt.Errorf("failed to create GitHub team %s: %w", opt.TeamName, err),
-				}
+			return nil, ErrFailedSCM{
+				Method:   "CreateTeam",
+				Message:  fmt.Sprintf("failed to create GitHub team %s, make sure it does not already exist", opt.TeamName),
+				GitError: fmt.Errorf("failed to create GitHub team %s: %w", opt.TeamName, err),
 			}
-			// continue if it is the standard teacher team that can be safely reused
-			s.logger.Debugf("Team %s already exists on organization %s", teamName, opt.Organization)
 		}
 		s.logger.Debugf("CreateTeam: done creating %s", teamName)
 	}

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -46,8 +46,6 @@ const (
 
 	// TeachersTeam is the team with all teachers and teaching assistants of a course.
 	TeachersTeam = "allteachers"
-	// StudentsTeam is the team with all students of a course.
-	StudentsTeam = "allstudents"
 )
 
 const (

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -50,11 +50,6 @@ func NewMockSCMClientWithCourse() *MockSCM {
 			Name:         TeachersTeam,
 			Organization: qtest.MockOrg,
 		},
-		2: {
-			ID:           2,
-			Name:         StudentsTeam,
-			Organization: qtest.MockOrg,
-		},
 	}
 	s.Repositories = map[uint64]*Repository{
 		1: {
@@ -390,11 +385,6 @@ func (s *MockSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Repo
 		1: {
 			ID:           1,
 			Name:         TeachersTeam,
-			Organization: org.Name,
-		},
-		2: {
-			ID:           2,
-			Name:         StudentsTeam,
 			Organization: org.Name,
 		},
 	}

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -92,11 +92,6 @@ func TestMockSCMWithCourse(t *testing.T) {
 			Name:         scm.TeachersTeam,
 			Organization: qtest.MockOrg,
 		},
-		2: {
-			ID:           2,
-			Name:         scm.StudentsTeam,
-			Organization: qtest.MockOrg,
-		},
 	}
 	if diff := cmp.Diff(wantTeams, s.Teams); diff != "" {
 		t.Errorf("mismatch teams (-want +got):\n%s", diff)
@@ -938,11 +933,6 @@ func TestMockCreateCourse(t *testing.T) {
 				1: {
 					ID:           1,
 					Name:         scm.TeachersTeam,
-					Organization: qtest.MockOrg,
-				},
-				2: {
-					ID:           2,
-					Name:         scm.StudentsTeam,
 					Organization: qtest.MockOrg,
 				},
 			},


### PR DESCRIPTION
The default `allstudents` team serves no real purpose in the current system. However, it adds an extra call to GitHub API every time the status of enrollment changes. This PR removes this team and the corresponding steps in the enrollment process.

Resolves #897.