### PR TITLE
scm fields rename

### DIFF
--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -26,11 +26,11 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		if err := scmApp.DeleteIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		}); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("Deleted issues at repo: %+v", repo.Path)
+		t.Logf("Deleted issues at repo: %+v", repo.Repo)
 	})
 
 	// Create issues on student repositories for the first assignment's tasks
@@ -44,19 +44,19 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		scmIssues, err := scmApp.GetIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		issues := make(map[string]*scm.Issue)
 		for _, issue := range scmIssues {
-			t.Logf("Found issue (%s): %s", repo.Path, issue.Title)
+			t.Logf("Found issue (%s): %s", repo.Repo, issue.Title)
 			issues[issue.Title] = issue
 		}
 		for _, task := range first[0].Tasks {
 			if _, ok := issues[task.Title]; !ok {
-				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Path)
+				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Repo)
 			}
 		}
 	})
@@ -72,19 +72,19 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 	repoFn(repos, func(repo *scm.Repository) {
 		scmIssues, err := scmApp.GetIssues(ctx, &scm.RepositoryOptions{
 			Owner: course.ScmOrganizationName,
-			Path:  repo.Path,
+			Repo:  repo.Repo,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		issues := make(map[string]*scm.Issue)
 		for _, issue := range scmIssues {
-			t.Logf("Found issue (%s): %s", repo.Path, issue.Title)
+			t.Logf("Found issue (%s): %s", repo.Repo, issue.Title)
 			issues[issue.Title] = issue
 		}
 		for _, task := range second[0].Tasks {
 			if _, ok := issues[task.Title]; !ok {
-				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Path)
+				t.Errorf("task.Title = %s not found in repo %s", task.Title, repo.Repo)
 			}
 		}
 	})
@@ -92,7 +92,7 @@ func TestSynchronizeTasksWithIssues(t *testing.T) {
 
 func repoFn(repos []*scm.Repository, fn func(repo *scm.Repository)) {
 	for _, repo := range repos {
-		if qf.RepoType(repo.Path).IsCourseRepo() {
+		if qf.RepoType(repo.Repo).IsCourseRepo() {
 			continue
 		}
 		fn(repo)
@@ -130,7 +130,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 			ScmRepositoryID:   scmRepo.ID,
 			ScmOrganizationID: org.GetScmOrganizationID(),
 			HTMLURL:           scmRepo.HTMLURL,
-			RepoType:          qf.RepoType(scmRepo.Path),
+			RepoType:          qf.RepoType(scmRepo.Repo),
 		}
 		if repo.IsUserRepo() {
 			user := qtest.CreateFakeUser(t, db)
@@ -148,7 +148,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 			repo.RepoType = qf.Repository_GROUP
 			repo.GroupID = group.GetID()
 		}
-		t.Logf("Creating repo in database: %v", scmRepo.Path)
+		t.Logf("Creating repo in database: %v", scmRepo.Repo)
 		if err = db.CreateRepository(repo); err != nil {
 			t.Fatal(err)
 		}

--- a/assignments/tasks_test.go
+++ b/assignments/tasks_test.go
@@ -119,7 +119,7 @@ func initDatabase(t *testing.T, db database.Database, sc scm.SCM) (*qf.Course, [
 	admin := qtest.CreateFakeUser(t, db)
 	qtest.CreateCourse(t, db, admin, course)
 
-	repos, err := sc.GetRepositories(ctx, org)
+	repos, err := sc.GetRepositories(ctx, org.GetScmOrganizationName())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scm/main.go
+++ b/cmd/scm/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-github/v62/github"
 	"github.com/quickfeed/quickfeed/internal/qlog"
-	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
 
 	"github.com/urfave/cli"
@@ -208,14 +207,14 @@ func deleteRepositories(client *scm.GithubSCM) cli.ActionFunc {
 				return err
 			}
 
-			repos, err := (*client).GetRepositories(ctx, &qf.Organization{ScmOrganizationName: c.String("namespace")})
+			repos, err := (*client).GetRepositories(ctx, c.String("namespace"))
 			if err != nil {
 				return err
 			}
 
 			for _, repo := range repos {
 				var errs []error
-				if _, err := (*client).Client().Repositories.Delete(ctx, repo.Owner, repo.Path); err != nil {
+				if _, err := (*client).Client().Repositories.Delete(ctx, repo.Owner, repo.Repo); err != nil {
 					errs = append(errs, err)
 				} else {
 					fmt.Println("Deleted repository", repo.HTMLURL)
@@ -248,7 +247,7 @@ func getRepositories(client *scm.GithubSCM) cli.ActionFunc {
 			return cli.NewExitError("name and namespace must be provided", 3)
 		}
 		if c.Bool("all") {
-			repos, err := (*client).GetRepositories(ctx, &qf.Organization{ScmOrganizationName: c.String("namespace")})
+			repos, err := (*client).GetRepositories(ctx, c.String("namespace"))
 			if err != nil {
 				return err
 			}

--- a/scm/github_issues.go
+++ b/scm/github_issues.go
@@ -53,11 +53,11 @@ func (s *GithubSCM) UpdateIssue(ctx context.Context, opt *IssueOptions) (*Issue,
 // GetIssue implements the SCM interface
 func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number int) (*Issue, error) {
 	const op Op = "GetIssue"
-	m := M("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Path)
+	m := M("failed to get issue #%d on %s/%s", number, opt.Owner, opt.Repo)
 	if !opt.valid() {
 		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
-	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Path, number)
+	issue, _, err := s.client.Issues.Get(ctx, opt.Owner, opt.Repo, number)
 	if err != nil {
 		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}
@@ -67,11 +67,11 @@ func (s *GithubSCM) GetIssue(ctx context.Context, opt *RepositoryOptions, number
 // GetIssues implements the SCM interface
 func (s *GithubSCM) GetIssues(ctx context.Context, opt *RepositoryOptions) ([]*Issue, error) {
 	const op Op = "GetIssues"
-	m := M("failed to get issues for %s/%s", opt.Owner, opt.Path)
+	m := M("failed to get issues for %s/%s", opt.Owner, opt.Repo)
 	if !opt.valid() {
 		return nil, E(op, m, fmt.Errorf("missing fields: %+v", opt))
 	}
-	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{})
+	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Repo, &github.IssueListByRepoOptions{})
 	if err != nil {
 		return nil, E(op, m, fmt.Errorf("%s: %w", m, err))
 	}

--- a/scm/github_issues_mock_test.go
+++ b/scm/github_issues_mock_test.go
@@ -86,7 +86,7 @@ func TestMockDeleteIssue(t *testing.T) {
 			t.Fatalf("failed to create issue: %v", err)
 		}
 	}
-	issues, err := s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Path: "meling-labs"})
+	issues, err := s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Repo: "meling-labs"})
 	if err != nil {
 		t.Fatalf("failed to get issues: %v", err)
 	}
@@ -102,30 +102,30 @@ func TestMockDeleteIssue(t *testing.T) {
 	}{
 		{name: "IncompleteRequest", opt: &RepositoryOptions{}, wantErr: true},
 		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo"}, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Path: "meling-labs"}, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Repo: "meling-labs"}, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantErr: true},
 
-		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Path: "meling-labs"}, number: 1, wantErr: true},
-		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Path: "lamport-labs"}, number: 1, wantErr: true},
-		{name: "CompleteRequest/MissingNumber", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantErr: true},
-		{name: "CompleteRequest/WrongNumber", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 543, wantErr: true},
+		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Repo: "meling-labs"}, number: 1, wantErr: true},
+		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Repo: "lamport-labs"}, number: 1, wantErr: true},
+		{name: "CompleteRequest/MissingNumber", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantErr: true},
+		{name: "CompleteRequest/WrongNumber", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 543, wantErr: true},
 
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 1, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 2, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, number: 1, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, number: 2, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, number: 1, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, number: 2, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 1, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 2, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, number: 1, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, number: 2, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, number: 1, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, number: 2, wantErr: false},
 	}
 	for _, tt := range tests {
-		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Path)
+		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
 			if err := s.DeleteIssue(context.Background(), tt.opt, tt.number); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteIssue() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
