### PR TITLE
fix: avoid searching for go.mod or git repo in init()

### DIFF
--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -34,7 +34,7 @@ func testRunData(qfTestOrg string) *RunData {
 }
 
 func TestLoadRunScript(t *testing.T) {
-	t.Setenv("QUICKFEED_REPOSITORY_PATH", filepath.Join(env.Root(), "testdata", "courses"))
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", env.TestdataPath())
 	runData := &RunData{
 		Course: &qf.Course{
 			ID:                  1,
@@ -63,7 +63,7 @@ func TestLoadRunScript(t *testing.T) {
 }
 
 func TestParseTestRunnerScript(t *testing.T) {
-	t.Setenv("QUICKFEED_REPOSITORY_PATH", filepath.Join(env.Root(), "testdata", "courses"))
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", env.TestdataPath())
 
 	const (
 		qfTestOrg        = "qf104-2022"
@@ -118,7 +118,7 @@ echo "$QUICKFEED_SESSION_SECRET"
 }
 
 func TestParseBadTestRunnerScript(t *testing.T) {
-	t.Setenv("QUICKFEED_REPOSITORY_PATH", filepath.Join(env.Root(), "testdata", "courses"))
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", env.TestdataPath())
 
 	const qfTestOrg = "qf104-2022"
 	randomSecret := rand.String()

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -36,6 +36,8 @@ func TestLoad(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
+	// ensure that QUICKFEED is set
+	env.Root()
 
 	want := map[string]string{
 		"QUICKFEED":           os.Getenv("QUICKFEED"),

--- a/internal/env/load.go
+++ b/internal/env/load.go
@@ -4,53 +4,13 @@ import (
 	"bufio"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
-
-	"github.com/quickfeed/quickfeed/kit/sh"
 )
-
-const (
-	dotEnvPath          = ".env"
-	quickfeedModulePath = "github.com/quickfeed/quickfeed"
-)
-
-var quickfeedRoot string
-
-func init() {
-	quickfeedRoot = os.Getenv("QUICKFEED")
-	if quickfeedRoot == "" {
-		out, err := sh.Output("go list -m -f {{.Dir}} " + quickfeedModulePath)
-		if err != nil {
-			log.Fatalf("Failed to set QUICKFEED variable: %v", err)
-		}
-		quickfeedRoot = strings.TrimSpace(out)
-		os.Setenv("QUICKFEED", quickfeedRoot)
-	}
-}
-
-// Root returns the root directory as defined by $QUICKFEED.
-func Root() string {
-	return quickfeedRoot
-}
-
-// RootEnv returns the path $QUICKFEED/{envFile}.
-func RootEnv(envFile string) string {
-	return filepath.Join(quickfeedRoot, envFile)
-}
-
-// PublicEnv returns the path $QUICKFEED/public/{envFile}.
-func PublicEnv(envFile string) string {
-	return filepath.Join(quickfeedRoot, "public", envFile)
-}
 
 // Load loads environment variables from the given file, or from $QUICKFEED/.env.
 // The variable's values are expanded with existing variables from the environment.
 // It will not override a variable that already exists in the environment.
 func Load(filename string) error {
-	if filename == "" {
-		filename = filepath.Join(quickfeedRoot, dotEnvPath)
-	}
 	file, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -42,3 +42,8 @@ func RootEnv(envFile string) string {
 func PublicEnv(envFile string) string {
 	return filepath.Join(quickfeedRoot, "public", envFile)
 }
+
+// TestdataPath returns the path to the testdata/courses directory.
+func TestdataPath() string {
+	return filepath.Join(quickfeedRoot, "testdata", "courses")
+}

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -28,8 +28,8 @@ func init() {
 	}
 }
 
-// Root returns the root directory as defined by $QUICKFEED.
-func Root() string {
+// root returns the root directory as defined by $QUICKFEED.
+func root() string {
 	return quickfeedRoot
 }
 

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -1,0 +1,44 @@
+package env
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/quickfeed/quickfeed/kit/sh"
+)
+
+const (
+	dotEnvPath          = ".env"
+	quickfeedModulePath = "github.com/quickfeed/quickfeed"
+)
+
+var quickfeedRoot string
+
+func init() {
+	quickfeedRoot = os.Getenv("QUICKFEED")
+	if quickfeedRoot == "" {
+		out, err := sh.Output("go list -m -f {{.Dir}} " + quickfeedModulePath)
+		if err != nil {
+			log.Fatalf("Failed to set QUICKFEED variable: %v", err)
+		}
+		quickfeedRoot = strings.TrimSpace(out)
+		os.Setenv("QUICKFEED", quickfeedRoot)
+	}
+}
+
+// Root returns the root directory as defined by $QUICKFEED.
+func Root() string {
+	return quickfeedRoot
+}
+
+// RootEnv returns the path $QUICKFEED/{envFile}.
+func RootEnv(envFile string) string {
+	return filepath.Join(quickfeedRoot, envFile)
+}
+
+// PublicEnv returns the path $QUICKFEED/public/{envFile}.
+func PublicEnv(envFile string) string {
+	return filepath.Join(quickfeedRoot, "public", envFile)
+}

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -18,32 +18,36 @@ var quickfeedRoot string
 
 func init() {
 	quickfeedRoot = os.Getenv("QUICKFEED")
-	if quickfeedRoot == "" {
-		out, err := sh.Output("go list -m -f {{.Dir}} " + quickfeedModulePath)
-		if err != nil {
-			log.Fatalf("Failed to set QUICKFEED variable: %v", err)
-		}
-		quickfeedRoot = strings.TrimSpace(out)
-		os.Setenv("QUICKFEED", quickfeedRoot)
-	}
 }
 
-// root returns the root directory as defined by $QUICKFEED.
+// root returns the root directory as defined by $QUICKFEED or
+// sets it relative to the quickfeed module's root.
 func root() string {
+	if quickfeedRoot != "" {
+		return quickfeedRoot
+	}
+
+	out, err := sh.Output("go list -m -f {{.Dir}} " + quickfeedModulePath)
+	if err != nil {
+		log.Fatalf("Failed to set QUICKFEED variable: %v", err)
+	}
+	quickfeedRoot = strings.TrimSpace(out)
+	os.Setenv("QUICKFEED", quickfeedRoot)
+
 	return quickfeedRoot
 }
 
 // RootEnv returns the path $QUICKFEED/{envFile}.
 func RootEnv(envFile string) string {
-	return filepath.Join(quickfeedRoot, envFile)
+	return filepath.Join(root(), envFile)
 }
 
 // PublicEnv returns the path $QUICKFEED/public/{envFile}.
 func PublicEnv(envFile string) string {
-	return filepath.Join(quickfeedRoot, "public", envFile)
+	return filepath.Join(root(), "public", envFile)
 }
 
 // TestdataPath returns the path to the testdata/courses directory.
 func TestdataPath() string {
-	return filepath.Join(quickfeedRoot, "testdata", "courses")
+	return filepath.Join(root(), "testdata", "courses")
 }

--- a/internal/env/scm.go
+++ b/internal/env/scm.go
@@ -70,7 +70,7 @@ func AppID() (string, error) {
 func AppKey() string {
 	appKey := os.Getenv("QUICKFEED_APP_KEY")
 	if appKey == "" {
-		return filepath.Join(root(), defaultKeyPath)
+		return filepath.Join(Root(), defaultKeyPath)
 	}
 	return appKey
 }

--- a/internal/env/scm.go
+++ b/internal/env/scm.go
@@ -70,7 +70,7 @@ func AppID() (string, error) {
 func AppKey() string {
 	appKey := os.Getenv("QUICKFEED_APP_KEY")
 	if appKey == "" {
-		return filepath.Join(Root(), defaultKeyPath)
+		return filepath.Join(root(), defaultKeyPath)
 	}
 	return appKey
 }

--- a/scm/mock.go
+++ b/scm/mock.go
@@ -88,7 +88,7 @@ func (s *MockSCM) Clone(ctx context.Context, opt *CloneOptions) (string, error) 
 		return "", err
 	}
 	// Simulate cloning by copying the testdata repository to the destination path.
-	testdataSrc := filepath.Join(env.Root(), "testdata", "courses", opt.Organization, opt.Repository)
+	testdataSrc := filepath.Join(env.TestdataPath(), opt.Organization, opt.Repository)
 	if err := fileop.CopyDir(testdataSrc, opt.DestDir); err != nil {
 		return "", err
 	}

--- a/web/rebuild_test.go
+++ b/web/rebuild_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -144,7 +143,7 @@ func TestRebuildSubmissions(t *testing.T) {
 		t.Errorf("Expected error: record not found")
 	}
 
-	t.Setenv("QUICKFEED_REPOSITORY_PATH", filepath.Join(env.Root(), "testdata", "courses"))
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", env.TestdataPath())
 	// rebuild existing submission
 	rebuildRequest.Msg.SubmissionID = 1
 	if _, err := q.RebuildSubmissions(ctx, &rebuildRequest); err != nil {


### PR DESCRIPTION
This moves the search for quickfeed's root folder out of the env package's init() function, since that requires that commands such as approvelist must be started from within a quickfeed folder. For situations where it is desirable to start quickfeed command itself outside the folder, requires that the QUICKFEED variable is set manually.

Fixes #1073

