### PR TITLE
Migrate to remote plugins

### DIFF
--- a/buf.gen.ui.yaml
+++ b/buf.gen.ui.yaml
@@ -2,9 +2,9 @@
 # For details, see https://docs.buf.build/configuration/v1/buf-gen-yaml
 version: v1
 plugins:
-  - remote: buf.build/bufbuild/plugins/es
+  - plugin: buf.build/bufbuild/es
     out: public/proto
     opt: target=ts
-  - remote: buf.build/bufbuild/plugins/connect-web
+  - plugin: buf.build/bufbuild/connect-web
     out: public/proto
     opt: target=ts

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,9 +2,9 @@
 # For details, see https://docs.buf.build/configuration/v1/buf-gen-yaml
 version: v1
 plugins:
-  - name: go-patch
+  - plugin: go-patch
     out: ./
     opt: plugin=go,paths=source_relative
-  - name: connect-go
+  - plugin: connect-go
     out: ./
     opt: paths=source_relative


### PR DESCRIPTION
We previously used the "name" and "remote" keys to specify whether or not a plugin was local or remote. As of April 30, 2023 these were deprecated.

This PR simply migrates our generate files to use the new "plugin" keys.

See <https://buf.build/docs/migration-guides/migrate-remote-generation-alpha#migrate-to-remote-plugins> for more info.