### PR TITLE
Fixes for manual grading

### DIFF
--- a/public/src/components/manual-grading/ReviewForm.tsx
+++ b/public/src/components/manual-grading/ReviewForm.tsx
@@ -21,7 +21,7 @@ const ReviewForm = (): JSX.Element => {
     }
 
     const isAuthor = (review: Review) => {
-        return review?.ID === state.self.ID
+        return review?.ReviewerID === state.self.ID
     }
 
     const reviewers = assignment.reviewers ?? 0

--- a/public/src/overmind/namespaces/review/state.ts
+++ b/public/src/overmind/namespaces/review/state.ts
@@ -47,11 +47,11 @@ export const state: ReviewState = {
         return check ? check[selectedReview] : null
     }),
 
-    reviewer: derived(({ currentReview }: ReviewState, { users }: Context["state"]) => {
+    reviewer: derived(({ currentReview }: ReviewState, { courseTeachers }: Context["state"]) => {
         if (!currentReview) {
             return null
         }
-        return users[currentReview.ReviewerID.toString()]
+        return courseTeachers[currentReview.ReviewerID.toString()]
     }),
 
     canUpdate: derived(({ currentReview }: ReviewState, { activeCourse, selectedSubmission }: Context["state"]) => {

--- a/public/src/overmind/state.tsx
+++ b/public/src/overmind/state.tsx
@@ -234,13 +234,12 @@ export const state: State = {
         if (!activeCourse || !courseEnrollments[activeCourse.toString()]) {
             return {}
         }
-        const teachers = courseEnrollments[activeCourse.toString()].filter(isTeacher)
         const teachersMap: { [userID: string]: User } = {}
-        for (const teacher of teachers) {
-            if (teacher.user) {
-                teachersMap[teacher.userID.toString()] = teacher.user
+        courseEnrollments[activeCourse.toString()].forEach(enrollment => {
+            if (isTeacher(enrollment) && enrollment.user) {
+                teachersMap[enrollment.userID.toString()] = enrollment.user
             }
-        }
+        })
         return teachersMap
     }),
     courseMembers: derived(({

--- a/public/src/overmind/state.tsx
+++ b/public/src/overmind/state.tsx
@@ -99,6 +99,10 @@ export type State = {
      *  values of sortSubmissionsBy, sortAscending, and submissionFilters */
     courseMembers: Enrollment[] | Group[],
 
+    /* Course teachers, indexed by user ID */
+    /* Derived from enrollments for selected course */
+    courseTeachers: { [userID: string]: User }
+
     /* Contains all enrollments for a given course */
     courseEnrollments: { [courseID: string]: Enrollment[] },
 
@@ -226,6 +230,19 @@ export const state: State = {
     users: {},
     allUsers: [],
     courses: [],
+    courseTeachers: derived(({ courseEnrollments, activeCourse }: State) => {
+        if (!activeCourse || !courseEnrollments[activeCourse.toString()]) {
+            return {}
+        }
+        const teachers = courseEnrollments[activeCourse.toString()].filter(isTeacher)
+        const teachersMap: { [userID: string]: User } = {}
+        for (const teacher of teachers) {
+            if (teacher.user) {
+                teachersMap[teacher.userID.toString()] = teacher.user
+            }
+        }
+        return teachersMap
+    }),
     courseMembers: derived(({
         activeCourse, groupView, submissionsForCourse, assignments, groups,
         courseEnrollments, submissionFilters, sortAscending, sortSubmissionsBy


### PR DESCRIPTION
This PR includes some fixes for manual grading in the frontend.

- Fetch reviewer from course enrollments (previously from `users`). Context: teachers that are not admins do not have access to the `GetUsers` endpoint. As a consequence, `users` will not be populated for non-admin teachers
- Fixed bug where `isAuthor` used review ID rather than reviewer ID
