### PR TITLE
fix: prevent duplicate case insensitive group names

### DIFF
--- a/web/groups.go
+++ b/web/groups.go
@@ -154,7 +154,7 @@ func (s *QuickFeedService) updateGroup(ctx context.Context, sc scm.SCM, request 
 }
 
 // newGroup returns a new group based on the request and the existing group.
-func (s *QuickFeedService) newGroup(group *qf.Group, request *qf.Group, users []*qf.User) (*qf.Group, error) {
+func (s *QuickFeedService) newGroup(group, request *qf.Group, users []*qf.User) (*qf.Group, error) {
 	if group.Name != request.Name && group.Status == qf.Group_PENDING {
 		if err := s.checkGroupName(request.GetCourseID(), request.GetName()); err != nil {
 			return nil, err // group name is invalid

--- a/web/groups.go
+++ b/web/groups.go
@@ -109,22 +109,9 @@ func (s *QuickFeedService) updateGroup(ctx context.Context, sc scm.SCM, request 
 
 	// allow changing the name of the group only if the group
 	// is not already approved and the new name is valid
-	if group.Name != request.Name && group.Status == qf.Group_PENDING {
-		// return error to user if group name is invalid
-		if err := s.checkGroupName(request.GetCourseID(), request.GetName()); err != nil {
-			return err
-		}
-		group.Name = request.Name
-	}
-
-	newGroup := &qf.Group{
-		ID:          group.ID,
-		Name:        group.Name,
-		CourseID:    group.CourseID,
-		ScmTeamID:   group.ScmTeamID,
-		Status:      group.Status,
-		Users:       users,
-		Enrollments: group.Enrollments,
+	newGroup, err := s.newGroup(group, request, users)
+	if err != nil {
+		return err
 	}
 
 	repo, err := s.getRepo(course, group.GetID(), qf.Repository_GROUP)
@@ -164,6 +151,25 @@ func (s *QuickFeedService) updateGroup(ctx context.Context, sc scm.SCM, request 
 	// approve and update the group in the database
 	newGroup.Status = qf.Group_APPROVED
 	return s.db.UpdateGroup(newGroup)
+}
+
+// newGroup returns a new group based on the request and the existing group.
+func (s *QuickFeedService) newGroup(group *qf.Group, request *qf.Group, users []*qf.User) (*qf.Group, error) {
+	if group.Name != request.Name && group.Status == qf.Group_PENDING {
+		if err := s.checkGroupName(request.GetCourseID(), request.GetName()); err != nil {
+			return nil, err // group name is invalid
+		}
+		group.Name = request.Name
+	}
+	return &qf.Group{
+		ID:          group.ID,
+		Name:        group.Name,
+		CourseID:    group.CourseID,
+		ScmTeamID:   group.ScmTeamID,
+		Status:      group.Status,
+		Users:       users,
+		Enrollments: group.Enrollments,
+	}, nil
 }
 
 // getGroupUsers returns the users of the specified group request, and checks

--- a/web/groups.go
+++ b/web/groups.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/quickfeed/quickfeed/qf"
@@ -220,7 +221,7 @@ func (s *QuickFeedService) checkGroupName(courseID uint64, groupName string) err
 		return err
 	}
 	for _, group := range courseGroups {
-		if group.GetName() == groupName {
+		if strings.EqualFold(group.GetName(), groupName) {
 			return ErrGroupNameDuplicate
 		}
 	}

--- a/web/groups_name_test.go
+++ b/web/groups_name_test.go
@@ -47,6 +47,8 @@ func TestBadGroupNames(t *testing.T) {
 		{"Å", web.ErrGroupNameInvalid},
 		{"DuplicateGroupName", nil},
 		{"DuplicateGroupName", web.ErrGroupNameDuplicate},
+		{"duplicateGroupName", web.ErrGroupNameDuplicate},
+		{"duplicateGroupname", web.ErrGroupNameDuplicate},
 	}
 	for _, tt := range groupNames {
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,6 +63,15 @@ func TestBadGroupNames(t *testing.T) {
 				Users:    []*qf.User{user1, user2},
 			}
 			_, err := client.CreateGroup(context.Background(), connect.NewRequest(group))
+			if tt.wantError == nil {
+				if err != nil {
+					t.Errorf("got error %v, want nil", err)
+				}
+				return
+			}
+			if err == nil && tt.wantError != nil {
+				t.Errorf("got no error, want %v", tt.wantError)
+			}
 			if connErr, ok := err.(*connect.Error); ok {
 				if connErr.Code() != tt.wantError.Code() {
 					t.Errorf("got error code %v, want %v", connErr.Code(), tt.wantError.Code())


### PR DESCRIPTION
This is an alternative fix that avoids adding another database method.

Fixes #1071

