### PR TITLE
Removed deprecated yaml assignmentid field

### DIFF
--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -16,7 +16,6 @@ const defaultAutoApproveScoreLimit = 80
 // Note that the struct can be private, but the fields must be
 // public to allow parsing.
 type assignmentData struct {
-	AssignmentID     uint   `yaml:"assignmentid"` // deprecated: use Order instead
 	Order            uint32 `yaml:"order"`
 	Deadline         string `yaml:"deadline"`
 	IsGroupLab       bool   `yaml:"isgrouplab"`
@@ -35,9 +34,6 @@ func newAssignmentFromFile(contents []byte, assignmentName string, courseID uint
 	// if no auto approve score limit is defined; use the default
 	if newAssignment.ScoreLimit < 1 {
 		newAssignment.ScoreLimit = defaultAutoApproveScoreLimit
-	}
-	if newAssignment.AssignmentID > 0 && newAssignment.Order == 0 {
-		newAssignment.Order = uint32(newAssignment.AssignmentID)
 	}
 	deadline, err := FixDeadline(newAssignment.Deadline)
 	if err != nil {


### PR DESCRIPTION
We no longer support the `assignmentid` field in `assignment.yaml` files; users should use the `order` field to define the order number of an assignment. See the dat320 and dat520 courses for an example. @JosteinLindhom We just need to make sure that the dat310 course and possibly others don't use `assignmentid` before merging and using this code.