### PR TITLE
Fix lab table squashing when test names are long

### DIFF
--- a/public/src/components/LabResultTable.tsx
+++ b/public/src/components/LabResultTable.tsx
@@ -1,139 +1,23 @@
-import React, { useCallback } from "react"
+import React from "react"
 import { Assignment, Submission } from "../../proto/qf/types_pb"
-import { assignmentStatusText, getFormattedTime, getPassedTestsCount, isApproved, isManuallyGraded } from "../Helpers"
-import { useAppState } from "../overmind"
 import ProgressBar, { Progress } from "./ProgressBar"
-import SubmissionScore from "./SubmissionScore"
+import SubmissionInfo from "./submissions/SubmissionInfo"
+import SubmissionScores from "./submissions/SubmissionScores"
 
-interface lab {
+type LabProps = {
     submission: Submission
     assignment: Assignment
 }
 
-type ScoreSort = "name" | "score" | "weight"
-
-const LabResultTable = ({ submission, assignment }: lab): JSX.Element => {
-    const state = useAppState()
-
-    const [sortKey, setSortKey] = React.useState<ScoreSort>("name")
-    const [sortAscending, setSortAscending] = React.useState<boolean>(true)
-
-    const sortScores = () => {
-        const sortBy = sortAscending ? 1 : -1
-        const scores = submission.clone().Scores
-        return scores.sort((a, b) => {
-            switch (sortKey) {
-                case "name":
-                    return sortBy * (a.TestName.localeCompare(b.TestName))
-                case "score":
-                    return sortBy * (a.Score - b.Score)
-                case "weight":
-                    return sortBy * (a.Weight - b.Weight)
-                default:
-                    return 0
-            }
-        })
-    }
-
-    const handleSort = useCallback((event: React.MouseEvent<HTMLTableCellElement>) => {
-        const key = event.currentTarget.dataset["key"] as ScoreSort
-        if (sortKey === key) {
-            setSortAscending(!sortAscending)
-        } else {
-            setSortKey(key)
-            setSortAscending(true)
-        }
-    }, [sortKey, sortAscending])
-
-    const sortedScores = React.useMemo(sortScores, [submission, sortKey, sortAscending])
-
+const LabResultTable = ({ submission, assignment }: LabProps): JSX.Element => {
     if (submission && assignment) {
-        const enrollment = state.selectedEnrollment ?? state.enrollmentsByCourseID[assignment.CourseID.toString()]
-        const buildInfo = submission.BuildInfo
-        const delivered = getFormattedTime(buildInfo?.SubmissionDate)
-        const built = getFormattedTime(buildInfo?.BuildDate)
-        const executionTime = buildInfo ? `${buildInfo.ExecTime / BigInt(1000)} seconds` : ""
-
-        const className = isApproved(submission) ? "passed" : "failed"
         return (
             <div className="pb-2">
                 <div className="pb-2">
                     <ProgressBar key={"progress-bar"} courseID={assignment.CourseID.toString()} assignmentIndex={assignment.order - 1} submission={submission} type={Progress.LAB} />
                 </div>
-                <table className="table table-curved table-striped">
-                    <thead className="thead-dark">
-                        <tr>
-                            <th colSpan={2}>Lab information</th>
-                            <th>{assignment.name}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td colSpan={2} className={className}>Status</td>
-                            <td>{assignmentStatusText(assignment, submission)}</td>
-                        </tr>
-                        <tr>
-                            <td colSpan={2}>Delivered</td>
-                            <td>{delivered}</td>
-                        </tr>
-                        <tr>
-                            <td colSpan={2}>Built</td>
-                            <td>{built}</td>
-                        </tr>
-                        { // Only render row if submission has an approved date
-                            submission.approvedDate ?
-                                <tr>
-                                    <td colSpan={2}>Approved</td>
-                                    <td>{getFormattedTime(submission.approvedDate)}</td>
-                                </tr>
-                                : null
-                        }
-                        <tr>
-                            <td colSpan={2}>Deadline</td>
-                            <td>{getFormattedTime(assignment.deadline)}</td>
-                        </tr>
-
-                        {!isManuallyGraded(assignment) ?
-                            <tr>
-                                <td colSpan={2}>Tests Passed</td>
-                                <td>{getPassedTestsCount(submission.Scores)}</td>
-                            </tr>
-                            : null
-                        }
-                        <tr>
-                            <td colSpan={2}>Execution time</td>
-                            <td>{executionTime}</td>
-                        </tr>
-                        <tr>
-                            <td colSpan={2}>Slip days</td>
-                            <td>{
-                                enrollment.slipDaysRemaining
-                            }</td>
-                        </tr>
-                    </tbody>
-                </table>
-                
-                <table className="table table-curved table-striped">
-                    <thead className="thead-dark">
-                        <tr>
-                            <th colSpan={1} data-key={"name"} role="button" onClick={handleSort}>Test Name</th>
-                            <th colSpan={1} data-key={"score"} role="button" onClick={handleSort}>Score</th>
-                            <th colSpan={1} data-key={"weight"} role="button" onClick={handleSort}>Weight</th>
-                        </tr>
-                    </thead>
-                    <tbody style={{"wordBreak": "break-word"}}>
-                        {sortedScores.map(score =>
-                            <SubmissionScore key={score.ID.toString()} score={score} />
-                        )}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <th>Total Score</th>
-                            <th>{submission.score}%</th>
-                            <th>100%</th>
-                        </tr>
-                    </tfoot>
-                </table>
+                <SubmissionInfo submission={submission} assignment={assignment} />    
+                <SubmissionScores submission={submission} />
             </div>
         )
     }

--- a/public/src/components/LabResultTable.tsx
+++ b/public/src/components/LabResultTable.tsx
@@ -61,10 +61,10 @@ const LabResultTable = ({ submission, assignment }: lab): JSX.Element => {
                     <ProgressBar key={"progress-bar"} courseID={assignment.CourseID.toString()} assignmentIndex={assignment.order - 1} submission={submission} type={Progress.LAB} />
                 </div>
                 <table className="table table-curved table-striped">
-                    <thead className={"thead-dark"}>
+                    <thead className="thead-dark">
                         <tr>
                             <th colSpan={2}>Lab information</th>
-                            <th colSpan={1}>{assignment.name}</th>
+                            <th>{assignment.name}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -110,16 +110,21 @@ const LabResultTable = ({ submission, assignment }: lab): JSX.Element => {
                                 enrollment.slipDaysRemaining
                             }</td>
                         </tr>
-                        <tr className={"thead-dark"}>
+                    </tbody>
+                </table>
+                
+                <table className="table table-curved table-striped">
+                    <thead className="thead-dark">
+                        <tr>
                             <th colSpan={1} data-key={"name"} role="button" onClick={handleSort}>Test Name</th>
                             <th colSpan={1} data-key={"score"} role="button" onClick={handleSort}>Score</th>
                             <th colSpan={1} data-key={"weight"} role="button" onClick={handleSort}>Weight</th>
-
                         </tr>
+                    </thead>
+                    <tbody style={{"wordBreak": "break-word"}}>
                         {sortedScores.map(score =>
                             <SubmissionScore key={score.ID.toString()} score={score} />
                         )}
-
                     </tbody>
                     <tfoot>
                         <tr>

--- a/public/src/components/submissions/SubmissionInfo.tsx
+++ b/public/src/components/submissions/SubmissionInfo.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { assignmentStatusText, getFormattedTime, getPassedTestsCount, isApproved, isManuallyGraded } from "../../Helpers"
+import { Assignment, Submission } from "../../../proto/qf/types_pb"
+import { useAppState } from "../../overmind"
+
+type SubmissionInfoProps = {
+    submission: Submission
+    assignment: Assignment
+}
+
+const SubmissionInfo = ({ submission, assignment }: SubmissionInfoProps) => {
+    const state = useAppState()
+    const enrollment = state.selectedEnrollment ?? state.enrollmentsByCourseID[assignment.CourseID.toString()]
+    const buildInfo = submission.BuildInfo
+    const delivered = getFormattedTime(buildInfo?.SubmissionDate)
+    const built = getFormattedTime(buildInfo?.BuildDate)
+    const executionTime = buildInfo ? `${buildInfo.ExecTime / BigInt(1000)} seconds` : ""
+    
+    const className = isApproved(submission) ? "passed" : "failed"
+    return (
+        <table className="table table-curved table-striped">
+            <thead className="thead-dark">
+                <tr>
+                    <th colSpan={2}>Lab information</th>
+                    <th>{assignment.name}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colSpan={2} className={className}>
+                        Status
+                    </td>
+                    <td>{assignmentStatusText(assignment, submission)}</td>
+                </tr>
+                <tr>
+                    <td colSpan={2}>Delivered</td>
+                    <td>{delivered}</td>
+                </tr>
+                <tr>
+                    <td colSpan={2}>Built</td>
+                    <td>{built}</td>
+                </tr>
+                {
+                    // Only render row if submission has an approved date
+                    submission.approvedDate ? (
+                        <tr>
+                            <td colSpan={2}>Approved</td>
+                            <td>{getFormattedTime(submission.approvedDate)}</td>
+                        </tr>
+                    ) : null
+                }
+                <tr>
+                    <td colSpan={2}>Deadline</td>
+                    <td>{getFormattedTime(assignment.deadline)}</td>
+                </tr>
+
+                {!isManuallyGraded(assignment) ? (
+                    <tr>
+                        <td colSpan={2}>Tests Passed</td>
+                        <td>{getPassedTestsCount(submission.Scores)}</td>
+                    </tr>
+                ) : null}
+                <tr>
+                    <td colSpan={2}>Execution time</td>
+                    <td>{executionTime}</td>
+                </tr>
+                <tr>
+                    <td colSpan={2}>Slip days</td>
+                    <td>{enrollment.slipDaysRemaining}</td>
+                </tr>
+            </tbody>
+        </table>
+    )
+}
+
+export default SubmissionInfo

--- a/public/src/components/submissions/SubmissionScore.tsx
+++ b/public/src/components/submissions/SubmissionScore.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Score } from "../../proto/kit/score/score_pb"
+import { Score } from "../../../proto/kit/score/score_pb"
 
 
 const SubmissionScore = ({ score }: { score: Score }) => {

--- a/public/src/components/submissions/SubmissionScores.tsx
+++ b/public/src/components/submissions/SubmissionScores.tsx
@@ -39,25 +39,25 @@ const SubmissionScores = ({submission}: {submission: Submission}) => {
 
     return (
         <table className="table table-curved table-striped">
-                    <thead className="thead-dark">
-                        <tr>
-                            <th colSpan={1} data-key={"name"} role="button" onClick={handleSort}>Test Name</th>
-                            <th colSpan={1} data-key={"score"} role="button" onClick={handleSort}>Score</th>
-                            <th colSpan={1} data-key={"weight"} role="button" onClick={handleSort}>Weight</th>
-                        </tr>
-                    </thead>
-                    <tbody style={{"wordBreak": "break-word"}}>
-                        {sortedScores.map(score =>
-                            <SubmissionScore key={score.ID.toString()} score={score} />
-                        )}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <th>Total Score</th>
-                            <th>{submission.score}%</th>
-                            <th>100%</th>
-                        </tr>
-                    </tfoot>
+            <thead className="thead-dark">
+                <tr>
+                    <th colSpan={1} data-key={"name"} role="button" onClick={handleSort}>Test Name</th>
+                    <th colSpan={1} data-key={"score"} role="button" onClick={handleSort}>Score</th>
+                    <th colSpan={1} data-key={"weight"} role="button" onClick={handleSort}>Weight</th>
+                </tr>
+            </thead>
+            <tbody style={{"wordBreak": "break-word"}}>
+                {sortedScores.map(score =>
+                    <SubmissionScore key={score.ID.toString()} score={score} />
+                )}
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th>Total Score</th>
+                    <th>{submission.score}%</th>
+                    <th>100%</th>
+                </tr>
+            </tfoot>
         </table>
     )
 }

--- a/public/src/components/submissions/SubmissionScores.tsx
+++ b/public/src/components/submissions/SubmissionScores.tsx
@@ -26,7 +26,7 @@ const SubmissionScores = ({submission}: {submission: Submission}) => {
     }
 
     const handleSort = useCallback((event: React.MouseEvent<HTMLTableCellElement>) => {
-        const key = event.currentTarget.dataset["key"] as ScoreSort
+        const key = event.currentTarget.dataset.key as ScoreSort
         if (sortKey === key) {
             setSortAscending(!sortAscending)
         } else {

--- a/public/src/components/submissions/SubmissionScores.tsx
+++ b/public/src/components/submissions/SubmissionScores.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback } from 'react'
+import { Submission } from "../../../proto/qf/types_pb"
+import SubmissionScore from "../SubmissionScore"
+
+type ScoreSort = "name" | "score" | "weight"
+
+const SubmissionScores = ({submission}: {submission: Submission}) => {
+    const [sortKey, setSortKey] = React.useState<ScoreSort>("name")
+    const [sortAscending, setSortAscending] = React.useState<boolean>(true)
+
+    const sortScores = () => {
+        const sortBy = sortAscending ? 1 : -1
+        const scores = submission.clone().Scores
+        return scores.sort((a, b) => {
+            switch (sortKey) {
+                case "name":
+                    return sortBy * (a.TestName.localeCompare(b.TestName))
+                case "score":
+                    return sortBy * (a.Score - b.Score)
+                case "weight":
+                    return sortBy * (a.Weight - b.Weight)
+                default:
+                    return 0
+            }
+        })
+    }
+
+    const handleSort = useCallback((event: React.MouseEvent<HTMLTableCellElement>) => {
+        const key = event.currentTarget.dataset["key"] as ScoreSort
+        if (sortKey === key) {
+            setSortAscending(!sortAscending)
+        } else {
+            setSortKey(key)
+            setSortAscending(true)
+        }
+    }, [sortKey, sortAscending])
+
+    const sortedScores = React.useMemo(sortScores, [submission, sortKey, sortAscending])
+
+    return (
+        <table className="table table-curved table-striped">
+                    <thead className="thead-dark">
+                        <tr>
+                            <th colSpan={1} data-key={"name"} role="button" onClick={handleSort}>Test Name</th>
+                            <th colSpan={1} data-key={"score"} role="button" onClick={handleSort}>Score</th>
+                            <th colSpan={1} data-key={"weight"} role="button" onClick={handleSort}>Weight</th>
+                        </tr>
+                    </thead>
+                    <tbody style={{"wordBreak": "break-word"}}>
+                        {sortedScores.map(score =>
+                            <SubmissionScore key={score.ID.toString()} score={score} />
+                        )}
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <th>Total Score</th>
+                            <th>{submission.score}%</th>
+                            <th>100%</th>
+                        </tr>
+                    </tfoot>
+        </table>
+    )
+}
+
+export default SubmissionScores

--- a/public/src/components/submissions/SubmissionScores.tsx
+++ b/public/src/components/submissions/SubmissionScores.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { Submission } from "../../../proto/qf/types_pb"
-import SubmissionScore from "../SubmissionScore"
+import SubmissionScore from "./SubmissionScore"
 
 type ScoreSort = "name" | "score" | "weight"
 


### PR DESCRIPTION
This change prevents the lab information from being squashed if a test name is very long.
It also prevents the lab view from being hidden at the bottom.

Closes #1054