-	issues, err = s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Path: "meling-labs"})
+	issues, err = s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Repo: "meling-labs"})
 	if err != nil {
 		t.Fatalf("failed to get issues: %v", err)
 	}
@@ -152,9 +152,9 @@ func TestMockDeleteIssues(t *testing.T) {
 	}
 	allIssuesMap := make(map[int64]*Issue)
 	queryOpts := []*RepositoryOptions{
-		{Owner: "foo", Path: "meling-labs"},
-		{Owner: "foo", Path: "josie-labs"},
-		{Owner: "dat320", Path: "meling-labs"},
+		{Owner: "foo", Repo: "meling-labs"},
+		{Owner: "foo", Repo: "josie-labs"},
+		{Owner: "dat320", Repo: "meling-labs"},
 	}
 	for _, opt := range queryOpts {
 		issues, err := s.GetIssues(context.Background(), opt)
@@ -177,17 +177,17 @@ func TestMockDeleteIssues(t *testing.T) {
 	}{
 		{name: "IncompleteRequest", opt: &RepositoryOptions{}, wantErr: true},
 		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo"}, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Path: "meling-labs"}, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Repo: "meling-labs"}, wantErr: true},
 
-		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Path: "meling-labs"}, wantErr: true},
-		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Path: "lamport-labs"}, wantErr: true},
+		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Repo: "meling-labs"}, wantErr: true},
+		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Repo: "lamport-labs"}, wantErr: true},
 
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantRemainingIssues: 4, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, wantRemainingIssues: 2, wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, wantRemainingIssues: 0, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantRemainingIssues: 4, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, wantRemainingIssues: 2, wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, wantRemainingIssues: 0, wantErr: false},
 	}
 	for _, tt := range tests {
-		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Path)
+		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
 			if err := s.DeleteIssues(context.Background(), tt.opt); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteIssue() error = %v, wantErr %v", err, tt.wantErr)
