### PR TITLE
Un-export token update check

### DIFF
--- a/web/auth/jwt_test.go
+++ b/web/auth/jwt_test.go
@@ -40,7 +40,7 @@ func TestNewManager(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie != nil {
-		t.Error("JWT update required is true, expected false")
+		t.Error("expected nil, got updated cookie")
 	}
 
 	// But must require update if claims are about to expire.
@@ -50,7 +50,7 @@ func TestNewManager(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie == nil {
-		t.Error("JWT update required is false for expiring token, expected true")
+		t.Error("expected updated cookie, got nil")
 	}
 
 	// User 2 must be in the update list.
@@ -66,7 +66,7 @@ func TestNewManager(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie == nil {
-		t.Error("JWT update required is false, expected true")
+		t.Error("expected updated cookie, got nil")
 	}
 }
 
@@ -155,7 +155,7 @@ func TestUpdateTokenList(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie != nil {
-		t.Error("JWT update required is true, expected false")
+		t.Error("expected nil, got updated cookie")
 	}
 
 	// Adding user must update manager's update list and database record.
@@ -176,7 +176,7 @@ func TestUpdateTokenList(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie == nil {
-		t.Error("JWT update required is false, expected true")
+		t.Error("expected updated cookie, got nil")
 	}
 
 	// Adding and then removing user from the list.
@@ -200,7 +200,7 @@ func TestUpdateTokenList(t *testing.T) {
 		t.Error(err)
 	}
 	if cookie != nil {
-		t.Error("JWT update required is true, expected false")
+		t.Error("expected nil, got updated cookie")
 	}
 }
 
@@ -232,7 +232,7 @@ func TestUpdateCookie(t *testing.T) {
 		t.Fatal(err)
 	}
 	if newCookie == nil {
-		t.Error("expected updated cookie")
+		t.Error("expected updated cookie, got nil")
 	}
 	newClaims, err := tm.GetClaims(newCookie.String())
 	if err != nil {

--- a/web/auth/jwt_update.go
+++ b/web/auth/jwt_update.go
@@ -8,7 +8,7 @@ import (
 
 // UpdateRequired returns true if JWT update is needed for this user ID
 // because the user's role has changed or the JWT is about to expire.
-func (tm *TokenManager) UpdateRequired(claims *Claims) bool {
+func (tm *TokenManager) updateRequired(claims *Claims) bool {
 	for _, token := range tm.tokensToUpdate {
 		if claims.UserID == token {
 			return true
@@ -18,6 +18,9 @@ func (tm *TokenManager) UpdateRequired(claims *Claims) bool {
 }
 
 func (tm *TokenManager) UpdateCookie(claims *Claims) (*http.Cookie, error) {
+	if !tm.updateRequired(claims) {
+		return nil, nil
+	}
 	updatedCookie, err := tm.NewAuthCookie(claims.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update cookie for user %d: %w", claims.UserID, err)

--- a/web/auth/jwt_update.go
+++ b/web/auth/jwt_update.go
@@ -6,17 +6,6 @@ import (
 	"time"
 )
 
-// UpdateRequired returns true if JWT update is needed for this user ID
-// because the user's role has changed or the JWT is about to expire.
-func (tm *TokenManager) updateRequired(claims *Claims) bool {
-	for _, token := range tm.tokensToUpdate {
-		if claims.UserID == token {
-			return true
-		}
-	}
-	return claims.ExpiresAt <= time.Now().Unix()
-}
-
 func (tm *TokenManager) UpdateCookie(claims *Claims) (*http.Cookie, error) {
 	if !tm.updateRequired(claims) {
 		return nil, nil
@@ -59,6 +48,17 @@ func (tm *TokenManager) Add(userID uint64) error {
 	}
 	tm.tokensToUpdate = append(tm.tokensToUpdate, userID)
 	return nil
+}
+
+// updateRequired returns true if JWT update is needed for this user ID
+// because the user's role has changed or the JWT is about to expire.
+func (tm *TokenManager) updateRequired(claims *Claims) bool {
+	for _, token := range tm.tokensToUpdate {
+		if claims.UserID == token {
+			return true
+		}
+	}
+	return claims.ExpiresAt <= time.Now().Unix()
 }
 
 // updateTokenList fetches IDs of users who need token updates from the database

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -54,25 +54,25 @@ func TestRefreshTokens(t *testing.T) {
 			ExpiresAt: time.Now().Add(1 * time.Minute).Unix(),
 		},
 	}
-	if tm.UpdateRequired(adminClaims) || tm.UpdateRequired(userClaims) {
+	if updateRequired(t, tm, userClaims) || updateRequired(t, tm, adminClaims) {
 		t.Error("No users should be in the token update list at the start")
 	}
 	if _, err := client.GetUsers(ctx, qtest.RequestWithCookie(&qf.Void{}, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if tm.UpdateRequired(adminClaims) || tm.UpdateRequired(userClaims) {
+	if updateRequired(t, tm, adminClaims) || updateRequired(t, tm, userClaims) {
 		t.Error("No users should be in the token update list")
 	}
 	if _, err := client.UpdateUser(ctx, qtest.RequestWithCookie(user, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if !tm.UpdateRequired(userClaims) {
+	if !updateRequired(t, tm, userClaims) {
 		t.Error("User must be in the token update list after admin has updated the user's information")
 	}
 	if _, err := client.GetUser(ctx, qtest.RequestWithCookie(&qf.Void{}, userCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if tm.UpdateRequired(userClaims) {
+	if updateRequired(t, tm, userClaims) {
 		t.Error("User should not be in the token update list after the token has been updated")
 	}
 	course := &qf.Course{
@@ -92,26 +92,26 @@ func TestRefreshTokens(t *testing.T) {
 	if _, err := client.CreateCourse(ctx, qtest.RequestWithCookie(course, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if !tm.UpdateRequired(adminClaims) {
+	if !updateRequired(t, tm, adminClaims) {
 		t.Error("Admin must be in the token update list after creating a new course")
 	}
 	qtest.EnrollStudent(t, db, user, course)
 	if _, err := client.CreateGroup(ctx, qtest.RequestWithCookie(group, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if tm.UpdateRequired(userClaims) {
+	if updateRequired(t, tm, userClaims) {
 		t.Error("User should not be in the token update list after methods that don't affect the user's information")
 	}
 	if _, err := client.UpdateGroup(ctx, qtest.RequestWithCookie(group, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if !tm.UpdateRequired(userClaims) {
+	if !updateRequired(t, tm, userClaims) {
 		t.Error("User must be in the token update group after changes to the group")
 	}
 	if _, err := client.GetUser(ctx, qtest.RequestWithCookie(&qf.Void{}, userCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if tm.UpdateRequired(userClaims) {
+	if updateRequired(t, tm, userClaims) {
 		t.Error("User should be removed from the token update list after the user's token has been updated")
 	}
 	if _, err := client.DeleteGroup(ctx, qtest.RequestWithCookie(&qf.GroupRequest{
@@ -120,10 +120,19 @@ func TestRefreshTokens(t *testing.T) {
 	}, adminCookie)); err != nil {
 		t.Fatal(err)
 	}
-	if !tm.UpdateRequired(userClaims) {
+	if !updateRequired(t, tm, userClaims) {
 		t.Error("User must be in the token update list after the group has been deleted")
 	}
-	if tm.UpdateRequired(adminClaims) {
+	if updateRequired(t, tm, adminClaims) {
 		t.Error("Admin should not be in the token update list")
 	}
+}
+
+func updateRequired(t *testing.T, tm *auth.TokenManager, claims *auth.Claims) bool {
+	t.Helper()
+	updated, err := tm.UpdateCookie(claims)
+	if err != nil {
+		t.Error(err)
+	}
+	return updated != nil
 }

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -73,10 +73,6 @@ func (u *UserInterceptor) processHeader(header http.Header) (*auth.Claims, *http
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to extract JWT claims from session cookie: %w", err))
 	}
-	// if !u.tm.UpdateRequired(claims) {
-	// 	return claims, nil, nil
-	// }
-	// u.logger.Debug("Updating cookie for user ", claims.UserID)
 	updatedCookie, err := u.tm.UpdateCookie(claims)
 	if err != nil {
 		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -73,13 +73,16 @@ func (u *UserInterceptor) processHeader(header http.Header) (*auth.Claims, *http
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to extract JWT claims from session cookie: %w", err))
 	}
-	if !u.tm.UpdateRequired(claims) {
-		return claims, nil, nil
-	}
-	u.logger.Debug("Updating cookie for user ", claims.UserID)
+	// if !u.tm.UpdateRequired(claims) {
+	// 	return claims, nil, nil
+	// }
+	// u.logger.Debug("Updating cookie for user ", claims.UserID)
 	updatedCookie, err := u.tm.UpdateCookie(claims)
 	if err != nil {
 		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))
+	}
+	if updatedCookie == nil {
+		return claims, nil, nil
 	}
 	return claims, updatedCookie, nil
 }


### PR DESCRIPTION
JWT manager's method `UpdateRequired` is now unexported.

Closes #812.