### PR TITLE
Rename SCM fields

### DIFF
--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -26,11 +26,11 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		if err := scmApp.DeleteIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		}); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("Deleted issues at repo: %+v", repo.Path)
+		t.Logf("Deleted issues at repo: %+v", repo.Repo)
 	})
 
 	// Create issues on student repositories for the first assignment's tasks
@@ -44,19 +44,19 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		scmIssues, err := scmApp.GetIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		issues := make(map[string]*scm.Issue)
 		for _, issue := range scmIssues {
-			t.Logf("Found issue (%s): %s", repo.Path, issue.Title)
+			t.Logf("Found issue (%s): %s", repo.Repo, issue.Title)
 			issues[issue.Title] = issue
 		}
 		for _, task := range first[0].Tasks {
 			if _, ok := issues[task.Title]; !ok {
-				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Path)
+				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Repo)
 			}
 		}
 	})
@@ -72,19 +72,19 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		scmIssues, err := scmApp.GetIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		issues := make(map[string]*scm.Issue)
 		for _, issue := range scmIssues {
-			t.Logf("Found issue (%s): %s", repo.Path, issue.Title)
+			t.Logf("Found issue (%s): %s", repo.Repo, issue.Title)
 			issues[issue.Title] = issue
 		}
 		for _, task := range second[0].Tasks {
 			if _, ok := issues[task.Title]; !ok {
-				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Path)
+				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Repo)
 			}
 		}
 	})
