### PR TITLE
Navbar width fix

### DIFF
--- a/public/src/components/navbar/Breadcrumbs.tsx
+++ b/public/src/components/navbar/Breadcrumbs.tsx
@@ -1,19 +1,28 @@
 import React, { useEffect, useState } from 'react'
 import { useLocation, Link } from 'react-router-dom'
 import { useActions, useAppState } from '../../overmind'
+import useWindowSize from "../../hooks/windowsSize"
+import { ScreenSize } from "../../consts"
 
 
 const Breadcrumbs = () => {
     const state = useAppState()
     const actions = useActions()
     const location = useLocation()
+    const { width } = useWindowSize();
     const [courseName, setCourseName] = useState<string | null>(null)
     const [assignmentName, setAssignmentName] = useState<string | null>(null)
     const pathnames = location.pathname.split('/').filter(x => x)
 
     const getCourseNameById = (id: string): string | null => {
         const course = state.courses.find(course => course.ID.toString() === id)
-        return course ? course.name : null
+        if (!course) {
+            return null
+        }
+        if (width < ScreenSize.ExtraLarge) {
+            return course.code
+        }
+        return course.name
     }
 
     const getAssignmentNameById = (id: string): string | null => {
@@ -35,7 +44,7 @@ const Breadcrumbs = () => {
         if (pathnames[2] === 'lab' && pathnames[3]) {
             setAssignmentName(getAssignmentNameById(pathnames[3]))
         }
-    }, [pathnames])
+    }, [pathnames, width])
 
     return (
         <nav aria-label="breadcrumb">

--- a/public/src/consts.ts
+++ b/public/src/consts.ts
@@ -6,3 +6,13 @@ export const Status = {
 }
 
 export const NoSubmission = "No submission"
+
+
+// Screen size breakpoints.
+// These can be used in conjunction with the useWindowSize hook to determine the current screen size.
+export const ScreenSize = {
+    Small: 576,
+    Medium: 768,
+    Large: 992,
+    ExtraLarge: 1200
+}

--- a/public/src/hooks/windowsSize.tsx
+++ b/public/src/hooks/windowsSize.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;

--- a/public/src/style.scss
+++ b/public/src/style.scss
@@ -462,7 +462,7 @@ nav.flexbox {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-
+    flex-wrap: nowrap;
     ul {
         padding: 0.3rem;
         margin: 0.3rem;
@@ -632,4 +632,5 @@ nav.flexbox {
     .breadcrumb-item + .breadcrumb-item::before {
         content: ">" !important;
     }
+    flex-wrap: nowrap;
 }


### PR DESCRIPTION
This PR adds a windowSize hook that components can use to react to changes in screen height/width.

Our `Breadcrumbs` component now uses the hook to display the course code instead of course name on smaller screens.


https://github.com/quickfeed/quickfeed/assets/1346291/bfcad291-114e-4ba5-a8b6-1e184e103ab3



closes #1105 