### PR TITLE
fix(ci): handle image conflict during build

### DIFF
--- a/ci/consts.go
+++ b/ci/consts.go
@@ -1,5 +1,9 @@
 package ci
 
+import "fmt"
+
 // Environment variable used by the CI system to pass
 // the session secret from QuickFeed to the test code.
 const secretEnvName = "QUICKFEED_SESSION_SECRET"
+
+var ErrConflict = fmt.Errorf("submission is already being built, please wait")

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -2,6 +2,7 @@ package ci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,6 +87,9 @@ func (r *RunData) RunTests(ctx context.Context, logger *zap.SugaredLogger, sc sc
 	out, err := runner.Run(ctx, job)
 	if err != nil && out == "" {
 		testsFailedCounter.WithLabelValues(r.JobOwner, r.Course.Code).Inc()
+		if errors.Is(err, ErrConflict) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("test execution failed without output: %w", err)
 	}
 	if err != nil {


### PR DESCRIPTION
This commit adds error handling for the case when an image is already being built for a job. It logs an error message and returns an `ErrConflict` error.
