### PR TITLE
UpdateAssignments now use transactions

### DIFF
--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -7,15 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/quickfeed/quickfeed/ci"
 	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/internal/rand"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/testing/protocmp"
-	"gorm.io/gorm"
 )
 
 // MaxWait is the maximum time allowed for updating a course's assignments
@@ -58,9 +55,6 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, sc scm
 	if err != nil {
 		logger.Errorf("Failed to parse assignments from '%s' repository: %v", qf.TestsRepo, err)
 		return
-	}
-	for _, assignment := range assignments {
-		updateGradingCriteria(logger, db, assignment)
 	}
 
 	if course.HasUpdatedDockerfile(dockerfile) {
@@ -114,45 +108,4 @@ func buildDockerImage(ctx context.Context, logger *zap.SugaredLogger, course *qf
 		return fmt.Errorf("failed to build image from %s's Dockerfile: %s", course.GetCode(), err)
 	}
 	return nil
-}
-
-// updateGradingCriteria will remove old grading criteria and related reviews when criteria.json gets updated
-func updateGradingCriteria(logger *zap.SugaredLogger, db database.Database, assignment *qf.Assignment) {
-	if len(assignment.GetGradingBenchmarks()) > 0 {
-		gradingBenchmarks, err := db.GetBenchmarks(&qf.Assignment{
-			CourseID: assignment.CourseID,
-			Order:    assignment.Order,
-		})
-		if err != nil {
-			if err == gorm.ErrRecordNotFound {
-				// a new assignment, no actions required
-				return
-			}
-			logger.Debugf("Failed to fetch assignment %s from database: %s", assignment.Name, err)
-			return
-		}
-		if len(gradingBenchmarks) > 0 {
-			if !cmp.Equal(assignment.GradingBenchmarks, gradingBenchmarks, cmp.Options{
-				protocmp.Transform(),
-				protocmp.IgnoreFields(&qf.GradingBenchmark{}, "ID", "AssignmentID", "ReviewID"),
-				protocmp.IgnoreFields(&qf.GradingCriterion{}, "ID", "BenchmarkID"),
-				protocmp.IgnoreEnums(),
-			}) {
-				for _, bm := range gradingBenchmarks {
-					for _, c := range bm.Criteria {
-						if err := db.DeleteCriterion(c); err != nil {
-							logger.Errorf("Failed to delete criteria %v: %s\n", c, err)
-							return
-						}
-					}
-					if err := db.DeleteBenchmark(bm); err != nil {
-						logger.Errorf("Failed to delete benchmark %v: %s\n", bm, err)
-						return
-					}
-				}
-			} else {
-				assignment.GradingBenchmarks = nil
-			}
-		}
-	}
 }

--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -208,18 +208,17 @@ func TestUpdateCriteria(t *testing.T) {
 		}
 	}
 
