### PR TITLE
feat: Add context logging support

### DIFF
--- a/web/interceptor/logging.go
+++ b/web/interceptor/logging.go
@@ -1,0 +1,67 @@
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/quickfeed/quickfeed/database"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/web/auth"
+	"go.uber.org/zap"
+)
+
+type ContextLoggingInterceptor struct {
+	db     database.Database
+	logger *zap.Logger
+}
+
+func NewContextLoggingInterceptor(logger *zap.Logger, db database.Database) *ContextLoggingInterceptor {
+	return &ContextLoggingInterceptor{logger: logger, db: db}
+}
+
+func (*ContextLoggingInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return connect.StreamingHandlerFunc(func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		return next(ctx, conn)
+	})
+}
+
+func (*ContextLoggingInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return connect.StreamingClientFunc(func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		return next(ctx, spec)
+	})
+}
+
+// WrapUnary updates list of users who need a new JWT next time they send a request to the server.
+// This method only logs errors to avoid overwriting the gRPC error messages returned by the server.
+func (t *ContextLoggingInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return connect.UnaryFunc(func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
+		procedure := request.Spec().Procedure
+		method := procedure[strings.LastIndex(procedure, "/")+1:]
+		if claims, ok := auth.ClaimsFromContext(ctx); ok {
+			user, err := t.db.GetUser(claims.UserID)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("cannot get user for %s: %w", method, err))
+			}
+			logger := t.logger.With(
+				zap.String("method", method),
+				zap.String("user", user.GetLogin()),
+			)
+			for courseID, status := range claims.Courses {
+				course, err := t.db.GetCourse(courseID, false)
+				if err != nil {
+					return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("cannot get course for %s: %w", method, err))
+				}
+				logger = logger.With(
+					zap.String("course", course.GetCode()),
+					zap.String("status", qf.Enrollment_UserStatus_name[int32(status)]),
+				)
+			}
+			ctx = context.WithValue(ctx, "logger", logger)
+		} else {
+			return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("cannot populate context for %s: message type %T does not implement 'userIDs' interface", method, request))
+		}
+		return next(ctx, request)
+	})
+}

--- a/web/interceptor/logging_test.go
+++ b/web/interceptor/logging_test.go
@@ -1,0 +1,95 @@
+package interceptor_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/web"
+	"github.com/quickfeed/quickfeed/web/auth"
+	"github.com/quickfeed/quickfeed/web/interceptor"
+)
+
+// TestLoggingInterceptor tests that the logging interceptor logs the correct information.
+// Must run with LOG=1 to see the logs:
+//
+//	LOG=1 go test -v -run TestLoggingInterceptor
+func TestLoggingInterceptor(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	logger := qtest.Logger(t)
+
+	tm, err := auth.NewTokenManager(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := web.MockClient(t, db, connect.WithInterceptors(
+		interceptor.NewUserInterceptor(logger, tm),
+		interceptor.NewAccessControlInterceptor(tm),
+		interceptor.NewContextLoggingInterceptor(logger.Desugar(), db),
+	))
+	ctx := context.Background()
+
+	courseAdmin := qtest.CreateNamedUser(t, db, 1, "course admin")
+	groupStudent := qtest.CreateNamedUser(t, db, 2, "group student")
+	student := qtest.CreateNamedUser(t, db, 3, "student")
+	user := qtest.CreateNamedUser(t, db, 4, "user")
+	admin := qtest.CreateNamedUser(t, db, 6, "admin")
+	admin.IsAdmin = true
+	if err := db.UpdateUser(admin); err != nil {
+		t.Fatal(err)
+	}
+
+	course := &qf.Course{
+		Code:                "DAT101",
+		Year:                2024,
+		ScmOrganizationID:   1,
+		ScmOrganizationName: "test",
+		CourseCreatorID:     courseAdmin.ID,
+	}
+	if err := db.CreateCourse(courseAdmin.ID, course); err != nil {
+		t.Fatal(err)
+	}
+	qtest.EnrollStudent(t, db, groupStudent, course)
+	qtest.EnrollStudent(t, db, student, course)
+	group := &qf.Group{
+		CourseID: course.ID,
+		Name:     "Test",
+		Users:    []*qf.User{groupStudent},
+	}
+	if err := db.CreateGroup(group); err != nil {
+		t.Fatal(err)
+	}
+
+	f := func(t *testing.T, id uint64) string {
+		cookie, err := tm.NewAuthCookie(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cookie.String()
+	}
+	courseAdminCookie := f(t, courseAdmin.ID)
+	groupStudentCookie := f(t, groupStudent.ID)
+	studentCookie := f(t, student.ID)
+	userCookie := f(t, user.ID)
+	adminCookie := f(t, admin.ID)
+
+	freeAccessTest := map[string]accessTest{
+		"admin":             {cookie: courseAdminCookie, courseID: course.ID, wantAccess: true, wantCode: connect.CodePermissionDenied},
+		"student":           {cookie: studentCookie, courseID: course.ID, wantAccess: true, wantCode: connect.CodePermissionDenied},
+		"group student":     {cookie: groupStudentCookie, courseID: course.ID, wantAccess: true, wantCode: connect.CodePermissionDenied},
+		"user":              {cookie: userCookie, courseID: course.ID, wantAccess: true, wantCode: connect.CodePermissionDenied},
+		"non-teacher admin": {cookie: adminCookie, courseID: course.ID, wantAccess: true, wantCode: connect.CodePermissionDenied},
+		"empty context":     {wantAccess: false, wantCode: connect.CodeUnauthenticated},
+	}
+	for name, tt := range freeAccessTest {
+		t.Run("UnrestrictedAccess/"+name, func(t *testing.T) {
+			_, err := client.GetUser(ctx, qtest.RequestWithCookie(&qf.Void{}, tt.cookie))
+			checkAccess(t, "GetUser", err, tt.wantCode, tt.wantAccess)
+			_, err = client.GetCourse(ctx, qtest.RequestWithCookie(&qf.CourseRequest{CourseID: tt.courseID}, tt.cookie))
+			checkAccess(t, "GetCourse", err, tt.wantCode, tt.wantAccess)
+		})
+	}
+}


### PR DESCRIPTION
This adds a simple interceptor-based context logging feature that can be used in RPC calls to fetch the context logger to log with session context such as source method, userID, courseID etc. We can add more global context if necessary, but most often we
probably want to add logging information via the actual log msg.

This version just uses the current zap logger to avoid introducing another logging framework now. We can decide later whether or not to replace zap with slog.

Fixes #670
Fixes #489 