@@ -92,7 +92,7 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 
 func repoFn(repos []*scm.Repository, fn func(repo *scm.Repository)) {
 	for _, repo := range repos {
-		if qf.RepoType(repo.Path).IsCourseRepo() {
+		if qf.RepoType(repo.Repo).IsCourseRepo() {
 			continue
 		}
 		fn(repo)
@@ -130,7 +130,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 			ScmRepositoryID:   scmRepo.ID,
 			ScmOrganizationID: org.GetScmOrganizationID(),
 			HTMLURL:           scmRepo.HTMLURL,
-			RepoType:          qf.RepoType(scmRepo.Path),
+			RepoType:          qf.RepoType(scmRepo.Repo),
 		}
 		if repo.IsUserRepo() {
 			user := qtest.CreateFakeUser(t, db)
@@ -148,7 +148,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 			repo.RepoType = qf.Repository_GROUP
 			repo.GroupID = group.GetID()
 		}
-		t.Logf("Creating repo in database: %v", scmRepo.Path)
+		t.Logf("Creating repo in database: %v", scmRepo.Repo)
 		if err = db.CreateRepository(repo); err != nil {
 			t.Fatal(err)
 		}

--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -119,7 +119,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 	admin := qtest.CreateFakeUser(t, db)
 	qtest.CreateCourse(t, db, admin, course)
 
-	repos, err := sc.GetRepositories(ctx, org)
+	repos, err := sc.GetRepositories(ctx, org.GetScmOrganizationName())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-github/v62/github"
 	"github.com/quickfeed/quickfeed/internal/qlog"
-	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
 
 	"github.com/urfave/cli"
@@ -208,14 +207,14 @@ func deleteRepositories(client *scm.GithubSCM) cli.ActionFunc {
 				return err
 			}
 
-			repos, err := (*client).GetRepositories(ctx, &qf.Organization{ScmOrganizationName: c.String("namespace")})
+			repos, err := (*client).GetRepositories(ctx, c.String("namespace"))
 			if err != nil {
 				return err
 			}
 
 			for _, repo := range repos {
 				var errs []error
-				if _, err := (*client).Client().Repositories.Delete(ctx, repo.Owner, repo.Path); err != nil {
+				if _, err := (*client).Client().Repositories.Delete(ctx, repo.Owner, repo.Repo); err != nil {
 					errs = append(errs, err)
 				} else {
 					fmt.Println("Deleted repository", repo.HTMLURL)
@@ -248,7 +247,7 @@ func getRepositories(client *scm.GithubSCM) cli.ActionFunc {
 			return cli.NewExitError("name and namespace must be provided", 3)
 		}
 		if c.Bool("all") {
-			repos, err := (*client).GetRepositories(ctx, &qf.Organization{ScmOrganizationName: c.String("namespace")})
+			repos, err := (*client).GetRepositories(ctx, c.String("namespace"))
 			if err != nil {
 				return err
 			}

--- a/scm/github.go
+++ b/scm/github.go
@@ -2,7 +2,6 @@ package scm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -74,7 +73,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 	// If getting organization for the purpose of creating a new course,
 	// ensure that the organization does not already contain any course repositories.
 	if opt.NewCourse {
-		repos, err := s.GetRepositories(ctx, org)
+		repos, err := s.GetRepositories(ctx, org.ScmOrganizationName)
 		if err != nil {
 			return nil, err
 		}
@@ -103,17 +102,13 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 }
 
 // GetRepositories implements the SCM interface.
-func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) ([]*Repository, error) {
-	path := org.GetScmOrganizationName()
-	if path == "" {
-		return nil, errors.New("organization name must be provided")
-	}
-	repos, _, err := s.client.Repositories.ListByOrg(ctx, path, nil)
+func (s *GithubSCM) GetRepositories(ctx context.Context, owner string) ([]*Repository, error) {
+	repos, _, err := s.client.Repositories.ListByOrg(ctx, owner, nil)
 	if err != nil {
 		return nil, ErrFailedSCM{
 			GitError: err,
 			Method:   "GetRepositories",
-			Message:  fmt.Sprintf("failed to access repositories for organization %s", path),
+			Message:  fmt.Sprintf("failed to access repositories for organization %s", owner),
 		}
 	}
 	repositories := make([]*Repository, 0, len(repos))

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -58,10 +58,10 @@ func TestGetIssue(t *testing.T) {
 
 	opt := &scm.RepositoryOptions{
 		Owner: qfTestOrg,
-		Path:  qf.StudentRepoName(qfTestUser),
+		Repo:  qf.StudentRepoName(qfTestUser),
 	}
 
-	wantIssue, cleanup := createIssue(t, s, opt.Owner, opt.Path)
+	wantIssue, cleanup := createIssue(t, s, opt.Owner, opt.Repo)
 	defer cleanup()
 
 	gotIssue, err := s.GetIssue(context.Background(), opt, wantIssue.Number)
@@ -111,7 +111,7 @@ func TestDeleteAllIssues(t *testing.T) {
 
 	opt := &scm.RepositoryOptions{
 		Owner: qfTestOrg,
-		Path:  qf.StudentRepoName(qfTestUser),
+		Repo:  qf.StudentRepoName(qfTestUser),
 	}
 	if err := s.DeleteIssues(context.Background(), opt); err != nil {
 		t.Fatal(err)
@@ -259,7 +259,7 @@ func TestEmptyRepo(t *testing.T) {
 		{
 			"tests repo, assume not empty",
 			&scm.RepositoryOptions{
-				Path:  "tests",
+				Repo:  "tests",
 				Owner: qfTestOrg,
 			},
 			false,
@@ -267,7 +267,7 @@ func TestEmptyRepo(t *testing.T) {
 		{
 			"info repo, assume empty",
 			&scm.RepositoryOptions{
-				Path:  "info",
+				Repo:  "info",
 				Owner: qfTestOrg,
 			},
 			true,
@@ -275,7 +275,7 @@ func TestEmptyRepo(t *testing.T) {
 		{
 			"non-existent repo, handle as empty",
 			&scm.RepositoryOptions{
-				Path:  "some-other-repo",
+				Repo:  "some-other-repo",
 				Owner: qfTestOrg,
 			},
 			true,
@@ -303,7 +303,7 @@ func createIssue(t *testing.T, s scm.SCM, org, repo string) (*scm.Issue, func())
 
 	return issue, func() {
 		if err := s.DeleteIssue(context.Background(), &scm.RepositoryOptions{
-			Owner: org, Path: repo,
+			Owner: org, Repo: repo,
 		}, issue.Number); err != nil {
 			t.Fatal(err)
 		}

--- a/scm/githubv4.go
+++ b/scm/githubv4.go
@@ -18,7 +18,7 @@ func (s *GithubSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, iss
 	}
 	variables := map[string]interface{}{
 		"repositoryOwner": githubv4.String(opt.Owner),
-		"repositoryName":  githubv4.String(opt.Path),
+		"repositoryName":  githubv4.String(opt.Repo),
 		"issueNumber":     githubv4.Int(issueNumber),
 	}
 	err := s.clientV4.Query(ctx, &q, variables)
@@ -42,16 +42,16 @@ func (s *GithubSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, iss
 
 func (s *GithubSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) error {
 	// List all open and closed issues (and pull requests)
-	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{State: "all"})
+	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Repo, &github.IssueListByRepoOptions{State: "all"})
 	if err != nil {
-		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Path, err)
+		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Repo, err)
 	}
 	for _, issue := range issueList {
 		if issue.IsPullRequest() {
 			continue // ignore pull requests when deleting issues
 		}
 		if err = s.DeleteIssue(ctx, opt, *issue.Number); err != nil {
-			return fmt.Errorf("failed to delete issue %d in %s: %w", *issue.Number, opt.Path, err)
+			return fmt.Errorf("failed to delete issue %d in %s: %w", *issue.Number, opt.Repo, err)
 		}
 	}
 	return nil

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -96,7 +96,7 @@ func isDirty(repos []*Repository) bool {
 		return false
 	}
 	for _, repo := range repos {
-		if _, exists := RepoPaths[repo.Path]; exists {
+		if _, exists := RepoPaths[repo.Repo]; exists {
 			return true
 		}
 	}

--- a/scm/mock_test.go
+++ b/scm/mock_test.go
@@ -43,15 +43,13 @@ var (
 	mockRepos = []*scm.Repository{
 		{
 			ID:    1,
-			OrgID: 1,
 			Owner: qtest.MockOrg,
-			Path:  qf.StudentRepoName("test"),
+			Repo:  qf.StudentRepoName("test"),
 		},
 		{
 			ID:    2,
-			OrgID: 1,
 			Owner: qtest.MockOrg,
-			Path:  qf.StudentRepoName(user),
+			Repo:  qf.StudentRepoName(user),
 		},
 	}
 )
@@ -61,27 +59,23 @@ func TestMockSCMWithCourse(t *testing.T) {
 	wantRepos := map[uint64]*scm.Repository{
 		1: {
 			ID:    1,
-			Path:  "info",
+			Repo:  "info",
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 		2: {
 			ID:    2,
-			Path:  "assignments",
+			Repo:  "assignments",
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 		3: {
 			ID:    3,
-			Path:  "tests",
+			Repo:  "tests",
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 		4: {
 			ID:    4,
-			Path:  qf.StudentRepoName("user"),
+			Repo:  qf.StudentRepoName("user"),
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 	}
 	if diff := cmp.Diff(wantRepos, s.Repositories); diff != "" {
@@ -380,7 +374,7 @@ func TestMockGetIssue(t *testing.T) {
 		{
 			name: "correct issue",
 			opt: &scm.RepositoryOptions{
-				Path:  issue.Repository,
+				Repo:  issue.Repository,
 				Owner: qtest.MockOrg,
 			},
 			number:    issue.Number,
@@ -390,7 +384,7 @@ func TestMockGetIssue(t *testing.T) {
 		{
 			name: "incorrect issue number",
 			opt: &scm.RepositoryOptions{
-				Path:  issue.Repository,
+				Repo:  issue.Repository,
 				Owner: qtest.MockOrg,
 			},
 			number:    13,
@@ -400,7 +394,7 @@ func TestMockGetIssue(t *testing.T) {
 		{
 			name: "incorrect organization name",
 			opt: &scm.RepositoryOptions{
-				Path:  issue.Repository,
+				Repo:  issue.Repository,
 				Owner: "some-org",
 			},
 			number:    issue.Number,
@@ -449,7 +443,7 @@ func TestMockGetIssues(t *testing.T) {
 			name: "issues for 'test-labs' repo",
 			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
-				Path:  mockIssues[0].Repository,
+				Repo:  mockIssues[0].Repository,
 			},
 			wantIssues: []*scm.Issue{mockIssues[0], mockIssues[1]},
 			wantErr:    false,
@@ -458,7 +452,7 @@ func TestMockGetIssues(t *testing.T) {
 			name: "issues for 'user-labs' repo",
 			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
-				Path:  mockIssues[2].Repository,
+				Repo:  mockIssues[2].Repository,
 			},
 			wantIssues: []*scm.Issue{mockIssues[2]},
 			wantErr:    false,
@@ -467,7 +461,7 @@ func TestMockGetIssues(t *testing.T) {
 			name: "incorrect repository",
 			opt: &scm.RepositoryOptions{
 				Owner: qtest.MockOrg,
-				Path:  "unknown-labs",
+				Repo:  "unknown-labs",
 			},
 			wantIssues: nil,
 			wantErr:    true,
@@ -476,7 +470,7 @@ func TestMockGetIssues(t *testing.T) {
 			name: "incorrect organization",
 			opt: &scm.RepositoryOptions{
 				Owner: "some-org",
-				Path:  mockIssues[0].Repository,
+				Repo:  mockIssues[0].Repository,
 			},
 			wantIssues: nil,
 			wantErr:    true,
@@ -501,21 +495,20 @@ func TestMockGetIssues2(t *testing.T) {
 	s.Repositories = map[uint64]*scm.Repository{
 		1: {
 			ID:    1,
-			OrgID: 1,
 			Owner: qtest.MockOrg,
-			Path:  qf.StudentRepoName("test"),
+			Repo:  qf.StudentRepoName("test"),
 		},
 	}
 
 	ctx := context.Background()
 	opt := &scm.RepositoryOptions{
 		Owner: qtest.MockOrg,
-		Path:  qf.StudentRepoName("test"),
+		Repo:  qf.StudentRepoName("test"),
 	}
 
 	var wantIssueIDs []int
 	for i := 1; i <= 5; i++ {
-		issue, cleanup := createIssue(t, s, opt.Owner, opt.Path)
+		issue, cleanup := createIssue(t, s, opt.Owner, opt.Repo)
 		defer cleanup()
 		wantIssueIDs = append(wantIssueIDs, issue.Number)
 	}
@@ -555,7 +548,7 @@ func TestMockDeleteIssue(t *testing.T) {
 		}
 		opt := &scm.RepositoryOptions{
 			Owner: qtest.MockOrg,
-			Path:  issue.Repository,
+			Repo:  issue.Repository,
 		}
 		if err := s.DeleteIssue(ctx, opt, issue.Number); err != nil {
 			t.Error(err)
@@ -583,7 +576,7 @@ func TestMockCreateGetDeleteIssueSequence(t *testing.T) {
 
 	repoOpt := &scm.RepositoryOptions{
 		Owner: qtest.MockOrg,
-		Path:  opt.Repository,
+		Repo:  opt.Repository,
 	}
 	issues, err := s.GetIssues(ctx, repoOpt)
 	if err != nil {
@@ -632,7 +625,7 @@ func TestMockDeleteIssues(t *testing.T) {
 		{
 			name: "delete all issues for 'user-labs' repo (issue 3)",
 			opt: &scm.RepositoryOptions{
-				Path:  qf.StudentRepoName(user),
+				Repo:  qf.StudentRepoName(user),
 				Owner: course.ScmOrganizationName,
 			},
 			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1]},
@@ -641,7 +634,7 @@ func TestMockDeleteIssues(t *testing.T) {
 		{
 			name: "delete all issues for 'test-labs' repo (issues 1 and 2)",
 			opt: &scm.RepositoryOptions{
-				Path:  "test-labs",
+				Repo:  "test-labs",
 				Owner: course.ScmOrganizationName,
 			},
 			wantIssues: map[uint64]*scm.Issue{3: mockIssues[2]},
@@ -651,7 +644,7 @@ func TestMockDeleteIssues(t *testing.T) {
 			name: "missing repository, nothing deleted",
 			opt: &scm.RepositoryOptions{
 				Owner: course.ScmOrganizationName,
-				Path:  "some-labs",
+				Repo:  "some-labs",
 			},
 			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
 			wantErr:    true,
@@ -660,7 +653,7 @@ func TestMockDeleteIssues(t *testing.T) {
 			name: "incorrect organization name",
 			opt: &scm.RepositoryOptions{
 				Owner: "organization",
-				Path:  "test-labs",
+				Repo:  "test-labs",
 			},
 			wantIssues: map[uint64]*scm.Issue{1: mockIssues[0], 2: mockIssues[1], 3: mockIssues[2]},
 			wantErr:    true,
@@ -859,7 +852,7 @@ func TestMockUpdateIssueComment(t *testing.T) {
 	for _, tt := range tests {
 		if err := s.UpdateIssueComment(ctx, &scm.IssueCommentOptions{
 			Organization: qtest.MockOrg,
-			Repository:   mockRepos[0].Path,
+			Repository:   mockRepos[0].Repo,
 			Number:       tt.issueNumber,
 			CommentID:    tt.commentID,
 			Body:         "Updated",
@@ -882,9 +875,8 @@ func TestMockUpdateIssueComment2(t *testing.T) {
 	s := scm.NewMockSCMClient()
 	repo := &scm.Repository{
 		ID:    1,
-		OrgID: 1,
 		Owner: qtest.MockOrg,
-		Path:  qf.StudentRepoName("user"),
+		Repo:  qf.StudentRepoName("user"),
 	}
 	s.Repositories = map[uint64]*scm.Repository{
 		1: repo,
@@ -893,7 +885,7 @@ func TestMockUpdateIssueComment2(t *testing.T) {
 	body := "Issue Comment"
 	opt := &scm.IssueCommentOptions{
 		Organization: repo.Owner,
-		Repository:   repo.Path,
+		Repository:   repo.Repo,
 		Body:         body,
 	}
 
@@ -921,7 +913,7 @@ func TestMockCreateCourse(t *testing.T) {
 	wantRepos := []string{qf.InfoRepo, qf.AssignmentsRepo, qf.TestsRepo, qf.StudentRepoName(user)}
 	found := func(wantRepo string, repos []*scm.Repository) bool {
 		for _, repo := range repos {
-			if repo.Path == wantRepo {
+			if repo.Repo == wantRepo {
 				return true
 			}
 		}
@@ -1034,9 +1026,8 @@ func TestMockUpdateEnrollment(t *testing.T) {
 			wantRepos: map[uint64]*scm.Repository{
 				1: {
 					ID:    1,
-					Path:  qf.StudentRepoName(user),
+					Repo:  qf.StudentRepoName(user),
 					Owner: qtest.MockOrg,
-					OrgID: 1,
 				},
 			},
 			wantErr: false,
@@ -1059,8 +1050,7 @@ func TestMockRejectEnrollment(t *testing.T) {
 	repo := &scm.Repository{
 		ID:    1,
 		Owner: qtest.MockOrg,
-		Path:  "test-group",
-		OrgID: 1,
+		Repo:  "test-group",
 	}
 	s.Repositories = map[uint64]*scm.Repository{
 		1: repo,
@@ -1128,15 +1118,13 @@ func TestMockCreateGroup(t *testing.T) {
 	groupRepos := []*scm.Repository{
 		{
 			ID:    1,
-			Path:  paths[0],
+			Repo:  paths[0],
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 		{
 			ID:    2,
-			Path:  paths[1],
+			Repo:  paths[1],
 			Owner: qtest.MockOrg,
-			OrgID: 1,
 		},
 	}
 	tests := []struct {
@@ -1217,15 +1205,13 @@ func TestMockDeleteGroup(t *testing.T) {
 	repositories := []*scm.Repository{
 		{
 			ID:    1,
-			OrgID: 1,
 			Owner: qtest.MockOrg,
-			Path:  qf.StudentRepoName(user),
+			Repo:  qf.StudentRepoName(user),
 		},
 		{
 			ID:    2,
-			OrgID: 1,
 			Owner: qtest.MockOrg,
-			Path:  "a_group",
+			Repo:  "a_group",
 		},
 	}
 	s.Repositories = map[uint64]*scm.Repository{

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -91,11 +91,9 @@ func newSCMAppClient(ctx context.Context, logger *zap.SugaredLogger, config *Con
 // Repository represents a git remote repository.
 type Repository struct {
 	ID      uint64
-	Path    string
+	Repo    string
 	Owner   string // Only used by GitHub.
 	HTMLURL string // Repository website.
-	OrgID   uint64
-	Size    uint64
 }
 
 // Authorization stores information about user scopes

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -15,7 +15,7 @@ type SCM interface {
 	// Gets an organization.
 	GetOrganization(context.Context, *OrganizationOptions) (*qf.Organization, error)
 	// Get repositories within organization.
-	GetRepositories(context.Context, *qf.Organization) ([]*Repository, error)
+	GetRepositories(ctx context.Context, owner string) ([]*Repository, error)
 	// Returns true if there are no commits in the given repository
 	RepositoryIsEmpty(context.Context, *RepositoryOptions) bool
 	// UpdateGroupMembers adds or removes members of an existing group repository based on list of users in GroupOptions.

--- a/scm/scm_options.go
+++ b/scm/scm_options.go
@@ -52,24 +52,24 @@ func (opt OrganizationOptions) valid() bool {
 // Either ID or both Path and Owner fields must be set.
 type RepositoryOptions struct {
 	ID    uint64
-	Path  string
+	Repo  string
 	Owner string
 }
 
 func (opt RepositoryOptions) valid() bool {
-	return opt.ID > 0 || (opt.Path != "" && opt.Owner != "")
+	return opt.ID > 0 || (opt.Repo != "" && opt.Owner != "")
 }
 
 // CreateRepositoryOptions contains information on how a repository should be created.
 type CreateRepositoryOptions struct {
-	Organization string
-	Path         string
-	Private      bool
-	Permission   string // Default permission level for the given repo. Can be "read", "write", "admin", "none".
+	Owner      string
+	Repo       string
+	Private    bool
+	Permission string // Default permission level for the given repo. Can be "read", "write", "admin", "none".
 }
 
 func (opt CreateRepositoryOptions) valid() bool {
-	return opt.Organization != "" && opt.Path != ""
+	return opt.Owner != "" && opt.Repo != ""
 }
 
 // GroupOptions is used when creating or modifying a group.

--- a/web/courses_new.go
+++ b/web/courses_new.go
@@ -29,13 +29,13 @@ func (s *QuickFeedService) createCourse(ctx context.Context, sc scm.SCM, request
 			ScmOrganizationID: request.ScmOrganizationID,
 			ScmRepositoryID:   repo.ID,
 			HTMLURL:           repo.HTMLURL,
-			RepoType:          qf.RepoType(repo.Path),
+			RepoType:          qf.RepoType(repo.Repo),
 		}
 		if dbRepo.IsUserRepo() {
 			dbRepo.UserID = courseCreator.ID
 		}
 		if err := s.db.CreateRepository(&dbRepo); err != nil {
-			return nil, fmt.Errorf("failed to create database record for repository %s: %w", repo.Path, err)
+			return nil, fmt.Errorf("failed to create database record for repository %s: %w", repo.Repo, err)
 		}
 	}
 

--- a/web/hooks/installation.go
+++ b/web/hooks/installation.go
@@ -54,13 +54,13 @@ func (wh GitHubWebHook) handleInstallationCreated(event *github.InstallationEven
 			ScmOrganizationID: orgID,
 			ScmRepositoryID:   repo.ID,
 			HTMLURL:           repo.HTMLURL,
-			RepoType:          qf.RepoType(repo.Path),
+			RepoType:          qf.RepoType(repo.Repo),
 		}
 		if dbRepo.IsUserRepo() {
 			dbRepo.UserID = courseCreator.ID
 		}
 		if err := wh.db.CreateRepository(&dbRepo); err != nil {
-			wh.logger.Errorf("Could not create database repository %s: %v", repo.Path, err)
+			wh.logger.Errorf("Could not create database repository %s: %v", repo.Repo, err)
 			return
 		}
 	}


### PR DESCRIPTION
closes #1094 

also changes signature of GetRepositories as suggested in #1098, although it may be more sensible to remove it. `initDatabase` in `tasks_test.go` needs some rewriting if we remove it. 