### PR TITLE
Fix bug due to go.work

### DIFF
--- a/internal/env/load.go
+++ b/internal/env/load.go
@@ -83,5 +83,5 @@ func Load(filename string) error {
 
 func ignore(line string) bool {
 	trimmedLine := strings.TrimSpace(line)
-	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+	return trimmedLine == "" || strings.HasPrefix(trimmedLine, "#")
 }

--- a/internal/env/load.go
+++ b/internal/env/load.go
@@ -10,14 +10,17 @@ import (
 	"github.com/quickfeed/quickfeed/kit/sh"
 )
 
-const dotEnvPath = ".env"
+const (
+	dotEnvPath          = ".env"
+	quickfeedModulePath = "github.com/quickfeed/quickfeed"
+)
 
 var quickfeedRoot string
 
 func init() {
 	quickfeedRoot = os.Getenv("QUICKFEED")
 	if quickfeedRoot == "" {
-		out, err := sh.Output("go list -m -f {{.Dir}}")
+		out, err := sh.Output("go list -m -f {{.Dir}} " + quickfeedModulePath)
 		if err != nil {
 			log.Fatalf("Failed to set QUICKFEED variable: %v", err)
 		}


### PR DESCRIPTION
This fixes the bug due to go.work giving two root paths for the
modules (./ ./kit)

Fixes #1040