@@ -204,7 +204,7 @@ func TestMockDeleteIssues(t *testing.T) {
 			}
 			gotIssues := 0
 			for _, opt := range queryOpts {
-				if opt.Owner == tt.opt.Owner && opt.Path == tt.opt.Path {
+				if opt.Owner == tt.opt.Owner && opt.Repo == tt.opt.Repo {
 					continue
 				}
 				issues, err := s.GetIssues(context.Background(), opt)
@@ -338,23 +338,23 @@ func TestMockGetIssue(t *testing.T) {
 	}{
 		{name: "IncompleteRequest", opt: &RepositoryOptions{}, wantIssue: nil, wantErr: true},
 		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo"}, wantIssue: nil, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Path: "meling-labs"}, wantIssue: nil, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantIssue: nil, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Repo: "meling-labs"}, wantIssue: nil, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantIssue: nil, wantErr: true},
 
-		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Path: "meling-labs"}, number: 1, wantIssue: nil, wantErr: true},
-		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Path: "lamport-labs"}, number: 1, wantIssue: nil, wantErr: true},
-		{name: "CompleteRequest/MissingNumber", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantIssue: nil, wantErr: true},
-		{name: "CompleteRequest/WrongNumber", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 543, wantIssue: nil, wantErr: true},
+		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Repo: "meling-labs"}, number: 1, wantIssue: nil, wantErr: true},
+		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Repo: "lamport-labs"}, number: 1, wantIssue: nil, wantErr: true},
+		{name: "CompleteRequest/MissingNumber", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantIssue: nil, wantErr: true},
+		{name: "CompleteRequest/WrongNumber", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 543, wantIssue: nil, wantErr: true},
 
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 1, wantIssue: wantIssues["foo"]["meling-labs"][0], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, number: 2, wantIssue: wantIssues["foo"]["meling-labs"][1], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, number: 1, wantIssue: wantIssues["foo"]["josie-labs"][0], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, number: 2, wantIssue: wantIssues["foo"]["josie-labs"][1], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, number: 1, wantIssue: wantIssues["dat320"]["meling-labs"][0], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, number: 2, wantIssue: wantIssues["dat320"]["meling-labs"][1], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 1, wantIssue: wantIssues["foo"]["meling-labs"][0], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, number: 2, wantIssue: wantIssues["foo"]["meling-labs"][1], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, number: 1, wantIssue: wantIssues["foo"]["josie-labs"][0], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, number: 2, wantIssue: wantIssues["foo"]["josie-labs"][1], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, number: 1, wantIssue: wantIssues["dat320"]["meling-labs"][0], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, number: 2, wantIssue: wantIssues["dat320"]["meling-labs"][1], wantErr: false},
 	}
 	for _, tt := range tests {
-		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Path)
+		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
 			issue, err := s.GetIssue(context.Background(), tt.opt, tt.number)
 			if (err != nil) != tt.wantErr {
@@ -411,17 +411,17 @@ func TestMockGetIssues(t *testing.T) {
 	}{
 		{name: "IncompleteRequest", opt: &RepositoryOptions{}, wantIssues: nil, wantErr: true},
 		{name: "IncompleteRequest", opt: &RepositoryOptions{Owner: "foo"}, wantIssues: nil, wantErr: true},
-		{name: "IncompleteRequest", opt: &RepositoryOptions{Path: "meling-labs"}, wantIssues: nil, wantErr: true},
+		{name: "IncompleteRequest", opt: &RepositoryOptions{Repo: "meling-labs"}, wantIssues: nil, wantErr: true},
 
-		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Path: "meling-labs"}, wantIssues: nil, wantErr: true},
-		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Path: "lamport-labs"}, wantIssues: nil, wantErr: true},
+		{name: "CompleteRequest/OrgNotFound", opt: &RepositoryOptions{Owner: "buz", Repo: "meling-labs"}, wantIssues: nil, wantErr: true},
+		{name: "CompleteRequest/RepoNotFound", opt: &RepositoryOptions{Owner: "foo", Repo: "lamport-labs"}, wantIssues: nil, wantErr: true},
 
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "meling-labs"}, wantIssues: wantIssues["foo"]["meling-labs"], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Path: "josie-labs"}, wantIssues: wantIssues["foo"]["josie-labs"], wantErr: false},
-		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Path: "meling-labs"}, wantIssues: wantIssues["dat320"]["meling-labs"], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "meling-labs"}, wantIssues: wantIssues["foo"]["meling-labs"], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "foo", Repo: "josie-labs"}, wantIssues: wantIssues["foo"]["josie-labs"], wantErr: false},
+		{name: "CompleteRequest", opt: &RepositoryOptions{Owner: "dat320", Repo: "meling-labs"}, wantIssues: wantIssues["dat320"]["meling-labs"], wantErr: false},
 	}
 	for _, tt := range tests {
-		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Path)
+		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
 			issues, err := s.GetIssues(context.Background(), tt.opt)
 			if (err != nil) != tt.wantErr {
@@ -455,7 +455,7 @@ func TestMockGetIssues_CheckIssueNumbers(t *testing.T) {
 	}
 
 	gotIssueNumbers := make([]int, len(createIssues))
-	issues, err := s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Path: "meling-labs"})
+	issues, err := s.GetIssues(context.Background(), &RepositoryOptions{Owner: "foo", Repo: "meling-labs"})
 	if err != nil {
 		t.Fatalf("failed to get issues: %v", err)
 	}

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -59,10 +59,10 @@ func TestGetIssue(t *testing.T) {
 
 	opt := &scm.RepositoryOptions{
 		Owner: qfTestOrg,
-		Path:  qf.StudentRepoName(qfTestUser),
+		Repo:  qf.StudentRepoName(qfTestUser),
 	}
 
-	wantIssue, cleanup := createIssue(t, s, opt.Owner, opt.Path)
+	wantIssue, cleanup := createIssue(t, s, opt.Owner, opt.Repo)
 	defer cleanup()
 
 	gotIssue, err := s.GetIssue(context.Background(), opt, wantIssue.Number)
@@ -112,7 +112,7 @@ func TestDeleteAllIssues(t *testing.T) {
 
 	opt := &scm.RepositoryOptions{
 		Owner: qfTestOrg,
-		Path:  qf.StudentRepoName(qfTestUser),
+		Repo:  qf.StudentRepoName(qfTestUser),
 	}
 	if err := s.DeleteIssues(context.Background(), opt); err != nil {
 		t.Fatal(err)
@@ -256,14 +256,14 @@ func TestEmptyRepo(t *testing.T) {
 		opt       *scm.RepositoryOptions
 		wantEmpty bool
 	}{
-		{name: "NonEmptyRepo", opt: &scm.RepositoryOptions{Path: "tests", Owner: qfTestOrg}, wantEmpty: false},
+		{name: "NonEmptyRepo", opt: &scm.RepositoryOptions{Repo: "tests", Owner: qfTestOrg}, wantEmpty: false},
 		{name: "NonEmptyRepo", opt: &scm.RepositoryOptions{ID: 328688692}, wantEmpty: false},
-		{name: "EmptyRepo", opt: &scm.RepositoryOptions{Path: "info", Owner: qfTestOrg}, wantEmpty: true},
+		{name: "EmptyRepo", opt: &scm.RepositoryOptions{Repo: "info", Owner: qfTestOrg}, wantEmpty: true},
 		{name: "EmptyRepo", opt: &scm.RepositoryOptions{ID: 328688666}, wantEmpty: true},
-		{name: "NonExistentRepo", opt: &scm.RepositoryOptions{Path: "some-other-repo", Owner: qfTestOrg}, wantEmpty: true}, // treat non-existent repo as empty
+		{name: "NonExistentRepo", opt: &scm.RepositoryOptions{Repo: "some-other-repo", Owner: qfTestOrg}, wantEmpty: true}, // treat non-existent repo as empty
 	}
 	for _, tt := range tests {
-		name := qtest.Name(tt.name, []string{"ID", "Owner", "Repo"}, tt.opt.ID, tt.opt.Owner, tt.opt.Path)
+		name := qtest.Name(tt.name, []string{"ID", "Owner", "Repo"}, tt.opt.ID, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
 			if empty := s.RepositoryIsEmpty(context.Background(), tt.opt); empty != tt.wantEmpty {
 				t.Errorf("RepositoryIsEmpty(%+v) = %t, want %t", *tt.opt, empty, tt.wantEmpty)
@@ -287,7 +287,7 @@ func createIssue(t *testing.T, s scm.SCM, org, repo string) (*scm.Issue, func())
 
 	return issue, func() {
 		if err := s.DeleteIssue(context.Background(), &scm.RepositoryOptions{
-			Owner: org, Path: repo,
+			Owner: org, Repo: repo,
 		}, issue.Number); err != nil {
 			t.Fatal(err)
 		}

--- a/scm/githubv4.go
+++ b/scm/githubv4.go
@@ -18,7 +18,7 @@ func (s *GithubSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, iss
 	}
 	variables := map[string]interface{}{
 		"repositoryOwner": githubv4.String(opt.Owner),
-		"repositoryName":  githubv4.String(opt.Path),
+		"repositoryName":  githubv4.String(opt.Repo),
 		"issueNumber":     githubv4.Int(issueNumber),
 	}
 	if err := s.clientV4.Query(ctx, &q, variables); err != nil {
@@ -40,16 +40,16 @@ func (s *GithubSCM) DeleteIssue(ctx context.Context, opt *RepositoryOptions, iss
 
 func (s *GithubSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) error {
 	// List all open and closed issues (and pull requests)
-	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Path, &github.IssueListByRepoOptions{State: "all"})
+	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Repo, &github.IssueListByRepoOptions{State: "all"})
 	if err != nil {
-		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Path, err)
+		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Repo, err)
 	}
 	for _, issue := range issueList {
 		if issue.IsPullRequest() {
 			continue // ignore pull requests when deleting issues
 		}
 		if err = s.DeleteIssue(ctx, opt, *issue.Number); err != nil {
-			return fmt.Errorf("failed to delete issue %d in %s: %w", *issue.Number, opt.Path, err)
+			return fmt.Errorf("failed to delete issue %d in %s: %w", *issue.Number, opt.Repo, err)
 		}
 	}
 	return nil

--- a/scm/helper.go
+++ b/scm/helper.go
@@ -52,7 +52,7 @@ func isDirty(repos []*Repository) bool {
 		return false
 	}
 	for _, repo := range repos {
-		if _, exists := RepoPaths[repo.Path]; exists {
+		if _, exists := RepoPaths[repo.Repo]; exists {
 			return true
 		}
 	}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -14,7 +14,7 @@ type SCM interface {
 	// Gets an organization.
 	GetOrganization(context.Context, *OrganizationOptions) (*qf.Organization, error)
 	// Get repositories within organization.
-	GetRepositories(context.Context, *qf.Organization) ([]*Repository, error)
+	GetRepositories(context.Context, string) ([]*Repository, error)
 	// Returns true if there are no commits in the given repository
 	RepositoryIsEmpty(context.Context, *RepositoryOptions) bool
 

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -88,11 +88,9 @@ func newSCMAppClient(ctx context.Context, logger *zap.SugaredLogger, config *Con
 // Repository represents a git remote repository.
 type Repository struct {
 	ID      uint64
-	Path    string
+	Repo    string
 	Owner   string // Only used by GitHub.
 	HTMLURL string // Repository website.
-	OrgID   uint64
-	Size    uint64
 }
 
 // Issue represents an SCM issue.

--- a/scm/scm_options.go
+++ b/scm/scm_options.go
@@ -50,23 +50,23 @@ func (opt OrganizationOptions) valid() bool {
 // Either ID or both Path and Owner fields must be set.
 type RepositoryOptions struct {
 	ID    uint64
-	Path  string
+	Repo  string
 	Owner string
 }
 
 func (opt RepositoryOptions) valid() bool {
-	return opt.ID > 0 || (opt.Path != "" && opt.Owner != "")
+	return opt.ID > 0 || (opt.Repo != "" && opt.Owner != "")
 }
 
 // CreateRepositoryOptions contains information on how a repository should be created.
 type CreateRepositoryOptions struct {
-	Organization string
-	Path         string
-	Private      bool
+	Owner   string
+	Repo    string
+	Private bool
 }
 
 func (opt CreateRepositoryOptions) valid() bool {
-	return opt.Organization != "" && opt.Path != ""
+	return opt.Owner != "" && opt.Repo != ""
 }
 
 // GroupOptions is used when creating or modifying a group.

--- a/web/courses_new.go
+++ b/web/courses_new.go
@@ -28,13 +28,13 @@ func (s *QuickFeedService) createCourse(ctx context.Context, sc scm.SCM, request
 			ScmOrganizationID: request.ScmOrganizationID,
 			ScmRepositoryID:   repo.ID,
 			HTMLURL:           repo.HTMLURL,
-			RepoType:          qf.RepoType(repo.Path),
+			RepoType:          qf.RepoType(repo.Repo),
 		}
 		if dbRepo.IsUserRepo() {
 			dbRepo.UserID = courseCreator.ID
 		}
 		if err := s.db.CreateRepository(&dbRepo); err != nil {
-			return nil, fmt.Errorf("failed to create database record for repository %s: %w", repo.Path, err)
+			return nil, fmt.Errorf("failed to create database record for repository %s: %w", repo.Repo, err)
 		}
 	}
 

--- a/web/hooks/installation.go
+++ b/web/hooks/installation.go
@@ -54,13 +54,13 @@ func (wh GitHubWebHook) handleInstallationCreated(event *github.InstallationEven
 			ScmOrganizationID: orgID,
 			ScmRepositoryID:   repo.ID,
 			HTMLURL:           repo.HTMLURL,
-			RepoType:          qf.RepoType(repo.Path),
+			RepoType:          qf.RepoType(repo.Repo),
 		}
 		if dbRepo.IsUserRepo() {
 			dbRepo.UserID = courseCreator.ID
 		}
 		if err := wh.db.CreateRepository(&dbRepo); err != nil {
-			wh.logger.Errorf("Could not create database repository %s: %v", repo.Path, err)
+			wh.logger.Errorf("Could not create database repository %s: %v", repo.Repo, err)
 			return
 		}
 	}


### PR DESCRIPTION
- chore: rename SCM type fields `Path`, `Organization` to `Repo`, `Owner`, remove OrgID, Size
- chore: update GetRepositories method signature in SCM interface, implementation (qf.Organization -> string)

Fixes #1094 

Supersedes #1110 