### PR TITLE
Clean up SCM error messages and handling

### DIFF
--- a/internal/qtest/mock_data.go
+++ b/internal/qtest/mock_data.go
@@ -21,7 +21,7 @@ var MockCourses = []*qf.Course{
 		Year:                2017,
 		Tag:                 "Fall",
 		ScmOrganizationID:   2,
-		ScmOrganizationName: "DAT320",
+		ScmOrganizationName: "dat320",
 	},
 	{
 		Name:                "New Systems",
@@ -30,7 +30,7 @@ var MockCourses = []*qf.Course{
 		Year:                2019,
 		Tag:                 "Fall",
 		ScmOrganizationID:   3,
-		ScmOrganizationName: "DATx20-2019",
+		ScmOrganizationName: "dat1020-2019",
 	},
 	{
 		Name:                "Hyped Systems",

--- a/scm/github.go
+++ b/scm/github.go
@@ -61,9 +61,9 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 	}
 	if err != nil || gitOrg == nil {
 		return nil, SCMError{
-			Method:   "GetOrganization",
-			Message:  fmt.Sprintf("could not find github organization %s. Make sure it allows third party access.", orgNameOrID), // this message is logged, never sent to user
-			GitError: err,
+			Method:  "GetOrganization",
+			Message: fmt.Sprintf("could not find github organization %s. Make sure it allows third party access.", orgNameOrID), // this message is logged, never sent to user
+			Err:     err,
 		}
 	}
 
@@ -90,9 +90,9 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 		membership, _, err := s.client.Organizations.GetOrgMembership(ctx, opt.Username, org.ScmOrganizationName)
 		if err != nil {
 			return nil, SCMError{
-				Method:   "GetOrganization",
-				Message:  fmt.Sprintf("Failed to GetOrganization for (%q, %q)", opt.Username, org.ScmOrganizationName),
-				GitError: fmt.Errorf("failed to GetOrgMembership(%q, %q): %w", opt.Username, org.ScmOrganizationName, err),
+				Method:  "GetOrganization",
+				Message: fmt.Sprintf("Failed to GetOrganization for (%q, %q)", opt.Username, org.ScmOrganizationName),
+				Err:     fmt.Errorf("failed to GetOrgMembership(%q, %q): %w", opt.Username, org.ScmOrganizationName, err),
 			}
 		}
 		// membership role must be "admin", if not, return error (possibly to show user)
@@ -112,9 +112,9 @@ func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) (
 	repos, _, err := s.client.Repositories.ListByOrg(ctx, path, nil)
 	if err != nil {
 		return nil, SCMError{
-			GitError: err,
-			Method:   "GetRepositories",
-			Message:  fmt.Sprintf("failed to access repositories for organization %s", path),
+			Err:     err,
+			Method:  "GetRepositories",
+			Message: fmt.Sprintf("failed to access repositories for organization %s", path),
 		}
 	}
 	repositories := make([]*Repository, 0, len(repos))
@@ -284,9 +284,9 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 	oldUsers, _, err := s.client.Repositories.ListCollaborators(ctx, opt.Organization, opt.GroupName, nil)
 	if err != nil {
 		return SCMError{
-			GitError: err,
-			Method:   "UpdateGroupMembers",
-			Message:  fmt.Sprintf("failed to get members for %s/%s", opt.Organization, opt.GroupName),
+			Err:     err,
+			Method:  "UpdateGroupMembers",
+			Message: fmt.Sprintf("failed to get members for %s/%s", opt.Organization, opt.GroupName),
 		}
 	}
 
@@ -295,9 +295,9 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 		_, _, err = s.client.Repositories.AddCollaborator(ctx, opt.Organization, opt.GroupName, member, pushAccess)
 		if err != nil {
 			return SCMError{
-				GitError: err,
-				Method:   "UpdateGroupMembers",
-				Message:  fmt.Sprintf("failed to add user %s to repository %s", member, opt.GroupName),
+				Err:     err,
+				Method:  "UpdateGroupMembers",
+				Message: fmt.Sprintf("failed to add user %s to repository %s", member, opt.GroupName),
 			}
 		}
 	}
@@ -309,9 +309,9 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 			_, err = s.client.Repositories.RemoveCollaborator(ctx, opt.Organization, opt.GroupName, member)
 			if err != nil {
 				return SCMError{
-					GitError: err,
-					Method:   "UpdateGroupMembers",
-					Message:  fmt.Sprintf("failed to remove user %s from repository %s", member, opt.GroupName),
+					Err:     err,
+					Method:  "UpdateGroupMembers",
+					Message: fmt.Sprintf("failed to remove user %s from repository %s", member, opt.GroupName),
 				}
 			}
 		}
@@ -365,9 +365,9 @@ func (s *GithubSCM) createRepository(ctx context.Context, opt *CreateRepositoryO
 	})
 	if err != nil {
 		return nil, SCMError{
-			Method:   "CreateRepository",
-			Message:  fmt.Sprintf("failed to create repository %s, make sure it does not already exist", opt.Path),
-			GitError: err,
+			Method:  "CreateRepository",
+			Message: fmt.Sprintf("failed to create repository %s, make sure it does not already exist", opt.Path),
+			Err:     err,
 		}
 	}
 	s.logger.Debugf("CreateRepository: done creating %s", opt.Path)
@@ -385,9 +385,9 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions
 		repo, _, err := s.client.Repositories.GetByID(ctx, int64(opt.ID))
 		if err != nil {
 			return SCMError{
-				GitError: err,
-				Method:   "DeleteRepository",
-				Message:  fmt.Sprintf("failed to fetch repository %d: may not exists in the course organization", opt.ID),
+				Err:     err,
+				Method:  "DeleteRepository",
+				Message: fmt.Sprintf("failed to fetch repository %d: may not exists in the course organization", opt.ID),
 			}
 		}
 		opt.Path = repo.GetName()
@@ -396,9 +396,9 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions
 
 	if _, err := s.client.Repositories.Delete(ctx, opt.Owner, opt.Path); err != nil {
 		return SCMError{
-			GitError: err,
-			Method:   "DeleteRepository",
-			Message:  fmt.Sprintf("failed to delete repository %s", opt.Path),
+			Err:     err,
+			Method:  "DeleteRepository",
+			Message: fmt.Sprintf("failed to delete repository %s", opt.Path),
 		}
 	}
 	return nil

--- a/scm/github.go
+++ b/scm/github.go
@@ -96,7 +96,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 		}
 		// membership role must be "admin"
 		if membership.GetRole() != OrgOwner {
-			return nil, E(op, m, fmt.Errorf("%s is not an owner of organization %s: %w", opt.Username, org.ScmOrganizationName, ErrNotOwner))
+			return nil, E(op, m, fmt.Errorf("%s/%s: %w", org.ScmOrganizationName, opt.Username, ErrNotOwner))
 		}
 	}
 	return org, nil

--- a/scm/github.go
+++ b/scm/github.go
@@ -62,7 +62,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 	if err != nil || gitOrg == nil {
 		return nil, SCMError{
 			Method:  "GetOrganization",
-			Message: fmt.Sprintf("could not find github organization %s. Make sure it allows third party access.", orgNameOrID), // this message is logged, never sent to user
+			Message: fmt.Sprintf("could not find github organization %s. Make sure it allows third party access.", orgNameOrID),
 			Err:     err,
 		}
 	}
@@ -92,7 +92,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 			return nil, SCMError{
 				Method:  "GetOrganization",
 				Message: fmt.Sprintf("Failed to GetOrganization for (%q, %q)", opt.Username, org.ScmOrganizationName),
-				Err:     fmt.Errorf("failed to GetOrgMembership(%q, %q): %w", opt.Username, org.ScmOrganizationName, err),
+				Err:     err,
 			}
 		}
 		// membership role must be "admin", if not, return error (possibly to show user)

