### PR TITLE
Minor fix for env.IsLocal

### DIFF
--- a/internal/env/cert.go
+++ b/internal/env/cert.go
@@ -88,10 +88,12 @@ func IsLocal(domain string) bool {
 	if err != nil {
 		return false
 	}
+	local := true
 	for _, ip := range ips {
-		if ip.IsLoopback() || ip.IsPrivate() {
-			return true
+		if !(ip.IsLoopback() || ip.IsPrivate()) {
+			local = false
+			break
 		}
 	}
-	return false
+	return local
 }

--- a/internal/env/cert.go
+++ b/internal/env/cert.go
@@ -88,12 +88,10 @@ func IsLocal(domain string) bool {
 	if err != nil {
 		return false
 	}
-	local := true
 	for _, ip := range ips {
 		if !(ip.IsLoopback() || ip.IsPrivate()) {
-			local = false
-			break
+			return false
 		}
 	}
-	return local
+	return true
 }


### PR DESCRIPTION
In some cases `net.LookupIP(domain)` would return a slice of IPs, for example:

```
127.0.1.1
154.X.X.X
```

where the first one is local, but the second is public. The current `IsLocal` would return `true` in this case, while we want it to return `false`.

The change introduced in this PR returns `false` if at least one IP is public, and `true` if not.