### PR TITLE
Set enrolling students' organization membership to `member`

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -399,7 +399,16 @@ func (s *GithubSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentO
 		if err := s.grantPullAccessToCourseRepos(ctx, org.ScmOrganizationName, opt.User); err != nil {
 			return nil, err
 		}
-		return s.createStudentRepo(ctx, org.ScmOrganizationName, opt.User)
+		repo, err := s.createStudentRepo(ctx, org.ScmOrganizationName, opt.User)
+		if err != nil {
+			return nil, err
+		}
+		// Promote user to organization member
+		role := OrgMember
+		if _, _, err := s.client.Organizations.EditOrgMembership(ctx, opt.User, org.ScmOrganizationName, &github.Membership{Role: &role}); err != nil {
+			return nil, err
+		}
+		return repo, nil
 
 	case qf.Enrollment_TEACHER:
 		// Promote user to organization owner


### PR DESCRIPTION
Currently enrolling a student cause them to become an outside collaborator in a course organization. 

When a student at a later point creates a group, the student will be added to a GitHub team for the group. The student will then be invited to be a member of the organization. 

For the student to be able to access their group repository they have to accept this organization invite. In a not insignificant number of cases this invite expires (GitHub invites expire after 7 days), and teachers have to resend the invites manually.

This PR sets the student membership to `member` in the process of enrolling. The subsequent call to `acceptRepositoryInvites` will also accept the organization invite.

closes #1022