-	// If assignment.GradingBenchmarks is empty beyond this point, it means that there were no added / removed benchmarks / criteria
-	updateGradingCriteria(qtest.Logger(t), db, assignment)
-
-	// Assignment has no added or removed benchmarks, expect nil
-	if assignment.GradingBenchmarks != nil {
-		t.Fatalf("Expected assignment.GradingBenchmarks to be nil, got %v", assignment.GradingBenchmarks)
+	if diff := cmp.Diff(benchmarks, assignment.GradingBenchmarks, protocmp.Transform()); diff != "" {
+		t.Errorf("Sanity check: mismatch (-want +got):\n%s", diff)
 	}
 
 	// Update assignments. GradingBenchmarks should not be updated
-	err := db.UpdateAssignments([]*qf.Assignment{assignment, assignment2})
-	if err != nil {
+	if err := db.UpdateAssignments([]*qf.Assignment{assignment, assignment2}); err != nil {
 		t.Fatal(err)
+	}
+	// Assignment has no added or removed benchmarks, expect nil
+	if assignment.GradingBenchmarks != nil {
+		t.Errorf("Expected nil, got %v", assignment.GradingBenchmarks)
 	}
 
 	for _, wantReview := range []*qf.Review{review, review2} {
@@ -264,19 +263,16 @@ func TestUpdateCriteria(t *testing.T) {
 
 	assignment.GradingBenchmarks = updatedBenchmarks
 
-	// This should delete the old benchmarks and criteria existing in the database, and return the new benchmarks
-	updateGradingCriteria(qtest.Logger(t), db, assignment)
-
-	gotBenchmarks, err = db.GetBenchmarks(&qf.Assignment{ID: assignment.ID, CourseID: course.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// updateGradingCriteria should have deleted the old benchmarks and criteria
-	if len(gotBenchmarks) > 0 {
-		t.Fatalf("Expected no benchmarks, got %v", gotBenchmarks)
+	if diff := cmp.Diff(updatedBenchmarks, assignment.GradingBenchmarks, protocmp.Transform()); diff != "" {
+		t.Errorf("Sanity check: mismatch (-want +got):\n%s", diff)
 	}
 
-	// Assignment has been modified, expect benchmarks to not be nil
+	// Update assignments. GradingBenchmarks should be updated.
+	// This should also delete the old benchmarks in the database, and return the new benchmarks.
+	if err := db.UpdateAssignments([]*qf.Assignment{assignment, assignment2}); err != nil {
+		t.Error(err)
+	}
+	// Assignment should still reflect the updated benchmark
 	if assignment.GradingBenchmarks == nil {
 		t.Fatal("Expected assignment.GradingBenchmarks to not be nil")
 	}

--- a/database/gormdb_assignment.go
+++ b/database/gormdb_assignment.go
@@ -1,7 +1,11 @@
 package database
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/quickfeed/quickfeed/qf"
+	"google.golang.org/protobuf/testing/protocmp"
 	"gorm.io/gorm"
 )
 
@@ -71,11 +75,106 @@ func (db *GormDB) GetAssignmentsByCourse(courseID uint64) (_ []*qf.Assignment, e
 
 // UpdateAssignments updates assignment information.
 func (db *GormDB) UpdateAssignments(assignments []*qf.Assignment) error {
-	// TODO(meling) Updating the database may need locking?? Or maybe rewrite as a single query or txn.
-	for _, v := range assignments {
-		// this will create or update an existing assignment
-		if err := db.CreateAssignment(v); err != nil {
-			return err
+	return db.conn.Transaction(func(tx *gorm.DB) error {
+		for _, v := range assignments {
+			if err := check(tx, v); err != nil {
+				return err
+			}
+
+			assignment := qf.Assignment{}
+			if tx.Model(&qf.Assignment{}).FirstOrInit(&assignment,
+				&qf.Assignment{
+					CourseID: v.CourseID,
+					Order:    v.Order,
+				},
+			).RowsAffected == 0 {
+				// Zero rows affected indicates that the assignment does not exist
+				return tx.Model(&qf.Assignment{}).Create(v).Error
+			}
+
+			// Assign the existing assignment ID to the incoming assignment
+			v.ID = assignment.ID
+			if err := db.updateGradingCriteria(tx, v); err != nil {
+				return err // will rollback transaction
+			}
+
+			if err := tx.Model(v).Where(&qf.Assignment{
+				ID: assignment.ID,
+			}).Select("*").Updates(&qf.Assignment{
+				ID:               v.ID,
+				CourseID:         v.CourseID,
+				Name:             v.Name,
+				Deadline:         v.Deadline,
+				AutoApprove:      v.AutoApprove,
+				Order:            v.Order,
+				IsGroupLab:       v.IsGroupLab,
+				ScoreLimit:       v.ScoreLimit,
+				Reviewers:        v.Reviewers,
+				ContainerTimeout: v.ContainerTimeout,
+				// Submissions:       v.Submissions,
+				Tasks:             v.Tasks,
+				GradingBenchmarks: v.GradingBenchmarks,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func check(tx *gorm.DB, assignment *qf.Assignment) error {
+	// Course id and assignment order must be given.
+	if assignment.CourseID < 1 || assignment.Order < 1 {
+		return gorm.ErrRecordNotFound
+	}
+	var course int64
+	if err := tx.Model(&qf.Course{}).Where(&qf.Course{
+		ID: assignment.CourseID,
+	}).Count(&course).Error; err != nil {
+		return err
+	}
+	if course != 1 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// updateGradingCriteria will remove old grading criteria and related reviews when criteria.json gets updated.
+func (db *GormDB) updateGradingCriteria(tx *gorm.DB, assignment *qf.Assignment) error {
+	if len(assignment.GetGradingBenchmarks()) > 0 {
+		gradingBenchmarks, err := db.GetBenchmarks(&qf.Assignment{
+			ID: assignment.ID,
+		})
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				// a new assignment, no actions required
+				return nil
+			}
+			return fmt.Errorf("failed to fetch assignment %s from database: %w", assignment.Name, err)
+		}
+		if len(gradingBenchmarks) > 0 {
+			if cmp.Equal(assignment.GradingBenchmarks, gradingBenchmarks, cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&qf.GradingBenchmark{}, "ID", "AssignmentID", "ReviewID"),
+				protocmp.IgnoreFields(&qf.GradingCriterion{}, "ID", "BenchmarkID"),
+				protocmp.IgnoreEnums(),
+			}) {
+				// no changes in the grading criteria for this assignment (from the tests repository)
+				// we set this to nil to avoid duplicates in the database
+				assignment.GradingBenchmarks = nil
+			} else {
+				// grading criteria changed for this assignment, remove old criteria and reviews
+				for _, bm := range gradingBenchmarks {
+					for _, c := range bm.Criteria {
+						if err := tx.Delete(c).Error; err != nil {
+							return fmt.Errorf("failed to delete criterion %d: %w", c.GetID(), err)
+						}
+					}
+					if err := tx.Delete(bm).Error; err != nil {
+						return fmt.Errorf("failed to delete benchmark %d: %w", bm.GetID(), err)
+					}
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Moved updateGradingCriteria to db.UpdateAssignments() and make use of transactions in UpdateAssignments().

Based on PR #950

Fixes #951

