### PR TITLE
Show submissions for group assignments where user not part of a group

### DIFF
--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -1,6 +1,6 @@
 
 import { Enrollment, Group, Submission } from "../../proto/qf/types_pb"
-import {  generateRow } from "../components/ComponentsHelpers"
+import { generateRow } from "../components/ComponentsHelpers"
 import { MockData } from "./mock_data/mockData"
 import { initializeOvermind } from "./TestHelpers"
 
@@ -28,7 +28,7 @@ describe("generateRow", () => {
             desc: "Enrollment{ID: 2, groupID: 0} should have rows {N/A, 2, N/A, 7}",
             enrollment: new Enrollment({ ID: 3n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
-            want: ["N/A", {value: "2" }, "N/A", { value: "7"}]
+            want: ["N/A", { value: "2" }, "N/A", { value: "7" }]
         },
         {
             // Enrolled user with enrollment ID: 3 and groupID: 0 (not in a group)
@@ -44,7 +44,7 @@ describe("generateRow", () => {
             // Group submissions:
             // - Submission ID: 4, Assignment ID: 4
             desc: "Group{ID: 1} should have rows {4}",
-            enrollment: new Group({ID: 1n}),
+            enrollment: new Group({ ID: 1n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "", link: "https://github.com//" }, { value: "4" }]
         },
@@ -52,12 +52,12 @@ describe("generateRow", () => {
             // Group with ID: 2
             // Has no submissions
             desc: "Group{ID: 2} should have rows {N/A}",
-            enrollment: new Group({ID: 2n}),
+            enrollment: new Group({ ID: 2n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "", link: "https://github.com//" }, "N/A"]
         }
     ]
-    
+
     const { state } = initializeOvermind({ courses: MockData.mockedCourses(), assignments: MockData.mockedCourseAssignments(), activeCourse: 1n, submissionsForCourse: MockData.mockedCourseSubmissions(1n) })
     test.each(tests)(`$desc`, (test) => {
         const rows = generateRow(test.enrollment, state.getAssignmentsMap(state.activeCourse), state.submissionsForCourse, test.generator, state.courses.find(c => c.ID === state.activeCourse), false)

--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -59,7 +59,7 @@ describe("generateRow", () => {
     ]
     
     const { state } = initializeOvermind({ courses: MockData.mockedCourses(), assignments: MockData.mockedCourseAssignments(), activeCourse: 1n, submissionsForCourse: MockData.mockedCourseSubmissions(1n) })
-    test.each(tests)(`$desc`, async (test) => {
+    test.each(tests)(`$desc`, (test) => {
         const rows = generateRow(test.enrollment, state.getAssignmentsMap(state.activeCourse), state.submissionsForCourse, test.generator, state.courses.find(c => c.ID === state.activeCourse), false)
         expect(rows).toEqual(test.want)
     })

--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -1,5 +1,5 @@
 
-import { Enrollment, Submission } from "../../proto/qf/types_pb"
+import { Enrollment, Group, Submission } from "../../proto/qf/types_pb"
 import {  generateRow } from "../components/ComponentsHelpers"
 import { MockData } from "./mock_data/mockData"
 import { initializeOvermind } from "./TestHelpers"
@@ -12,7 +12,7 @@ describe("ComponentsHelpers", () => {
             // - Submission ID: 1, Assignment ID: 1
             // - Submission ID: 3, Assignment ID: 3
             // Group submission:
-            // - Submission ID: 4, Assignment ID: 1
+            // - Submission ID: 4, Assignment ID: 4
             desc: "Enrollment{ID: 1, groupID: 1} should generate correct rows",
             enrollment: new Enrollment({ ID: 1n, groupID: 1n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
@@ -38,6 +38,23 @@ describe("ComponentsHelpers", () => {
             enrollment: new Enrollment({ ID: 5n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "6" }, "N/A", "N/A", "N/A"]
+        },
+        {
+            // Group with ID: 1
+            // Group submissions:
+            // - Submission ID: 4, Assignment ID: 4
+            des: "Group{ID: 1} should generate correct rows",
+            enrollment: new Group({ID: 1n}),
+            generator: (s: Submission) => ({ value: `${s.ID}` }),
+            want: [{ value: "", link: "https://github.com//" }, { value: "4" }]
+        },
+        {
+            // Group with ID: 2
+            // Has no submissions
+            des: "Group{ID: 2} should generate correct rows",
+            enrollment: new Group({ID: 2n}),
+            generator: (s: Submission) => ({ value: `${s.ID}` }),
+            want: [{ value: "", link: "https://github.com//" }, "N/A"]
         }
     ]
     

--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -33,7 +33,7 @@ describe("generateRow", () => {
         {
             // Enrolled user with enrollment ID: 3 and groupID: 0 (not in a group)
             // Individual submissions:
-            // - Submission ID: 5, Assignment ID: 3
+            // - Submission ID: 6, Assignment ID: 1
             desc: "Enrollment{ID: 3, groupID: 0} should have rows {6, N/A, N/A, N/A}",
             enrollment: new Enrollment({ ID: 5n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),

--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -4,7 +4,7 @@ import {  generateRow } from "../components/ComponentsHelpers"
 import { MockData } from "./mock_data/mockData"
 import { initializeOvermind } from "./TestHelpers"
 
-describe("ComponentsHelpers", () => {
+describe("generateRow", () => {
     const tests = [
         {
             // Enrolled user with enrollment ID: 1 and groupID: 1
@@ -13,7 +13,7 @@ describe("ComponentsHelpers", () => {
             // - Submission ID: 3, Assignment ID: 3
             // Group submission:
             // - Submission ID: 4, Assignment ID: 4
-            desc: "Enrollment{ID: 1, groupID: 1} should generate correct rows",
+            desc: "Enrollment{ID: 1, groupID: 1} should have rows {1, N/A, 3, 4}",
             enrollment: new Enrollment({ ID: 1n, groupID: 1n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "1" }, "N/A", { value: "3" }, { value: "4" }]
@@ -25,7 +25,7 @@ describe("ComponentsHelpers", () => {
             // - Submission ID: 7, Assignment ID: 4
             // Individual submission for group assignment
             // should be included as the user is not in a group
-            desc: "Enrollment{ID: 2, groupID: 0} should generate correct rows",
+            desc: "Enrollment{ID: 2, groupID: 0} should have rows {N/A, 2, N/A, 7}",
             enrollment: new Enrollment({ ID: 3n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: ["N/A", {value: "2" }, "N/A", { value: "7"}]
@@ -34,7 +34,7 @@ describe("ComponentsHelpers", () => {
             // Enrolled user with enrollment ID: 3 and groupID: 0 (not in a group)
             // Individual submissions:
             // - Submission ID: 5, Assignment ID: 3
-            desc: "Enrollment{ID: 3, groupID: 0} should generate correct rows",
+            desc: "Enrollment{ID: 3, groupID: 0} should have rows {6, N/A, N/A, N/A}",
             enrollment: new Enrollment({ ID: 5n }),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "6" }, "N/A", "N/A", "N/A"]
@@ -43,7 +43,7 @@ describe("ComponentsHelpers", () => {
             // Group with ID: 1
             // Group submissions:
             // - Submission ID: 4, Assignment ID: 4
-            des: "Group{ID: 1} should generate correct rows",
+            desc: "Group{ID: 1} should have rows {4}",
             enrollment: new Group({ID: 1n}),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "", link: "https://github.com//" }, { value: "4" }]
@@ -51,7 +51,7 @@ describe("ComponentsHelpers", () => {
         {
             // Group with ID: 2
             // Has no submissions
-            des: "Group{ID: 2} should generate correct rows",
+            desc: "Group{ID: 2} should have rows {N/A}",
             enrollment: new Group({ID: 2n}),
             generator: (s: Submission) => ({ value: `${s.ID}` }),
             want: [{ value: "", link: "https://github.com//" }, "N/A"]

--- a/public/src/__tests__/ComponentsHelpers.test.ts
+++ b/public/src/__tests__/ComponentsHelpers.test.ts
@@ -1,0 +1,50 @@
+
+import { Enrollment, Submission } from "../../proto/qf/types_pb"
+import {  generateRow } from "../components/ComponentsHelpers"
+import { MockData } from "./mock_data/mockData"
+import { initializeOvermind } from "./TestHelpers"
+
+describe("ComponentsHelpers", () => {
+    const tests = [
+        {
+            // Enrolled user with enrollment ID: 1 and groupID: 1
+            // Individual submissions:
+            // - Submission ID: 1, Assignment ID: 1
+            // - Submission ID: 3, Assignment ID: 3
+            // Group submission:
+            // - Submission ID: 4, Assignment ID: 1
+            desc: "Enrollment{ID: 1, groupID: 1} should generate correct rows",
+            enrollment: new Enrollment({ ID: 1n, groupID: 1n }),
+            generator: (s: Submission) => ({ value: `${s.ID}` }),
+            want: [{ value: "1" }, "N/A", { value: "3" }, { value: "4" }]
+        },
+        {
+            // Enrolled user with enrollment ID: 2 and groupID: 0 (not in a group)
+            // Individual submissions:
+            // - Submission ID: 2, Assignment ID: 2
+            // - Submission ID: 7, Assignment ID: 4
+            // Individual submission for group assignment
+            // should be included as the user is not in a group
+            desc: "Enrollment{ID: 2, groupID: 0} should generate correct rows",
+            enrollment: new Enrollment({ ID: 3n }),
+            generator: (s: Submission) => ({ value: `${s.ID}` }),
+            want: ["N/A", {value: "2" }, "N/A", { value: "7"}]
+        },
+        {
+            // Enrolled user with enrollment ID: 3 and groupID: 0 (not in a group)
+            // Individual submissions:
+            // - Submission ID: 5, Assignment ID: 3
+            desc: "Enrollment{ID: 3, groupID: 0} should generate correct rows",
+            enrollment: new Enrollment({ ID: 5n }),
+            generator: (s: Submission) => ({ value: `${s.ID}` }),
+            want: [{ value: "6" }, "N/A", "N/A", "N/A"]
+        }
+    ]
+    
+    const { state } = initializeOvermind({ courses: MockData.mockedCourses(), assignments: MockData.mockedCourseAssignments(), activeCourse: 1n, submissionsForCourse: MockData.mockedCourseSubmissions(1n) })
+    test.each(tests)(`$desc`, async (test) => {
+        const rows = generateRow(test.enrollment, state.getAssignmentsMap(state.activeCourse), state.submissionsForCourse, test.generator, state.courses.find(c => c.ID === state.activeCourse), false)
+        expect(rows).toEqual(test.want)
+    })
+
+})

--- a/public/src/__tests__/mock_data/mockData.ts
+++ b/public/src/__tests__/mock_data/mockData.ts
@@ -1,30 +1,30 @@
 /* eslint-disable no-unused-vars */
-import {
-    Course,
-    Enrollment,
-    Enrollments,
-    GradingBenchmark,
-    GradingCriterion,
-    Group,
-    Groups,
-    Review,
-    Submission,
-    Submissions,
-    User,
-    Assignment,
-    Enrollment_UserStatus,
-    Group_GroupStatus,
-    Submission_Status,
-    GradingCriterion_Grade,
-    Enrollment_DisplayState,
-    Grade,
-} from "../../../proto/qf/types_pb"
+import { Timestamp } from "@bufbuild/protobuf"
+import { BuildInfo, Score } from "../../../proto/kit/score/score_pb"
 import {
     CourseSubmissions,
     Organization,
 } from "../../../proto/qf/requests_pb"
-import { BuildInfo, Score } from "../../../proto/kit/score/score_pb"
-import { Timestamp } from "@bufbuild/protobuf"
+import {
+    Assignment,
+    Course,
+    Enrollment,
+    Enrollment_DisplayState,
+    Enrollment_UserStatus,
+    Enrollments,
+    Grade,
+    GradingBenchmark,
+    GradingCriterion,
+    GradingCriterion_Grade,
+    Group,
+    Group_GroupStatus,
+    Groups,
+    Review,
+    Submission,
+    Submission_Status,
+    Submissions,
+    User,
+} from "../../../proto/qf/types_pb"
 import { SubmissionsForCourse } from "../../Helpers"
 
 export class MockData {
@@ -531,7 +531,7 @@ export class MockData {
     public static mockedCourseSubmissions(courseID: bigint): SubmissionsForCourse {
         const userSubmissions = new CourseSubmissions()
         const groupSubmissions = new CourseSubmissions()
-        
+
         const assignments = MockData.mockedAssignments().filter((a) => a.CourseID === courseID)
         const submissions = MockData.mockedSubmissions().submissions.filter((s) => assignments.map((a) => a.ID).includes(s.AssignmentID))
         const enrollments = MockData.mockedEnrollments().enrollments.filter((e) => e.courseID === courseID)
@@ -539,13 +539,13 @@ export class MockData {
         const sfc = new SubmissionsForCourse()
         for (const enrollment of enrollments) {
             const subs = submissions.filter((s) => s.userID === enrollment.userID)
-            userSubmissions.submissions[enrollment.ID.toString()] = new Submissions({submissions: subs})
+            userSubmissions.submissions[enrollment.ID.toString()] = new Submissions({ submissions: subs })
         }
 
         for (const group of groups) {
             const groupSubs = submissions.filter((s) => s.groupID === group.ID)
-            groupSubmissions.submissions[group.ID.toString()] = new Submissions({submissions: groupSubs})
-        }   
+            groupSubmissions.submissions[group.ID.toString()] = new Submissions({ submissions: groupSubs })
+        }
 
         sfc.setSubmissions("USER", userSubmissions)
         sfc.setSubmissions("GROUP", groupSubmissions)

--- a/public/src/components/ComponentsHelpers.ts
+++ b/public/src/components/ComponentsHelpers.ts
@@ -38,7 +38,16 @@ const generateRow = (enrollment: Enrollment | Group, assignments: AssignmentsMap
             // we should exit early without adding to the row.
             return
         }
-        if (isGroupLab) {
+
+        if (isGroupLab && isEnrollment && !enrollment.groupID) {
+            // If we're dealing with a group assignment, and the enrollment is not part of a group
+            // we should try to find an individual submission instead
+            submission = submissions.ForUser(enrollment)?.find(s => s.AssignmentID.toString() === assignmentID)
+        } else if (isGroupLab) {
+            // If the previous conditions are not met, we have this situation:
+            // - The assignment is a group assignment
+            // - We're either dealing with an enrollment that is part of a group
+            // - or we're dealing with a group
             submission = submissions.ForGroup(enrollment)?.find(s => s.AssignmentID.toString() === assignmentID)
         } else if (isEnrollment) {
             submission = submissions.ForUser(enrollment)?.find(s => s.AssignmentID.toString() === assignmentID)

--- a/public/src/components/ComponentsHelpers.ts
+++ b/public/src/components/ComponentsHelpers.ts
@@ -14,7 +14,7 @@ export const generateSubmissionRows = (elements: Enrollment[] | Group[], generat
     })
 }
 
-const generateRow = (enrollment: Enrollment | Group, assignments: AssignmentsMap, submissions: SubmissionsForCourse, generator: (s: Submission, e?: Enrollment | Group) => RowElement, course?: Course, withID?: boolean): Row => {
+export const generateRow = (enrollment: Enrollment | Group, assignments: AssignmentsMap, submissions: SubmissionsForCourse, generator: (s: Submission, e?: Enrollment | Group) => RowElement, course?: Course, withID?: boolean): Row => {
     const row: Row = []
     const isEnrollment = enrollment instanceof Enrollment
     const isGroup = enrollment instanceof Group
@@ -39,7 +39,7 @@ const generateRow = (enrollment: Enrollment | Group, assignments: AssignmentsMap
             return
         }
 
-        if (isGroupLab && isEnrollment && !enrollment.groupID) {
+        if (isGroupLab && isEnrollment && enrollment.groupID === 0n) {
             // If we're dealing with a group assignment, and the enrollment is not part of a group
             // we should try to find an individual submission instead
             submission = submissions.ForUser(enrollment)?.find(s => s.AssignmentID.toString() === assignmentID)

--- a/public/src/components/ComponentsHelpers.ts
+++ b/public/src/components/ComponentsHelpers.ts
@@ -2,7 +2,7 @@ import { Assignment, Course, Enrollment, Group, Submission } from "../../proto/q
 import { groupRepoLink, SubmissionsForCourse, SubmissionSort, userRepoLink } from "../Helpers"
 import { useActions, useAppState } from "../overmind"
 import { AssignmentsMap } from "../overmind/state"
-import { RowElement, Row } from "./DynamicTable"
+import { Row, RowElement } from "./DynamicTable"
 
 
 export const generateSubmissionRows = (elements: Enrollment[] | Group[], generator: (s: Submission, e?: Enrollment | Group) => RowElement): Row[] => {

--- a/public/src/overmind/actions.tsx
+++ b/public/src/overmind/actions.tsx
@@ -437,7 +437,7 @@ export const refreshCourseSubmissions = async ({ state, effects }: Context, cour
         CourseID: courseID,
         FetchMode: {
             case: "Type",
-            value: SubmissionRequest_SubmissionType.USER
+            value: SubmissionRequest_SubmissionType.ALL
         }
     })
     const groupResponse = await effects.api.client.getSubmissionsByCourse({

--- a/public/src/overmind/actions.tsx
+++ b/public/src/overmind/actions.tsx
@@ -1,14 +1,25 @@
-import { Color, ConnStatus, getStatusByUser, hasAllStatus, hasStudent, hasTeacher, isPending, isStudent, isTeacher, isVisible, newID, setStatusAll, setStatusByUser, SubmissionSort, SubmissionStatus, validateGroup } from "../Helpers"
-import {
-    User, Enrollment, Submission, Course, Group, GradingCriterion, Assignment, GradingBenchmark, Enrollment_UserStatus, Submission_Status, Enrollment_DisplayState, Group_GroupStatus,
-    Grade
-} from "../../proto/qf/types_pb"
-import { Organization, SubmissionRequest_SubmissionType, } from "../../proto/qf/requests_pb"
-import { Alert, CourseGroup, SubmissionOwner } from "./state"
-import * as internalActions from "./internalActions"
-import { Context } from "."
-import { Response } from "../client"
 import { Code, ConnectError } from "@bufbuild/connect"
+import { Context } from "."
+import { Organization, SubmissionRequest_SubmissionType, } from "../../proto/qf/requests_pb"
+import {
+    Assignment,
+    Course,
+    Enrollment,
+    Enrollment_DisplayState,
+    Enrollment_UserStatus,
+    Grade,
+    GradingBenchmark,
+    GradingCriterion,
+    Group,
+    Group_GroupStatus,
+    Submission,
+    Submission_Status,
+    User
+} from "../../proto/qf/types_pb"
+import { Response } from "../client"
+import { Color, ConnStatus, getStatusByUser, hasAllStatus, hasStudent, hasTeacher, isPending, isStudent, isTeacher, isVisible, newID, setStatusAll, setStatusByUser, SubmissionSort, SubmissionStatus, validateGroup } from "../Helpers"
+import * as internalActions from "./internalActions"
+import { Alert, CourseGroup, SubmissionOwner } from "./state"
 
 export const internal = internalActions
 
@@ -189,7 +200,7 @@ export const updateSubmission = async ({ state, effects }: Context, { owner, sub
     }
 
     let clone = submission.clone()
-    
+
     switch (owner.type) {
         case "ENROLLMENT":
             clone = setStatusByUser(clone, owner.id, status)
@@ -213,7 +224,7 @@ export const updateSubmission = async ({ state, effects }: Context, { owner, sub
     state.submissionsForCourse.update(owner, submission)
 }
 
-export const updateGrade = async ({state,  effects }: Context, { grade, status }: { grade: Grade, status: Submission_Status }): Promise<void> => {
+export const updateGrade = async ({ state, effects }: Context, { grade, status }: { grade: Grade, status: Submission_Status }): Promise<void> => {
     if (grade.Status === status || !state.selectedSubmission) {
         return
     }
@@ -221,14 +232,14 @@ export const updateGrade = async ({state,  effects }: Context, { grade, status }
     if (!confirm(`Are you sure you want to set status ${SubmissionStatus[status]} on this grade?`)) {
         return
     }
-    
+
     const clone = state.selectedSubmission.clone()
     clone.Grades = clone.Grades.map(g => {
         if (g.UserID === grade.UserID) {
             g.Status = status
         }
         return g
-    }) 
+    })
     const response = await effects.api.client.updateSubmission({
         courseID: state.activeCourse,
         submissionID: state.selectedSubmission.ID,
@@ -244,10 +255,10 @@ export const updateGrade = async ({state,  effects }: Context, { grade, status }
     const type = clone.userID ? "ENROLLMENT" : "GROUP"
     switch (type) {
         case "ENROLLMENT":
-            state.submissionsForCourse.update({type, id: clone.userID}, clone)
+            state.submissionsForCourse.update({ type, id: clone.userID }, clone)
             break
         case "GROUP":
-            state.submissionsForCourse.update({type, id: clone.groupID}, clone)
+            state.submissionsForCourse.update({ type, id: clone.groupID }, clone)
             break
     }
 }


### PR DESCRIPTION
- fix: refreshCourseSubmissions now fetches `ALL` submissions for enrollments
- feat(ui): the result view shows submissions for group labs for users not part of a group

Resolves #1047 