--- a/scm/github.go
+++ b/scm/github.go
@@ -61,7 +61,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 	}
 	if err != nil || gitOrg == nil {
 		return nil, SCMError{
-			Method:  "GetOrganization",
+			Op:      "GetOrganization",
 			Message: fmt.Sprintf("could not find github organization %s. Make sure it allows third party access.", orgNameOrID),
 			Err:     err,
 		}
@@ -90,7 +90,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 		membership, _, err := s.client.Organizations.GetOrgMembership(ctx, opt.Username, org.ScmOrganizationName)
 		if err != nil {
 			return nil, SCMError{
-				Method:  "GetOrganization",
+				Op:      "GetOrganization",
 				Message: fmt.Sprintf("Failed to GetOrganization for (%q, %q)", opt.Username, org.ScmOrganizationName),
 				Err:     err,
 			}
@@ -113,7 +113,7 @@ func (s *GithubSCM) GetRepositories(ctx context.Context, org *qf.Organization) (
 	if err != nil {
 		return nil, SCMError{
 			Err:     err,
-			Method:  "GetRepositories",
+			Op:      "GetRepositories",
 			Message: fmt.Sprintf("failed to access repositories for organization %s", path),
 		}
 	}
@@ -285,7 +285,7 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 	if err != nil {
 		return SCMError{
 			Err:     err,
-			Method:  "UpdateGroupMembers",
+			Op:      "UpdateGroupMembers",
 			Message: fmt.Sprintf("failed to get members for %s/%s", opt.Organization, opt.GroupName),
 		}
 	}
@@ -296,7 +296,7 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 		if err != nil {
 			return SCMError{
 				Err:     err,
-				Method:  "UpdateGroupMembers",
+				Op:      "UpdateGroupMembers",
 				Message: fmt.Sprintf("failed to add user %s to repository %s", member, opt.GroupName),
 			}
 		}
@@ -310,7 +310,7 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 			if err != nil {
 				return SCMError{
 					Err:     err,
-					Method:  "UpdateGroupMembers",
+					Op:      "UpdateGroupMembers",
 					Message: fmt.Sprintf("failed to remove user %s from repository %s", member, opt.GroupName),
 				}
 			}
@@ -365,7 +365,7 @@ func (s *GithubSCM) createRepository(ctx context.Context, opt *CreateRepositoryO
 	})
 	if err != nil {
 		return nil, SCMError{
-			Method:  "CreateRepository",
+			Op:      "CreateRepository",
 			Message: fmt.Sprintf("failed to create repository %s, make sure it does not already exist", opt.Path),
 			Err:     err,
 		}
@@ -386,7 +386,7 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions
 		if err != nil {
 			return SCMError{
 				Err:     err,
-				Method:  "DeleteRepository",
+				Op:      "DeleteRepository",
 				Message: fmt.Sprintf("failed to fetch repository %d: may not exists in the course organization", opt.ID),
 			}
 		}
@@ -397,7 +397,7 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions
 	if _, err := s.client.Repositories.Delete(ctx, opt.Owner, opt.Path); err != nil {
 		return SCMError{
 			Err:     err,
-			Method:  "DeleteRepository",
+			Op:      "DeleteRepository",
 			Message: fmt.Sprintf("failed to delete repository %s", opt.Path),
 		}
 	}

--- a/scm/github_issues.go
+++ b/scm/github_issues.go
@@ -21,7 +21,7 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	issue, _, err := s.client.Issues.Create(ctx, opt.Organization, opt.Repository, newIssue)
 	if err != nil {
 		return nil, SCMError{
-			Method:  "CreateIssue",
+			Op:      "CreateIssue",
 			Message: fmt.Sprintf("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository),
 			Err:     err,
 		}
@@ -45,7 +45,7 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	issue, _, err := s.client.Issues.Edit(ctx, opt.Organization, opt.Repository, opt.Number, issueReq)
 	if err != nil {
 		return nil, SCMError{
-			Method:  "UpdateIssue",
+			Op:      "UpdateIssue",
 			Message: fmt.Sprintf("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			Err:     err,
 		}
@@ -62,7 +62,7 @@ func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number
 	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
 	if err != nil {
 		return nil, SCMError{
-			Method:  "GetIssue",
+			Op:      "GetIssue",
 			Message: fmt.Sprintf("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path),
 			Err:     err,
 		}
@@ -78,7 +78,7 @@ func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*I
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
 	if err != nil {
 		return nil, SCMError{
-			Method:  "GetIssues",
+			Op:      "GetIssues",
 			Message: fmt.Sprintf("failed to get issues for %s/%s", opt.Owner, opt.Path),
 			Err:     err,
 		}
@@ -98,7 +98,7 @@ func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	createdComment, _, err := s.client.Issues.CreateComment(ctx, opt.Organization, opt.Repository, opt.Number, &github.IssueComment{Body: &opt.Body})
 	if err != nil {
 		return 0, SCMError{
-			Method:  "CreateIssueComment",
+			Op:      "CreateIssueComment",
 			Message: fmt.Sprintf("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			Err:     err,
 		}
@@ -113,7 +113,7 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	}
 	if _, _, err := s.client.Issues.EditComment(ctx, opt.Organization, opt.Repository, opt.CommentID, &github.IssueComment{Body: &opt.Body}); err != nil {
 		return SCMError{
-			Method:  "UpdateIssueComment",
+			Op:      "UpdateIssueComment",
 			Message: fmt.Sprintf("failed to edit comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository),
 			Err:     err,
 		}
@@ -131,7 +131,7 @@ func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersO
 	}
 	if _, _, err := s.client.PullRequests.RequestReviewers(ctx, opt.Organization, opt.Repository, opt.Number, reviewersRequest); err != nil {
 		return SCMError{
-			Method:  "RequestReviewers",
+			Op:      "RequestReviewers",
 			Message: fmt.Sprintf("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			Err:     err,
 		}

--- a/scm/github_issues.go
+++ b/scm/github_issues.go
@@ -9,8 +9,10 @@ import (
 
 // CreateIssue implements the SCM interface
 func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue, error) {
+	const op Op = "CreateIssue"
+	m := M("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository)
 	if !opt.valid() {
-		return nil, fmt.Errorf("missing fields: %+v", opt)
+		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	newIssue := &github.IssueRequest{
 		Title:     &opt.Title,
@@ -20,11 +22,7 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	}
 	issue, _, err := s.client.Issues.Create(ctx, opt.Organization, opt.Repository, newIssue)
 	if err != nil {
-		return nil, SCMError{
-			Op:      "CreateIssue",
-			Message: fmt.Sprintf("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository),
-			Err:     err,
-		}
+		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	s.logger.Debugf("Created issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository)
 	return toIssue(issue), nil
@@ -32,8 +30,10 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 
 // UpdateIssue implements the SCM interface
 func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue, error) {
+	const op Op = "UpdateIssue"
+	m := M("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository)
 	if !opt.valid() {
-		return nil, fmt.Errorf("missing fields: %+v", opt)
+		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	issueReq := &github.IssueRequest{
 		Title:     &opt.Title,
@@ -44,11 +44,7 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	}
 	issue, _, err := s.client.Issues.Edit(ctx, opt.Organization, opt.Repository, opt.Number, issueReq)
 	if err != nil {
-		return nil, SCMError{
-			Op:      "UpdateIssue",
-			Message: fmt.Sprintf("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			Err:     err,
-		}
+		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	s.logger.Debugf("Updated issue number %d on %s/%s", opt.Number, opt.Organization, opt.Repository)
 	return toIssue(issue), nil
@@ -56,32 +52,28 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 
 // GetIssue implements the SCM interface
 func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number int) (*Issue, error) {
+	const op Op = "GetIssue"
+	m := M("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path)
 	if !opt.valid() {
-		return nil, fmt.Errorf("missing fields: %+v", opt)
+		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
 	if err != nil {
-		return nil, SCMError{
-			Op:      "GetIssue",
-			Message: fmt.Sprintf("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path),
-			Err:     err,
-		}
+		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	return toIssue(issue), nil
 }
 
 // GetIssues implements the SCM interface
 func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Issue, error) {
+	const op Op = "GetIssues"
+	m := M("failed to get issues for %s/%s", opt.Owner, opt.Path)
 	if !opt.valid() {
-		return nil, fmt.Errorf("missing fields: %+v", opt)
+		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
 	if err != nil {
-		return nil, SCMError{
-			Op:      "GetIssues",
-			Message: fmt.Sprintf("failed to get issues for %s/%s", opt.Owner, opt.Path),
-			Err:     err,
-		}
+		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	var issues []*Issue
 	for _, issue := range issueList {
@@ -92,49 +84,43 @@ func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*I
 
 // CreateIssueComment implements the SCM interface
 func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOptions) (int64, error) {
+	const op Op = "CreateIssueComment"
+	m := M("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository)
 	if !opt.valid() {
-		return 0, fmt.Errorf("missing fields: %+v", opt)
+		return 0, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	createdComment, _, err := s.client.Issues.CreateComment(ctx, opt.Organization, opt.Repository, opt.Number, &github.IssueComment{Body: &opt.Body})
 	if err != nil {
-		return 0, SCMError{
-			Op:      "CreateIssueComment",
-			Message: fmt.Sprintf("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			Err:     err,
-		}
+		return 0, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	return createdComment.GetID(), nil
 }
 
 // UpdateIssueComment implements the SCM interface
 func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOptions) error {
+	const op Op = "UpdateIssueComment"
+	m := M("failed to update comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository)
 	if !opt.valid() {
-		return fmt.Errorf("missing fields: %+v", opt)
+		return E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	if _, _, err := s.client.Issues.EditComment(ctx, opt.Organization, opt.Repository, opt.CommentID, &github.IssueComment{Body: &opt.Body}); err != nil {
-		return SCMError{
-			Op:      "UpdateIssueComment",
-			Message: fmt.Sprintf("failed to edit comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository),
-			Err:     err,
-		}
+		return E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	return nil
 }
 
 // RequestReviewers implements the SCM interface
 func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersOptions) error {
+	const op Op = "RequestReviewers"
+	m := M("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository)
 	if !opt.valid() {
-		return fmt.Errorf("missing fields: %+v", opt)
+		return E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
 	reviewersRequest := github.ReviewersRequest{
 		Reviewers: opt.Reviewers,
 	}
 	if _, _, err := s.client.PullRequests.RequestReviewers(ctx, opt.Organization, opt.Repository, opt.Number, reviewersRequest); err != nil {
-		return SCMError{
-			Op:      "RequestReviewers",
-			Message: fmt.Sprintf("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			Err:     err,
-		}
+		return E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
 	return nil
 }

--- a/scm/github_issues.go
+++ b/scm/github_issues.go
@@ -20,7 +20,7 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	}
 	issue, _, err := s.client.Issues.Create(ctx, opt.Organization, opt.Repository, newIssue)
 	if err != nil {
-		return nil, ErrFailedSCM{
+		return nil, SCMError{
 			Method:   "CreateIssue",
 			Message:  fmt.Sprintf("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository),
 			GitError: err,
@@ -44,7 +44,7 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	}
 	issue, _, err := s.client.Issues.Edit(ctx, opt.Organization, opt.Repository, opt.Number, issueReq)
 	if err != nil {
-		return nil, ErrFailedSCM{
+		return nil, SCMError{
 			Method:   "UpdateIssue",
 			Message:  fmt.Sprintf("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			GitError: err,
@@ -61,7 +61,7 @@ func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number
 	}
 	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
 	if err != nil {
-		return nil, ErrFailedSCM{
+		return nil, SCMError{
 			Method:   "GetIssue",
 			Message:  fmt.Sprintf("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path),
 			GitError: err,
@@ -77,7 +77,7 @@ func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*I
 	}
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
 	if err != nil {
-		return nil, ErrFailedSCM{
+		return nil, SCMError{
 			Method:   "GetIssues",
 			Message:  fmt.Sprintf("failed to get issues for %s/%s", opt.Owner, opt.Path),
 			GitError: err,
@@ -97,7 +97,7 @@ func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	}
 	createdComment, _, err := s.client.Issues.CreateComment(ctx, opt.Organization, opt.Repository, opt.Number, &github.IssueComment{Body: &opt.Body})
 	if err != nil {
-		return 0, ErrFailedSCM{
+		return 0, SCMError{
 			Method:   "CreateIssueComment",
 			Message:  fmt.Sprintf("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			GitError: err,
@@ -112,7 +112,7 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 		return fmt.Errorf("missing fields: %+v", opt)
 	}
 	if _, _, err := s.client.Issues.EditComment(ctx, opt.Organization, opt.Repository, opt.CommentID, &github.IssueComment{Body: &opt.Body}); err != nil {
-		return ErrFailedSCM{
+		return SCMError{
 			Method:   "UpdateIssueComment",
 			Message:  fmt.Sprintf("failed to edit comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository),
 			GitError: err,
@@ -130,7 +130,7 @@ func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersO
 		Reviewers: opt.Reviewers,
 	}
 	if _, _, err := s.client.PullRequests.RequestReviewers(ctx, opt.Organization, opt.Repository, opt.Number, reviewersRequest); err != nil {
-		return ErrFailedSCM{
+		return SCMError{
 			Method:   "RequestReviewers",
 			Message:  fmt.Sprintf("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
 			GitError: err,

--- a/scm/github_issues.go
+++ b/scm/github_issues.go
@@ -21,9 +21,9 @@ func (s *GithubSCM) CreateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	issue, _, err := s.client.Issues.Create(ctx, opt.Organization, opt.Repository, newIssue)
 	if err != nil {
 		return nil, SCMError{
-			Method:   "CreateIssue",
-			Message:  fmt.Sprintf("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository),
-			GitError: err,
+			Method:  "CreateIssue",
+			Message: fmt.Sprintf("failed to create issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository),
+			Err:     err,
 		}
 	}
 	s.logger.Debugf("Created issue %q on %s/%s", opt.Title, opt.Organization, opt.Repository)
@@ -45,9 +45,9 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 	issue, _, err := s.client.Issues.Edit(ctx, opt.Organization, opt.Repository, opt.Number, issueReq)
 	if err != nil {
 		return nil, SCMError{
-			Method:   "UpdateIssue",
-			Message:  fmt.Sprintf("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			GitError: err,
+			Method:  "UpdateIssue",
+			Message: fmt.Sprintf("failed to update issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
+			Err:     err,
 		}
 	}
 	s.logger.Debugf("Updated issue number %d on %s/%s", opt.Number, opt.Organization, opt.Repository)
@@ -62,9 +62,9 @@ func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number
 	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
 	if err != nil {
 		return nil, SCMError{
-			Method:   "GetIssue",
-			Message:  fmt.Sprintf("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path),
-			GitError: err,
+			Method:  "GetIssue",
+			Message: fmt.Sprintf("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path),
+			Err:     err,
 		}
 	}
 	return toIssue(issue), nil
@@ -78,9 +78,9 @@ func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*I
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
 	if err != nil {
 		return nil, SCMError{
-			Method:   "GetIssues",
-			Message:  fmt.Sprintf("failed to get issues for %s/%s", opt.Owner, opt.Path),
-			GitError: err,
+			Method:  "GetIssues",
+			Message: fmt.Sprintf("failed to get issues for %s/%s", opt.Owner, opt.Path),
+			Err:     err,
 		}
 	}
 	var issues []*Issue
@@ -98,9 +98,9 @@ func (s *GithubSCM) CreateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	createdComment, _, err := s.client.Issues.CreateComment(ctx, opt.Organization, opt.Repository, opt.Number, &github.IssueComment{Body: &opt.Body})
 	if err != nil {
 		return 0, SCMError{
-			Method:   "CreateIssueComment",
-			Message:  fmt.Sprintf("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			GitError: err,
+			Method:  "CreateIssueComment",
+			Message: fmt.Sprintf("failed to create comment for issue #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
+			Err:     err,
 		}
 	}
 	return createdComment.GetID(), nil
@@ -113,9 +113,9 @@ func (s *GithubSCM) UpdateIssueComment(ctx context.Context, opt *IssueCommentOpt
 	}
 	if _, _, err := s.client.Issues.EditComment(ctx, opt.Organization, opt.Repository, opt.CommentID, &github.IssueComment{Body: &opt.Body}); err != nil {
 		return SCMError{
-			Method:   "UpdateIssueComment",
-			Message:  fmt.Sprintf("failed to edit comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository),
-			GitError: err,
+			Method:  "UpdateIssueComment",
+			Message: fmt.Sprintf("failed to edit comment %d on issue #%d on %s/%s", opt.CommentID, opt.Number, opt.Organization, opt.Repository),
+			Err:     err,
 		}
 	}
 	return nil
@@ -131,9 +131,9 @@ func (s *GithubSCM) RequestReviewers(ctx context.Context, opt *RequestReviewersO
 	}
 	if _, _, err := s.client.PullRequests.RequestReviewers(ctx, opt.Organization, opt.Repository, opt.Number, reviewersRequest); err != nil {
 		return SCMError{
-			Method:   "RequestReviewers",
-			Message:  fmt.Sprintf("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
-			GitError: err,
+			Method:  "RequestReviewers",
+			Message: fmt.Sprintf("failed to request reviewers for pull request #%d on %s/%s", opt.Number, opt.Organization, opt.Repository),
+			Err:     err,
 		}
 	}
 	return nil

--- a/scm/github_mock.go
+++ b/scm/github_mock.go
@@ -84,6 +84,8 @@ func NewMockedGithubSCMClient(logger *zap.SugaredLogger, opts ...MockOption) *Mo
 			}
 		}
 	}
+	// To assist with debugging; this may be useful
+	// logger.Debug(s.DumpState())
 
 	getOrganizationsByIDHandler := WithRequestMatchHandler(
 		getOrganizationsByID,

--- a/scm/github_mock_opts.go
+++ b/scm/github_mock_opts.go
@@ -163,10 +163,20 @@ func WithIssues(issues map[string]map[string][]github.Issue) MockOption {
 	}
 }
 
-func WithMockOrgs() MockOption {
+// WithMockOrgs sets up mock data with course organizations and members, if any.
+// The first member in the list is the owner of the organization.
+func WithMockOrgs(members ...string) MockOption {
 	return func(opts *mockOptions) {
 		for _, course := range qtest.MockCourses {
-			opts.orgs = append(opts.orgs, toOrg(course))
+			ghOrg := toOrg(course)
+			opts.orgs = append(opts.orgs, ghOrg)
+			for i, member := range members {
+				if i == 0 {
+					opts.members = append(opts.members, github.Membership{Organization: &ghOrg, Role: github.String(OrgOwner), User: &github.User{Login: github.String(member)}})
+				} else {
+					opts.members = append(opts.members, github.Membership{Organization: &ghOrg, Role: github.String(OrgMember), User: &github.User{Login: github.String(member)}})
+				}
+			}
 		}
 	}
 }

--- a/scm/github_mock_test.go
+++ b/scm/github_mock_test.go
@@ -79,7 +79,7 @@ var reviewers = map[string]map[string]map[int]github.ReviewersRequest{
 	},
 }
 
-func TestMustReplaceArgs(t *testing.T) {
+func TestReplaceArgs(t *testing.T) {
 	tests := []struct {
 		name    string
 		pattern string
@@ -96,7 +96,7 @@ func TestMustReplaceArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := replaceArgs(tt.pattern, tt.args...); got != tt.want {
-				t.Errorf("mustReplaceArgs() = %v, want %v", got, tt.want)
+				t.Errorf("replaceArgs(%q) = %v, want %v", tt.pattern, got, tt.want)
 			}
 		})
 	}

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -29,6 +29,11 @@ var (
 )
 
 var (
+	member = &github.Membership{Role: github.String(OrgMember)}
+	admin  = &github.Membership{Role: github.String(OrgOwner)}
+)
+
+var (
 	// RepoPaths maps from QuickFeed repository path names to a boolean indicating
 	// whether or not the repository should be create as public or private.
 	RepoPaths = map[string]bool{

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -1,7 +1,6 @@
 package scm
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/google/go-github/v62/github"
@@ -39,28 +38,7 @@ var (
 	}
 	repoNames = fmt.Sprintf("(%s, %s, %s)",
 		qf.InfoRepo, qf.AssignmentsRepo, qf.TestsRepo)
-
-	// ErrNotMember indicates that the requested organization exists, but the current user
-	// is not its member.
-	ErrNotMember = errors.New("user is not a member of the organization")
-	// ErrAlreadyExists indicates that one or more QuickFeed repositories
-	// already exists for the directory (or GitHub organization).
-	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
 )
-
-// ErrFailedSCM is returned to provide detailed information
-// to user about source of the error and possible solution
-type ErrFailedSCM struct {
-	Method   string
-	Message  string
-	GitError error
-}
-
-// Error message includes name of the failed method and the original error message
-// from GitHub, to make it suitable for informative back-end logging
-func (e ErrFailedSCM) Error() string {
-	return "github method " + e.Method + " failed: " + e.GitError.Error() + "\n" + e.Message
-}
 
 // isDirty returns true if the list of provided repositories contains
 // any of the repositories that QuickFeed wants to create.

--- a/scm/manager_mock.go
+++ b/scm/manager_mock.go
@@ -16,8 +16,13 @@ func MockManager(t *testing.T, opts ...MockOption) *Manager {
 	t.Helper()
 	env.SetFakeProvider(t)
 	sc := NewMockedGithubSCMClient(qtest.Logger(t), opts...)
+	// We reuse the same github mock client for all organizations.
+	scms := make(map[string]SCM)
+	for _, org := range sc.orgs {
+		scms[*org.Login] = sc
+	}
 	return &Manager{
-		scms:   map[string]SCM{qtest.MockOrg: sc},
+		scms:   scms,
 		Config: &Config{"qfClientID", "qfClientSecret", &app.Config{}},
 	}
 }

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -1,0 +1,26 @@
+package scm
+
+import "errors"
+
+var (
+	// ErrNotMember indicates that the requested organization exists, but the current user
+	// is not its member.
+	ErrNotMember = errors.New("user is not a member of the organization")
+	// ErrAlreadyExists indicates that one or more QuickFeed repositories
+	// already exists for the directory (or GitHub organization).
+	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
+)
+
+// ErrFailedSCM is returned to provide detailed information
+// to user about source of the error and possible solution
+type ErrFailedSCM struct {
+	Method   string
+	Message  string
+	GitError error
+}
+
+// Error message includes name of the failed method and the original error message
+// from GitHub, to make it suitable for informative back-end logging
+func (e ErrFailedSCM) Error() string {
+	return "github method " + e.Method + " failed: " + e.GitError.Error() + "\n" + e.Message
+}

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -6,25 +6,78 @@ import (
 )
 
 var (
-	// ErrNotMember indicates that the requested organization exists, but the current user
-	// is not its member.
-	ErrNotMember = errors.New("user is not a member of the organization")
-	// ErrAlreadyExists indicates that one or more QuickFeed repositories
-	// already exists for the directory (or GitHub organization).
-	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
+	// ErrNotFound indicates that the user is not member of the organization.
+	ErrNotMember = errors.New("not a member of the organization")
+	// ErrNotOwner indicates that the user is not an owner of the organization.
+	ErrNotOwner = errors.New("not an owner of the organization")
+	// ErrAlreadyExists indicates that one or more QuickFeed repositories already exist in the organization.
+	ErrAlreadyExists = errors.New("course repositories already exist")
 )
 
-// Op describes an operation, such as "GetOrganization".
-type Op string
-
-// SCMError is returned to provide detailed information
-// to user about source of the error and possible solution
+// SCMError holds the operation, user error message and the original error.
 type SCMError struct {
-	Op      Op
-	Message string
-	Err     error
+	op      Op
+	userErr Msg
+	err     error
 }
 
-func (e SCMError) Error() string {
-	return fmt.Sprintf("scm.%s: %v", e.Op, e.Message)
+var _ error = (*SCMError)(nil)
+
+type (
+	// Op describes an operation, such as "GetOrganization".
+	Op string
+	// Msg is the error message to be displayed to the user.
+	Msg string
+)
+
+func M(format string, a ...interface{}) Msg {
+	return Msg(fmt.Sprintf(format, a...))
+}
+
+func E(args ...interface{}) error {
+	if len(args) == 0 {
+		panic("call to scm.E with no arguments")
+	}
+	e := &SCMError{}
+	for _, arg := range args {
+		switch arg := arg.(type) {
+		case Op:
+			e.op = arg
+		case Msg:
+			e.userErr = arg
+		case *SCMError:
+			e.err = arg
+		case string:
+			e.err = errors.New(arg)
+		case error:
+			e.err = arg
+		}
+	}
+	return e
+}
+
+// Error returns the error message to be logged.
+func (e *SCMError) Error() string {
+	return fmt.Sprintf("scm.%s: %v", e.op, e.err)
+}
+
+func (e *SCMError) Unwrap() error {
+	return e.err
+}
+
+// UserError returns the error message to be displayed to the user.
+// It returns the first error in the chain of user errors.
+func (e *SCMError) UserError() error {
+	return errors.New(string(e.userErr))
+}
+
+// AllUserErrors returns all user errors in the error chain.
+func (e *SCMError) AllUserErrors() error {
+	err := errors.New(string(e.userErr))
+	var se *SCMError
+	for errors.As(e.err, &se) {
+		err = fmt.Errorf("%s: %w", err, errors.New(string(se.userErr)))
+		e = se
+	}
+	return err
 }

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -7,9 +7,9 @@ import (
 
 var (
 	// ErrNotFound indicates that the user is not member of the organization.
-	ErrNotMember = errors.New("not a member of the organization")
+	ErrNotMember = errors.New("not a member of organization")
 	// ErrNotOwner indicates that the user is not an owner of the organization.
-	ErrNotOwner = errors.New("not an owner of the organization")
+	ErrNotOwner = errors.New("not an owner of organization")
 	// ErrAlreadyExists indicates that one or more QuickFeed repositories already exist in the organization.
 	ErrAlreadyExists = errors.New("course repositories already exist")
 )

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -45,9 +45,7 @@ func M(format string, a ...interface{}) error {
 // E creates a new SCM error with the given operation, error, and user error.
 // The error message is constructed as "scm.<op>: <err>".
 // The user error can be constructed with the M function.
-// If more than one SCMError or UserError is passed, these are chained.
-// However, if more than one other error is added, only the last one is kept.
-// TODO (This limitation is temporary because too many tests and error messages would need to be updated.)
+// If more than one errors are passed, these are chained.
 // If no arguments are passed, E panics.
 func E(args ...interface{}) error {
 	if len(args) == 0 {
@@ -65,8 +63,7 @@ func E(args ...interface{}) error {
 		case string:
 			e.add(errors.New(arg))
 		case error:
-			// e.add(arg)
-			e.err = arg
+			e.add(arg)
 		}
 	}
 	return e
@@ -76,7 +73,7 @@ func (e *SCMError) add(err error) {
 	if e.err == nil {
 		e.err = err
 	} else {
-		e.err = fmt.Errorf("%s: %w", e.err, err)
+		e.err = fmt.Errorf("%w: %w", e.err, err)
 	}
 }
 

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -1,6 +1,9 @@
 package scm
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrNotMember indicates that the requested organization exists, but the current user
@@ -11,16 +14,17 @@ var (
 	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
 )
 
+// Op describes an operation, such as "GetOrganization".
+type Op string
+
 // SCMError is returned to provide detailed information
 // to user about source of the error and possible solution
 type SCMError struct {
-	Method  string
+	Op      Op
 	Message string
 	Err     error
 }
 
-// Error message includes name of the failed method and the original error message
-// from GitHub, to make it suitable for informative back-end logging
 func (e SCMError) Error() string {
-	return "github method " + e.Method + " failed: " + e.Err.Error() + "\n" + e.Message
+	return fmt.Sprintf("scm.%s: %v", e.Op, e.Message)
 }

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -10,8 +10,8 @@ var (
 	ErrNotMember = errors.New("not a member of organization")
 	// ErrNotOwner indicates that the user is not an owner of the organization.
 	ErrNotOwner = errors.New("not an owner of organization")
-	// ErrAlreadyExists indicates that one or more QuickFeed repositories already exist in the organization.
-	ErrAlreadyExists = errors.New("course repositories already exist")
+	// ErrAlreadyExists indicates that a repository already exist in the organization.
+	ErrAlreadyExists = errors.New("already exist")
 )
 
 // SCMError holds the operation, user error message and the original error.
@@ -30,16 +30,20 @@ type Op string
 
 // UserError is an error that is meant to be displayed to the user.
 type UserError struct {
-	s string
+	e error
 }
 
 func (e *UserError) Error() string {
-	return e.s
+	return e.e.Error()
+}
+
+func (e *UserError) Unwrap() error {
+	return e.e
 }
 
 // M creates a new user error with the given format string.
 func M(format string, a ...interface{}) error {
-	return &UserError{fmt.Sprintf(format, a...)}
+	return &UserError{fmt.Errorf(format, a...)}
 }
 
 // E creates a new SCM error with the given operation, error, and user error.

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -11,9 +11,9 @@ var (
 	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
 )
 
-// ErrFailedSCM is returned to provide detailed information
+// SCMError is returned to provide detailed information
 // to user about source of the error and possible solution
-type ErrFailedSCM struct {
+type SCMError struct {
 	Method   string
 	Message  string
 	GitError error
@@ -21,6 +21,6 @@ type ErrFailedSCM struct {
 
 // Error message includes name of the failed method and the original error message
 // from GitHub, to make it suitable for informative back-end logging
-func (e ErrFailedSCM) Error() string {
+func (e SCMError) Error() string {
 	return "github method " + e.Method + " failed: " + e.GitError.Error() + "\n" + e.Message
 }

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -14,13 +14,13 @@ var (
 // SCMError is returned to provide detailed information
 // to user about source of the error and possible solution
 type SCMError struct {
-	Method   string
-	Message  string
-	GitError error
+	Method  string
+	Message string
+	Err     error
 }
 
 // Error message includes name of the failed method and the original error message
 // from GitHub, to make it suitable for informative back-end logging
 func (e SCMError) Error() string {
-	return "github method " + e.Method + " failed: " + e.GitError.Error() + "\n" + e.Message
+	return "github method " + e.Method + " failed: " + e.Err.Error() + "\n" + e.Message
 }

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -43,6 +43,12 @@ func M(format string, a ...interface{}) error {
 	return &userError{fmt.Sprintf(format, a...)}
 }
 
+// E creates a new SCM error with the given operation, error, and user error.
+// The error message is constructed as "scm.<op>: <err>".
+// The user error can be constructed with the M function.
+// If more than one error (or user error) is passed, only the last one is kept.
+// If an SCMError itself is passed, it is used as the error.
+// If no arguments are passed, E panics.
 func E(args ...interface{}) error {
 	if len(args) == 0 {
 		panic("call to scm.E with no arguments")

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -40,7 +40,7 @@ func IgnoreURLPort() cmp.Option {
 func TestErrorGetOrganization(t *testing.T) {
 	const wantErrPrefix = "scm.GetOrganization: failed to get organization: "
 	const wantErrPrefix2 = "scm.GetOrganization: foo: course repositories already exist"
-	wantErrPrefix3 := "scm.GetOrganization: meling is not an owner of organization bar: " + ErrNotOwner.Error()
+	wantErrPrefix3 := "scm.GetOrganization: bar/meling: " + ErrNotOwner.Error()
 	const wantUserErrPrefix = "failed to get organization"
 	const wantUserErrSuffix = ": permission denied for "
 	const wantUserErrPrefix2 = "course repositories (info, assignments, tests) already exist for "
@@ -219,7 +219,7 @@ func TestErrorCreateCourse(t *testing.T) {
 		{
 			name:        "CompleteRequest/NotOwner",
 			opt:         &CourseOptions{OrganizationID: 456, CourseCreator: "jostein"},
-			wantErr:     "scm.GetOrganization: jostein is not an owner of organization bar: " + ErrNotOwner.Error(),
+			wantErr:     "scm.GetOrganization: bar/jostein: " + ErrNotOwner.Error(),
 			wantUserErr: "bar: permission denied for jostein",
 		},
 		{

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -1,0 +1,735 @@
+package scm
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/go-github/v62/github"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+)
+
+// IgnoreURLPort returns a cmp.Option that compares URLs in strings ignoring port numbers.
+func IgnoreURLPort() cmp.Option {
+	return cmp.Options{
+		cmp.Transformer("RemoveURLPort", func(s string) string {
+			parts := strings.Fields(s)
+			for i, part := range parts {
+				if strings.HasPrefix(part, "http://") || strings.HasPrefix(part, "https://") {
+					u, err := url.Parse(part)
+					if err != nil {
+						continue // ignore invalid URLs
+					}
+					// Remove the port number
+					u.Host = strings.Split(u.Host, ":")[0]
+					parts[i] = u.String()
+				}
+			}
+			return strings.Join(parts, " ")
+		}),
+		// Default equality check for other types of fields
+		cmpopts.EquateEmpty(),
+	}
+}
+
+func TestErrorGetOrganization(t *testing.T) {
+	const wantErrPrefix = "scm.GetOrganization: failed to get organization: "
+	const wantErrPrefix2 = "scm.GetOrganization: foo: course repositories already exist"
+	wantErrPrefix3 := "scm.GetOrganization: meling is not an owner of organization bar: " + ErrNotOwner.Error()
+	const wantUserErrPrefix = "failed to get organization"
+	const wantUserErrSuffix = ": permission denied for "
+	const wantUserErrPrefix2 = "course repositories (info, assignments, tests) already exist for "
+
+	tests := []struct {
+		name        string
+		opt         *OrganizationOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &OrganizationOptions{},
+			wantErr:     "scm.GetOrganization: missing fields: {ID:0 Name: Username: NewCourse:false}",
+			wantUserErr: wantUserErrPrefix,
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{ID: 789},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:61390/organizations/789: 404  []",
+			wantUserErr: wantUserErrPrefix + " by ID: 789",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{ID: 789, NewCourse: true},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:61730/organizations/789: 404  []",
+			wantUserErr: wantUserErrPrefix + " by ID: 789",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{ID: 789, Username: "meling"},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1/organizations/789: 404  []",
+			wantUserErr: wantUserErrPrefix + " by ID: 789",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{Name: "baz"},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:49915/orgs/baz: 404  []",
+			wantUserErr: wantUserErrPrefix + " baz",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{Name: "baz", NewCourse: true},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:49915/orgs/baz: 404  []",
+			wantUserErr: wantUserErrPrefix + " baz",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{Name: "baz", Username: "meling"},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:49915/orgs/baz: 404  []",
+			wantUserErr: wantUserErrPrefix + " baz",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &OrganizationOptions{Name: "baz", NewCourse: true, Username: "meling"},
+			wantErr:     wantErrPrefix + "GET http://127.0.0.1:51062/orgs/baz: 404  []",
+			wantUserErr: wantUserErrPrefix + " baz",
+		},
+		{
+			name:        "CompleteRequest/AlreadyExists",
+			opt:         &OrganizationOptions{ID: 123, NewCourse: true},
+			wantErr:     wantErrPrefix2,
+			wantUserErr: wantUserErrPrefix2 + "foo",
+		},
+		{
+			name:        "CompleteRequest/AlreadyExists",
+			opt:         &OrganizationOptions{Name: "foo", NewCourse: true},
+			wantErr:     wantErrPrefix2,
+			wantUserErr: wantUserErrPrefix2 + "foo",
+		},
+		{
+			name:        "CompleteRequest/AlreadyExists",
+			opt:         &OrganizationOptions{Name: "foo", NewCourse: true, Username: "meling"},
+			wantErr:     wantErrPrefix2,
+			wantUserErr: wantUserErrPrefix2 + "foo",
+		},
+		{
+			name:        "CompleteRequest/NotMember",
+			opt:         &OrganizationOptions{ID: 456, Username: "jostein"},
+			wantErr:     "scm.GetOrganization: failed to get membership: GET http://127.0.0.1:62169/orgs/bar/memberships/jostein: 404  []",
+			wantUserErr: "bar" + wantUserErrSuffix + "jostein",
+		},
+		{
+			name:        "CompleteRequest/NotMember",
+			opt:         &OrganizationOptions{Name: "bar", Username: "jostein"},
+			wantErr:     "scm.GetOrganization: failed to get membership: GET http://127.0.0.1:62169/orgs/bar/memberships/jostein: 404  []",
+			wantUserErr: "bar" + wantUserErrSuffix + "jostein",
+		},
+		{
+			name:        "CompleteRequest/OnlyMemberNotOwner",
+			opt:         &OrganizationOptions{ID: 456, Username: "meling"},
+			wantErr:     wantErrPrefix3,
+			wantUserErr: "bar" + wantUserErrSuffix + "meling",
+		},
+		{
+			name:        "CompleteRequest/OnlyMemberNotOwner",
+			opt:         &OrganizationOptions{Name: "bar", Username: "meling"},
+			wantErr:     wantErrPrefix3,
+			wantUserErr: "bar" + wantUserErrSuffix + "meling",
+		},
+		{
+			name:        "CompleteRequest/OnlyMemberNotOwner",
+			opt:         &OrganizationOptions{Name: "bar", NewCourse: true, Username: "meling"},
+			wantErr:     wantErrPrefix3,
+			wantUserErr: "bar" + wantUserErrSuffix + "meling",
+		},
+		{
+			name:        "CompleteRequest/Success",
+			opt:         &OrganizationOptions{Name: "foo", Username: "meling"},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"ID", "Name", "Username", "NewCourse"}, tt.opt.ID, tt.opt.Name, tt.opt.Username, tt.opt.NewCourse)
+		t.Run(name, func(t *testing.T) {
+			_, gotErr := s.GetOrganization(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("GetOrganization() error = nil, want %q", tt.wantErr)
+				}
+				if tt.wantUserErr != "" {
+					t.Errorf("GetOrganization() user error = nil, want %q", tt.wantUserErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("GetOrganization() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("GetOrganization() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorCreateCourse(t *testing.T) {
+	// we need to members (collaborators) with owner role to allow creating a course with meling as course creator
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling, Role: github.String(OrgOwner)},
+		{Organization: &ghOrgBar, User: &jostein, Role: github.String(OrgMember)}, // not allowed to create course
+		{Organization: &ghOrgBar, User: &meling, Role: github.String(OrgOwner)},
+	}
+
+	tests := []struct {
+		name        string
+		opt         *CourseOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &CourseOptions{},
+			wantErr:     "scm.CreateCourse: missing fields: {OrganizationID:0 CourseCreator:}",
+			wantUserErr: "failed to create course",
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &CourseOptions{OrganizationID: 789, CourseCreator: "meling"},
+			wantErr:     "scm.GetOrganization: failed to get organization: GET http://127.0.0.1/organizations/789: 404  []",
+			wantUserErr: "failed to get organization by ID: 789",
+		},
+		{
+			name:        "CompleteRequest/FooReposAlreadyExists",
+			opt:         &CourseOptions{OrganizationID: 123, CourseCreator: "meling"},
+			wantErr:     "scm.GetOrganization: foo: course repositories already exist",
+			wantUserErr: "course repositories (info, assignments, tests) already exist for foo",
+		},
+		{
+			name:        "CompleteRequest/NotOwner",
+			opt:         &CourseOptions{OrganizationID: 456, CourseCreator: "jostein"},
+			wantErr:     "scm.GetOrganization: jostein is not an owner of organization bar: " + ErrNotOwner.Error(),
+			wantUserErr: "bar: permission denied for jostein",
+		},
+		{
+			name:        "CompleteRequest/NotMember",
+			opt:         &CourseOptions{OrganizationID: 456, CourseCreator: "lamport"},
+			wantErr:     "scm.GetOrganization: failed to get membership: GET http://127.0.0.1:57346/orgs/bar/memberships/lamport: 404  []",
+			wantUserErr: "bar: permission denied for lamport",
+		},
+		{
+			name:        "CompleteRequest/Owner/Success",
+			opt:         &CourseOptions{OrganizationID: 456, CourseCreator: "meling"},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"OrganizationID", "CourseCreator"}, tt.opt.OrganizationID, tt.opt.CourseCreator)
+		t.Run(name, func(t *testing.T) {
+			_, gotErr := s.CreateCourse(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("CreateCourse() error = nil, want %q", tt.wantErr)
+				}
+				if tt.wantUserErr != "" {
+					t.Errorf("CreateCourse() user error = nil, want %q", tt.wantUserErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("CreateCourse() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("GetOrganization() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorUpdateEnrollment(t *testing.T) {
+	// we need to initialize the groups table (collaborators) to allow updating repository accesses
+	g := map[string]map[string][]github.User{
+		"foo": {
+			"assignments": {}, // needed to allow updating PULL access to the repository
+			"meling-labs": {}, // needed to allow updating PUSH access to the repository
+		},
+		"bar": {
+			// "assignments": {}, // commented to trigger error updating bar/assignments to grant PULL access to meling and frank
+		},
+	}
+	// two members; no roles defined yet
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling},
+		{Organization: &ghOrgBar, User: &meling},
+	}
+
+	wantUserErr := "failed to update enrollment"
+
+	tests := []struct {
+		name        string
+		opt         *UpdateEnrollmentOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &UpdateEnrollmentOptions{},
+			wantErr:     "scm.UpdateEnrollment: missing fields: {Organization: User: Status:NONE}",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &UpdateEnrollmentOptions{Organization: "fuzz", User: "meling"},
+			wantErr:     "scm.UpdateEnrollment: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:50580/orgs/fuzz: 404  []",
+			wantUserErr: wantUserErr,
+		},
+
+		// user frank does not exist, but is added to s.members in github_mock.go
+		{
+			name:        "CompleteRequest/IgnoredStatus",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank", Status: qf.Enrollment_NONE},
+			wantErr:     "scm.UpdateEnrollment: invalid enrollment status: NONE",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/IgnoredStatus",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank", Status: qf.Enrollment_PENDING},
+			wantErr:     "scm.UpdateEnrollment: invalid enrollment status: PENDING",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/CreateStudRepo",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank", Status: qf.Enrollment_STUDENT},
+			wantErr:     `scm.UpdateEnrollment: failed to add frank with "pull" access to bar/assignments: PUT http://127.0.0.1:55626/repos/bar/assignments/collaborators/frank: 404  []`,
+			wantUserErr: "failed to enroll frank as student in bar",
+		},
+		{
+			name:        "CompleteRequest/UpdateToTeacher",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank", Status: qf.Enrollment_TEACHER},
+			wantErr:     `scm.UpdateEnrollment: failed to update frank's role to "admin" in organization bar: PUT http://127.0.0.1:55626/orgs/bar/memberships/frank: 404  []`,
+			wantUserErr: "failed to enroll frank as teacher in bar",
+		},
+
+		// user meling already exists in s.members in github_mock.go
+		{
+			name:        "CompleteRequest/None",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "meling", Status: qf.Enrollment_NONE},
+			wantErr:     "scm.UpdateEnrollment: invalid enrollment status: NONE",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/Pending",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "meling", Status: qf.Enrollment_PENDING},
+			wantErr:     "scm.UpdateEnrollment: invalid enrollment status: PENDING",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/Student/Success",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "meling", Status: qf.Enrollment_STUDENT},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+		{
+			name:        "CompleteRequest/Teacher/Success",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "meling", Status: qf.Enrollment_TEACHER},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+		{
+			name:        "CompleteRequest/Student/Fail",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "meling", Status: qf.Enrollment_STUDENT},
+			wantErr:     `scm.UpdateEnrollment: failed to add meling with "pull" access to bar/assignments: PUT http://127.0.0.1:55783/repos/bar/assignments/collaborators/meling: 404  []`,
+			wantUserErr: "failed to enroll meling as student in bar",
+		},
+
+		// The following test succeeds because meling is already a member of the bar organization, and updating the role is allowed.
+		// On GitHub, only organization owners can update roles, but we do not enforce this in the mock.
+		{
+			name:        "CompleteRequest/Teacher/TODO",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "meling", Status: qf.Enrollment_TEACHER},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...), WithGroups(g))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"Organization", "User", "Status"}, tt.opt.Organization, tt.opt.User, tt.opt.Status)
+		t.Run(name, func(t *testing.T) {
+			_, gotErr := s.UpdateEnrollment(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("UpdateEnrollment() error = nil, want %q", tt.wantErr)
+				}
+				if tt.wantUserErr != "" {
+					t.Errorf("UpdateEnrollment() user error = nil, want %q", tt.wantUserErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("UpdateEnrollment() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("UpdateEnrollment() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorRejectEnrollment(t *testing.T) {
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling},
+		{Organization: &ghOrgFoo, User: &jostein},
+		{Organization: &ghOrgBar, User: &meling},
+	}
+	const userErrPrefix = "failed to reject enrollment for "
+
+	tests := []struct {
+		name        string
+		opt         *RejectEnrollmentOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &RejectEnrollmentOptions{},
+			wantErr:     "scm.RejectEnrollment: missing fields: {OrganizationID:0 RepositoryID:0 User:}",
+			wantUserErr: userErrPrefix,
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &RejectEnrollmentOptions{OrganizationID: 789, RepositoryID: 1, User: "meling"},
+			wantErr:     "scm.RejectEnrollment: scm.GetOrganization: failed to get organization: GET http://127.0.0.1/organizations/789: 404  []",
+			wantUserErr: userErrPrefix + "meling",
+		},
+		{
+			name:        "CompleteRequest/RepoNotFound",
+			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"},
+			wantErr:     "scm.RejectEnrollment: scm.deleteRepository: failed to get repository 999: GET http://127.0.0.1/repositories/999: 404  []",
+			wantUserErr: userErrPrefix + "jostein",
+		},
+		{
+			name:        "CompleteRequest/UserNotFound",
+			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "frank"},
+			wantErr:     "scm.RejectEnrollment: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/frank: 404  []",
+			wantUserErr: userErrPrefix + "frank",
+		},
+		{
+			name:        "CompleteRequest/UserAlreadyRemoved",
+			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 5, User: "jostein"},
+			wantErr:     "scm.RejectEnrollment: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/jostein: 404  []",
+			wantUserErr: userErrPrefix + "jostein",
+		},
+		{
+			name:        "CompleteRequest/Success",
+			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "meling"},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"OrganizationID", "RepositoryID", "User"}, tt.opt.OrganizationID, tt.opt.RepositoryID, tt.opt.User)
+		t.Run(name, func(t *testing.T) {
+			err := s.RejectEnrollment(context.Background(), tt.opt)
+			if err == nil {
+				if tt.wantErr != "" {
+					t.Errorf("RejectEnrollment() error = nil, want %q", tt.wantErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, err.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(err.Error())
+				t.Errorf("RejectEnrollment() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(err, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("RejectEnrollment() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorDemoteTeacherToStudent(t *testing.T) {
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling, Role: github.String(OrgOwner)},
+		{Organization: &ghOrgFoo, User: &jostein, Role: github.String(OrgMember)},
+		{Organization: &ghOrgBar, User: &meling, Role: github.String(OrgOwner)},
+	}
+
+	tests := []struct {
+		name        string
+		opt         *UpdateEnrollmentOptions // cannot be nil; the Status field is not used by DemoteTeacherToStudent
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &UpdateEnrollmentOptions{},
+			wantErr:     "scm.DemoteTeacherToStudent: missing fields: {Organization: User: Status:NONE}",
+			wantUserErr: "failed to demote teacher to student",
+		},
+
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &UpdateEnrollmentOptions{Organization: "fuzz", User: "meling"},
+			wantErr:     `scm.DemoteTeacherToStudent: failed to update meling's role to "member" in organization fuzz: PUT http://127.0.0.1:59502/orgs/fuzz/memberships/meling: 404  []`,
+			wantUserErr: "failed to demote teacher meling to student in fuzz",
+		},
+		{
+			name:        "CompleteRequest/UserNotFound",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank"},
+			wantErr:     `scm.DemoteTeacherToStudent: failed to update frank's role to "member" in organization bar: PUT http://127.0.0.1:59685/orgs/bar/memberships/frank: 404  []`,
+			wantUserErr: "failed to demote teacher frank to student in bar",
+		},
+		{
+			name:        "CompleteRequest/FooStudent/Success",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "jostein"},
+			wantErr:     ``,
+			wantUserErr: "",
+		},
+		{
+			name:        "CompleteRequest/FooTeacher/Success",
+			opt:         &UpdateEnrollmentOptions{Organization: "foo", User: "meling"},
+			wantErr:     ``,
+			wantUserErr: "",
+		},
+		{
+			name:        "CompleteRequest/BarTeacher/Success",
+			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "meling"},
+			wantErr:     ``,
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"Organization", "User"}, tt.opt.Organization, tt.opt.User)
+		t.Run(name, func(t *testing.T) {
+			gotErr := s.DemoteTeacherToStudent(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("DemoteTeacherToStudent() error = nil, want %q", tt.wantErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("DemoteTeacherToStudent() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("DemoteTeacherToStudent() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorCreateGroup(t *testing.T) {
+	const wantUserErr = "failed to create group"
+
+	tests := []struct {
+		name        string
+		opt         *GroupOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &GroupOptions{},
+			wantErr:     "scm.CreateGroup: missing fields: {Organization: GroupName: Users:[]}",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/OrgNotFound",
+			opt:         &GroupOptions{Organization: "x", GroupName: "sphinx", Users: []string{"meling"}},
+			wantErr:     "scm.CreateGroup: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:61071/orgs/x: 404  []",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/RepoAlreadyExists",
+			opt:         &GroupOptions{Organization: "foo", Users: []string{"meling"}, GroupName: "tests"},
+			wantErr:     "scm.CreateGroup: repository foo/tests already exists: " + ErrAlreadyExists.Error(),
+			wantUserErr: wantUserErr,
+		},
+
+		// This test cannot be implemented until the mock can check if a user exists.
+		{
+			name:        "CompleteRequest/UserDoesNotExists/TODO",
+			opt:         &GroupOptions{Organization: "foo", Users: []string{"frank"}, GroupName: "franks-group"},
+			wantErr:     "",
+			wantUserErr: "",
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithGroups(groups))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"Organization", "GroupName"}, tt.opt.Organization, tt.opt.GroupName)
+		t.Run(name, func(t *testing.T) {
+			_, gotErr := s.CreateGroup(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("CreateGroup() error = nil, want %q", tt.wantErr)
+				}
+				if tt.wantUserErr != "" {
+					t.Errorf("CreateGroup() user error = nil, want %q", tt.wantUserErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("CreateGroup() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("CreateGroup() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorUpdateGroupMembers(t *testing.T) {
+	const wantUserErr = "failed to update group members"
+
+	tests := []struct {
+		name        string
+		opt         *GroupOptions // cannot be nil
+		wantErr     string
+		wantUserErr string
+	}{
+		{
+			name:        "IncompleteRequest",
+			opt:         &GroupOptions{},
+			wantErr:     "scm.UpdateGroupMembers: missing fields: {Organization: GroupName: Users:[]}",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/NotFound",
+			opt:         &GroupOptions{Organization: "foo", GroupName: "a"},
+			wantErr:     "scm.UpdateGroupMembers: failed to get members for foo/a: GET http://127.0.0.1:63851/repos/foo/a/collaborators: 404  []",
+			wantUserErr: wantUserErr,
+		},
+		{
+			name:        "CompleteRequest/NotFound",
+			opt:         &GroupOptions{Organization: "x", GroupName: "info"},
+			wantErr:     "scm.UpdateGroupMembers: failed to get members for x/info: GET http://127.0.0.1:63851/repos/x/info/collaborators: 404  []",
+			wantUserErr: wantUserErr,
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithGroups(groups))
+	for _, tt := range tests {
+		name := qtest.Name(tt.name, []string{"Organization", "GroupName", "Users"}, tt.opt.Organization, tt.opt.GroupName, tt.opt.Users)
+		t.Run(name, func(t *testing.T) {
+			gotErr := s.UpdateGroupMembers(context.Background(), tt.opt)
+			if gotErr == nil {
+				if tt.wantErr != "" {
+					t.Errorf("UpdateGroupMembers() error = nil, want %q", tt.wantErr)
+				}
+				if tt.wantUserErr != "" {
+					t.Errorf("UpdateGroupMembers() user error = nil, want %q", tt.wantUserErr)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
+				t.Errorf("UpdateGroupMembers() error mismatch (-want +got):\n%s", diff)
+			}
+			var scmErr *SCMError
+			if errors.As(gotErr, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Logf(gotUserErr)
+					t.Errorf("UpdateGroupMembers() user error mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorE(t *testing.T) {
+	e1 := E(Op("GetOrganization"), Msg("organization not found"), errors.New("organization not found"))
+	e2 := E(Op("GetRepository"), Msg("repository not found"), e1)
+	e3 := E(Op("GetUser"), Msg("user not found"), e2)
+
+	tests := []struct {
+		name           string
+		err            error
+		wantErr        string
+		wantUserErr    string
+		wantAllUserErr string
+	}{
+		{
+			name:           "E1",
+			err:            e1,
+			wantErr:        "scm.GetOrganization: organization not found",
+			wantUserErr:    "organization not found",
+			wantAllUserErr: "organization not found",
+		},
+		{
+			name:           "E2",
+			err:            e2,
+			wantErr:        "scm.GetRepository: scm.GetOrganization: organization not found",
+			wantUserErr:    "repository not found",
+			wantAllUserErr: "repository not found: organization not found",
+		},
+		{
+			name:           "E3",
+			err:            e3,
+			wantErr:        "scm.GetUser: scm.GetRepository: scm.GetOrganization: organization not found",
+			wantUserErr:    "user not found",
+			wantAllUserErr: "user not found: repository not found: organization not found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.wantErr, tt.err.Error()); diff != "" {
+				t.Errorf("%s() error mismatch (-want +got):\n%s", tt.name, diff)
+			}
+			var scmErr *SCMError
+			if errors.As(tt.err, &scmErr) {
+				gotUserErr := scmErr.UserError().Error()
+				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
+					t.Errorf("%s() user error mismatch (-want +got):\n%s", tt.name, diff)
+				}
+				gotAllUserErr := scmErr.AllUserErrors().Error()
+				if diff := cmp.Diff(tt.wantAllUserErr, gotAllUserErr); diff != "" {
+					t.Errorf("%s() all user errors mismatch (-want +got):\n%s", tt.name, diff)
+				}
+			}
+		})
+	}
+}

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -681,9 +681,9 @@ func TestErrorUpdateGroupMembers(t *testing.T) {
 }
 
 func TestErrorE(t *testing.T) {
-	e1 := E(Op("GetOrganization"), Msg("organization not found"), errors.New("organization not found"))
-	e2 := E(Op("GetRepository"), Msg("repository not found"), e1)
-	e3 := E(Op("GetUser"), Msg("user not found"), e2)
+	e1 := E(Op("GetOrganization"), M("organization not found"), errors.New("organization not found"))
+	e2 := E(Op("GetRepository"), M("repository not found"), e1)
+	e3 := E(Op("GetUser"), M("user not found"), e2)
 
 	tests := []struct {
 		name           string

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -368,7 +368,7 @@ func TestErrorRejectEnrollment(t *testing.T) {
 		{Organization: &ghOrgFoo, User: &jostein},
 		{Organization: &ghOrgBar, User: &meling},
 	}
-	const userErrPrefix = "failed to reject enrollment for "
+	const userErrPrefix = "failed to reject enrollment"
 
 	tests := []struct {
 		name        string
@@ -379,32 +379,32 @@ func TestErrorRejectEnrollment(t *testing.T) {
 		{
 			name:        "IncompleteRequest",
 			opt:         &RejectEnrollmentOptions{},
-			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for : missing fields: {OrganizationID:0 RepositoryID:0 User:}",
+			wantErr:     "scm.RejectEnrollment: failed to reject enrollment: missing fields: {OrganizationID:0 RepositoryID:0 User:}",
 			wantUserErr: userErrPrefix,
 		},
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 789, RepositoryID: 1, User: "meling"},
 			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for meling: scm.GetOrganization: failed to get organization by ID: 789: GET http://127.0.0.1/organizations/789: 404  []",
-			wantUserErr: userErrPrefix + "meling",
+			wantUserErr: userErrPrefix + " for meling",
 		},
 		{
 			name:        "CompleteRequest/RepoNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"},
 			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: scm.deleteRepository: failed to delete repository: failed to get repository 999: GET http://127.0.0.1/repositories/999: 404  []",
-			wantUserErr: userErrPrefix + "jostein",
+			wantUserErr: userErrPrefix + " for jostein",
 		},
 		{
 			name:        "CompleteRequest/UserNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "frank"},
 			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for frank: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/frank: 404  []",
-			wantUserErr: userErrPrefix + "frank",
+			wantUserErr: userErrPrefix + " for frank",
 		},
 		{
 			name:        "CompleteRequest/UserAlreadyRemoved",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 5, User: "jostein"},
 			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/jostein: 404  []",
-			wantUserErr: userErrPrefix + "jostein",
+			wantUserErr: userErrPrefix + " for jostein",
 		},
 		{
 			name:        "CompleteRequest/Success",

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -172,9 +172,9 @@ func TestErrorGetOrganization(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("GetOrganization() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("GetOrganization() user error mismatch (-want +got):\n%s", diff)
@@ -253,9 +253,9 @@ func TestErrorCreateCourse(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("CreateCourse() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("GetOrganization() user error mismatch (-want +got):\n%s", diff)
@@ -299,7 +299,7 @@ func TestErrorUpdateEnrollment(t *testing.T) {
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &UpdateEnrollmentOptions{Organization: "fuzz", User: "meling"},
-			wantErr:     "scm.UpdateEnrollment: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:50580/orgs/fuzz: 404  []",
+			wantErr:     "scm.UpdateEnrollment: failed to update enrollment: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:50580/orgs/fuzz: 404  []",
 			wantUserErr: wantUserErr,
 		},
 
@@ -388,9 +388,9 @@ func TestErrorUpdateEnrollment(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("UpdateEnrollment() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("UpdateEnrollment() user error mismatch (-want +got):\n%s", diff)
@@ -423,13 +423,13 @@ func TestErrorRejectEnrollment(t *testing.T) {
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 789, RepositoryID: 1, User: "meling"},
-			wantErr:     "scm.RejectEnrollment: scm.GetOrganization: failed to get organization: GET http://127.0.0.1/organizations/789: 404  []",
+			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for meling: scm.GetOrganization: failed to get organization: GET http://127.0.0.1/organizations/789: 404  []",
 			wantUserErr: userErrPrefix + "meling",
 		},
 		{
 			name:        "CompleteRequest/RepoNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"},
-			wantErr:     "scm.RejectEnrollment: scm.deleteRepository: failed to get repository 999: GET http://127.0.0.1/repositories/999: 404  []",
+			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: scm.deleteRepository: failed to get repository 999: GET http://127.0.0.1/repositories/999: 404  []",
 			wantUserErr: userErrPrefix + "jostein",
 		},
 		{
@@ -455,20 +455,20 @@ func TestErrorRejectEnrollment(t *testing.T) {
 	for _, tt := range tests {
 		name := qtest.Name(tt.name, []string{"OrganizationID", "RepositoryID", "User"}, tt.opt.OrganizationID, tt.opt.RepositoryID, tt.opt.User)
 		t.Run(name, func(t *testing.T) {
-			err := s.RejectEnrollment(context.Background(), tt.opt)
-			if err == nil {
+			gotErr := s.RejectEnrollment(context.Background(), tt.opt)
+			if gotErr == nil {
 				if tt.wantErr != "" {
 					t.Errorf("RejectEnrollment() error = nil, want %q", tt.wantErr)
 				}
 				return
 			}
-			if diff := cmp.Diff(tt.wantErr, err.Error(), IgnoreURLPort()); diff != "" {
-				t.Logf(err.Error())
+			if diff := cmp.Diff(tt.wantErr, gotErr.Error(), IgnoreURLPort()); diff != "" {
+				t.Logf(gotErr.Error())
 				t.Errorf("RejectEnrollment() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(err, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("RejectEnrollment() user error mismatch (-want +got):\n%s", diff)
@@ -544,9 +544,9 @@ func TestErrorDemoteTeacherToStudent(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("DemoteTeacherToStudent() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("DemoteTeacherToStudent() user error mismatch (-want +got):\n%s", diff)
@@ -574,7 +574,7 @@ func TestErrorCreateGroup(t *testing.T) {
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &GroupOptions{Organization: "x", GroupName: "sphinx", Users: []string{"meling"}},
-			wantErr:     "scm.CreateGroup: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:61071/orgs/x: 404  []",
+			wantErr:     "scm.CreateGroup: failed to create group: scm.GetOrganization: failed to get organization: GET http://127.0.0.1:61071/orgs/x: 404  []",
 			wantUserErr: wantUserErr,
 		},
 		{
@@ -610,9 +610,9 @@ func TestErrorCreateGroup(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("CreateGroup() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("CreateGroup() user error mismatch (-want +got):\n%s", diff)
@@ -668,9 +668,9 @@ func TestErrorUpdateGroupMembers(t *testing.T) {
 				t.Logf(gotErr.Error())
 				t.Errorf("UpdateGroupMembers() error mismatch (-want +got):\n%s", diff)
 			}
-			var scmErr *SCMError
-			if errors.As(gotErr, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(gotErr, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Logf(gotUserErr)
 					t.Errorf("UpdateGroupMembers() user error mismatch (-want +got):\n%s", diff)
@@ -686,32 +686,28 @@ func TestErrorE(t *testing.T) {
 	e3 := E(Op("GetUser"), M("user not found"), e2)
 
 	tests := []struct {
-		name           string
-		err            error
-		wantErr        string
-		wantUserErr    string
-		wantAllUserErr string
+		name        string
+		err         error
+		wantErr     string
+		wantUserErr string
 	}{
 		{
-			name:           "E1",
-			err:            e1,
-			wantErr:        "scm.GetOrganization: organization not found",
-			wantUserErr:    "organization not found",
-			wantAllUserErr: "organization not found",
+			name:        "E1",
+			err:         e1,
+			wantErr:     "scm.GetOrganization: organization not found",
+			wantUserErr: "organization not found",
 		},
 		{
-			name:           "E2",
-			err:            e2,
-			wantErr:        "scm.GetRepository: scm.GetOrganization: organization not found",
-			wantUserErr:    "repository not found",
-			wantAllUserErr: "repository not found: organization not found",
+			name:        "E2",
+			err:         e2,
+			wantErr:     "scm.GetRepository: repository not found: scm.GetOrganization: organization not found",
+			wantUserErr: "repository not found",
 		},
 		{
-			name:           "E3",
-			err:            e3,
-			wantErr:        "scm.GetUser: scm.GetRepository: scm.GetOrganization: organization not found",
-			wantUserErr:    "user not found",
-			wantAllUserErr: "user not found: repository not found: organization not found",
+			name:        "E3",
+			err:         e3,
+			wantErr:     "scm.GetUser: user not found: scm.GetRepository: repository not found: scm.GetOrganization: organization not found",
+			wantUserErr: "user not found",
 		},
 	}
 	for _, tt := range tests {
@@ -719,15 +715,11 @@ func TestErrorE(t *testing.T) {
 			if diff := cmp.Diff(tt.wantErr, tt.err.Error()); diff != "" {
 				t.Errorf("%s() error mismatch (-want +got):\n%s", tt.name, diff)
 			}
-			var scmErr *SCMError
-			if errors.As(tt.err, &scmErr) {
-				gotUserErr := scmErr.UserError().Error()
+			var userErr *UserError
+			if errors.As(tt.err, &userErr) {
+				gotUserErr := userErr.Error()
 				if diff := cmp.Diff(tt.wantUserErr, gotUserErr); diff != "" {
 					t.Errorf("%s() user error mismatch (-want +got):\n%s", tt.name, diff)
-				}
-				gotAllUserErr := scmErr.AllUserErrors().Error()
-				if diff := cmp.Diff(tt.wantAllUserErr, gotAllUserErr); diff != "" {
-					t.Errorf("%s() all user errors mismatch (-want +got):\n%s", tt.name, diff)
 				}
 			}
 		})

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -17,7 +17,7 @@ func TestCreateAndGetCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs())
+	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs("admin"))
 
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
 	cookie := Cookie(t, tm, admin)
@@ -48,7 +48,7 @@ func TestGetCourseWithoutDockerfileDigest(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs())
+	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs("admin"))
 
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
 	cookie := Cookie(t, tm, admin)
@@ -101,7 +101,7 @@ func TestCreateAndGetCourses(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs())
+	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs("admin"))
 
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
 	cookie := Cookie(t, tm, admin)
@@ -153,7 +153,7 @@ func TestEnrollmentProcess(t *testing.T) {
 	defer cleanup()
 
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
-	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs())
+	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs("admin"))
 
 	ctx := context.Background()
 	course, err := client.CreateCourse(ctx, qtest.RequestWithCookie(qtest.MockCourses[0], Cookie(t, tm, admin)))

--- a/web/groups_name_test.go
+++ b/web/groups_name_test.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 )
 
@@ -22,7 +23,7 @@ func TestBadGroupNames(t *testing.T) {
 	}
 	qtest.CreateCourse(t, db, admin, course)
 
-	client := web.MockClient(t, db, nil)
+	client := web.MockClient(t, db, scm.WithMockOrgs(), nil)
 	groupNames := []struct {
 		name      string
 		wantError *connect.Error

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -299,7 +299,7 @@ func TestDeleteGroup(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs())
+	client, tm := web.MockClientWithOption(t, db, scm.WithMockOrgs("admin"))
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
 
 	ctx := context.Background()

--- a/web/hooks/installation_test.go
+++ b/web/hooks/installation_test.go
@@ -29,9 +29,10 @@ func TestReceiveInstallationEvent(t *testing.T) {
 		ScmRemoteID: 1,
 	})
 
+	wantCourse1 := qtest.MockCourses[0]
 	response := sendEvent(t, event{
-		OrganizationLogin: "qf102-2022",
-		OrganizationScmID: 1,
+		OrganizationLogin: wantCourse1.ScmOrganizationName,
+		OrganizationScmID: int(wantCourse1.ScmOrganizationID),
 		UserLogin:         "quickfeed",
 		UserScmID:         1,
 	}, server)
@@ -44,19 +45,18 @@ func TestReceiveInstallationEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if course.Name != "qf102-2022" {
-		t.Errorf("got course name %s, want qf102-2022", course.Name)
+	if course.ScmOrganizationName != wantCourse1.ScmOrganizationName {
+		t.Errorf("got course %q, want %q", course.ScmOrganizationName, wantCourse1.ScmOrganizationName)
 	}
-
 	if course.CourseCreatorID != admin.ID {
 		t.Errorf("got course creator id %d, want 1", course.CourseCreatorID)
 	}
 
 	// Send another event with another organization.
+	wantCourse2 := qtest.MockCourses[1]
 	response = sendEvent(t, event{
-		OrganizationLogin: "qf103-2022",
-		OrganizationScmID: 2,
+		OrganizationLogin: wantCourse2.ScmOrganizationName,
+		OrganizationScmID: int(wantCourse2.ScmOrganizationID),
 		UserLogin:         "quickfeed",
 		UserScmID:         1,
 	}, server)
@@ -70,9 +70,8 @@ func TestReceiveInstallationEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if course.Name != "qf103-2022" {
-		t.Errorf("got course name %s, want qf102-2022", course.Name)
+	if course.ScmOrganizationName != wantCourse2.ScmOrganizationName {
+		t.Errorf("got course %s, want %s", course.ScmOrganizationName, wantCourse2.ScmOrganizationName)
 	}
 }
 
@@ -256,7 +255,7 @@ func TestCheckUserClaims(t *testing.T) {
 }
 
 func setupWebhook(t *testing.T, db database.Database) (*GitHubWebHook, *httptest.Server) {
-	mgr := scm.MockManager(t, scm.WithMockOrgs())
+	mgr := scm.MockManager(t, scm.WithMockOrgs("quickfeed"))
 	tm, err := auth.NewTokenManager(db)
 	if err != nil {
 		t.Fatal(err)

--- a/web/interceptor/access_control_test.go
+++ b/web/interceptor/access_control_test.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 	"github.com/quickfeed/quickfeed/web/auth"
 	"github.com/quickfeed/quickfeed/web/interceptor"
@@ -30,7 +31,7 @@ func TestAccessControl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := web.MockClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, scm.WithMockOrgs(), connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewAccessControlInterceptor(tm),
 	))

--- a/web/interceptor/tokens_test.go
+++ b/web/interceptor/tokens_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 	"github.com/quickfeed/quickfeed/web/auth"
 	"github.com/quickfeed/quickfeed/web/interceptor"
@@ -23,7 +24,7 @@ func TestRefreshTokens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := web.MockClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, scm.WithMockOrgs("admin"), connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 		interceptor.NewTokenInterceptor(tm),
 	))

--- a/web/interceptor/user_auth_test.go
+++ b/web/interceptor/user_auth_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 	"github.com/quickfeed/quickfeed/web/auth"
 	"github.com/quickfeed/quickfeed/web/interceptor"
@@ -23,7 +24,7 @@ func TestUserVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := web.MockClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, scm.WithMockOrgs(), connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 	))
 	ctx := context.Background()

--- a/web/quickfeed_mock_client.go
+++ b/web/quickfeed_mock_client.go
@@ -16,9 +16,9 @@ import (
 )
 
 // MockClient returns a QuickFeed client for invoking RPCs.
-func MockClient(t *testing.T, db database.Database, opts connect.Option) qfconnect.QuickFeedServiceClient {
+func MockClient(t *testing.T, db database.Database, mockOpt scm.MockOption, opts connect.Option) qfconnect.QuickFeedServiceClient {
 	t.Helper()
-	mgr := scm.MockManager(t, scm.WithMockOrgs())
+	mgr := scm.MockManager(t, mockOpt)
 	logger := qtest.Logger(t)
 	qfService := NewQuickFeedService(logger.Desugar(), db, mgr, BaseHookOptions{}, &ci.Local{})
 

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -330,6 +330,7 @@ func (s *QuickFeedService) DeleteGroup(ctx context.Context, in *connect.Request[
 			s.logger.Error(ctxErr)
 			return nil, ctxErr
 		}
+		// TODO why are we doing Unwrap here?
 		if ok, parsedErr := parseSCMError(errors.Unwrap(err)); ok {
 			return nil, parsedErr
 		}

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -560,7 +560,7 @@ func (s *QuickFeedService) GetOrganization(ctx context.Context, in *connect.Requ
 		if ok, parsedErr := parseSCMError(err); ok {
 			return nil, parsedErr
 		}
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("organization not found. Please make sure that 3rd-party access is enabled for your organization"))
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("organization not found. Please make sure that third-party access is enabled for your organization"))
 	}
 	return connect.NewResponse(org), nil
 }

--- a/web/repositories_test.go
+++ b/web/repositories_test.go
@@ -197,7 +197,7 @@ func TestGetRepositories(t *testing.T) {
 func TestQuickFeedService_IsEmptyRepo(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	client := web.MockClient(t, db, nil)
+	client := web.MockClient(t, db, scm.WithMockOrgs(), nil)
 
 	user := qtest.CreateFakeCustomUser(t, db, &qf.User{Login: "user"})
 	course := qtest.MockCourses[0]

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -90,9 +90,9 @@ func ctxErr(ctx context.Context) error {
 // Returns true and formatted error if error type is SCM error
 // designed to be shown to user
 func parseSCMError(err error) (bool, error) {
-	errStruct, ok := err.(scm.SCMError)
-	if ok {
-		return ok, connect.NewError(connect.CodeNotFound, errors.New(errStruct.Message))
+	var scmErr *scm.SCMError
+	if errors.As(err, &scmErr) {
+		return true, connect.NewError(connect.CodeNotFound, scmErr.UserError())
 	}
-	return ok, nil
+	return false, nil
 }

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -90,7 +90,7 @@ func ctxErr(ctx context.Context) error {
 // Returns true and formatted error if error type is SCM error
 // designed to be shown to user
 func parseSCMError(err error) (bool, error) {
-	errStruct, ok := err.(scm.ErrFailedSCM)
+	errStruct, ok := err.(scm.SCMError)
 	if ok {
 		return ok, connect.NewError(connect.CodeNotFound, errors.New(errStruct.Message))
 	}

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetUsers(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	client := web.MockClient(t, db, nil)
+	client := web.MockClient(t, db, scm.WithMockOrgs(), nil)
 	ctx := context.Background()
 
 	unexpectedUsers, err := client.GetUsers(ctx, &connect.Request[qf.Void]{Msg: &qf.Void{}})
@@ -45,7 +45,7 @@ func TestGetUsers(t *testing.T) {
 func TestGetEnrollmentsByCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
-	client := web.MockClient(t, db, nil)
+	client := web.MockClient(t, db, scm.WithMockOrgs(), nil)
 	ctx := context.Background()
 
 	var users []*qf.User
@@ -108,7 +108,7 @@ func TestUpdateUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := web.MockClient(t, db, connect.WithInterceptors(
+	client := web.MockClient(t, db, scm.WithMockOrgs(), connect.WithInterceptors(
 		interceptor.NewUserInterceptor(logger, tm),
 	))
 	ctx := context.Background()


### PR DESCRIPTION
This is aims to clean up the error messages and how errors are handled coming from the scm package.

The design is inspired by the upspin project's errors package, the Go 1.13 error wrapping, and Jay Conrod's blog about error handling guidelines.

This PR builds on #1093, which should be merged first before merging this one.

Fixes #571
Fixes #1113

