### PR TITLE
Ignore push on group repo's non-default branches

### DIFF
--- a/qf/repo.go
+++ b/qf/repo.go
@@ -35,6 +35,10 @@ func (r RepoURL) StudentRepoURL(userName string) string {
 	return fmt.Sprintf("https://%s/%s/%s", r.ProviderURL, r.Organization, StudentRepoName(userName))
 }
 
+func (r RepoURL) GroupRepoURL(groupName string) string {
+	return fmt.Sprintf("https://%s/%s/%s", r.ProviderURL, r.Organization, groupName)
+}
+
 func (r RepoURL) TestsRepoURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", r.ProviderURL, r.Organization, TestsRepo)
 }

--- a/web/hooks/push_test.go
+++ b/web/hooks/push_test.go
@@ -226,3 +226,54 @@ func TestDefaultBranch(t *testing.T) {
 		}
 	}
 }
+
+func TestIgnorePush(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	wh := NewGitHubWebHook(qtest.Logger(t), db, &scm.Manager{}, &ci.Local{}, "secret", stream.NewStreamServices(), nil)
+
+	repo := qf.RepoURL{ProviderURL: "github.com", Organization: "dat520-2024"}
+	usrRepo := &qf.Repository{RepoType: qf.Repository_USER, HTMLURL: repo.StudentRepoURL("user")}
+	grpRepo := &qf.Repository{RepoType: qf.Repository_GROUP, HTMLURL: repo.GroupRepoURL("group")}
+	pushEventRepo := &github.PushEventRepository{DefaultBranch: github.String("main")}
+	pushMain := &github.PushEvent{Ref: github.String("refs/heads/main"), Repo: pushEventRepo}
+	pushFeat := &github.PushEvent{Ref: github.String("refs/heads/feat-branch"), Repo: pushEventRepo}
+	pullFeat := &qf.PullRequest{ScmRepositoryID: 1, TaskID: 1, IssueID: 1, UserID: 1, Number: 1, SourceBranch: "feat-branch"}
+
+	const ignore bool = true
+	tests := []struct {
+		name        string
+		repo        *qf.Repository
+		pushEvent   *github.PushEvent
+		pullRequest *qf.PullRequest
+		want        bool // true = ignore, false = process
+	}{
+		{name: "DefaultBranch/UsrRepo", repo: usrRepo, pushEvent: pushMain, want: !ignore},
+		{name: "DefaultBranch/GrpRepo", repo: grpRepo, pushEvent: pushMain, want: !ignore},
+		{name: "DefaultBranch/UsrRepo/WithPullRequest", repo: usrRepo, pushEvent: pushMain, pullRequest: pullFeat, want: !ignore},
+		{name: "DefaultBranch/GrpRepo/WithPullRequest", repo: grpRepo, pushEvent: pushMain, pullRequest: pullFeat, want: !ignore},
+		{name: "FeatureBranch/UsrRepo", repo: usrRepo, pushEvent: pushFeat, want: ignore},
+		{name: "FeatureBranch/GrpRepo", repo: grpRepo, pushEvent: pushFeat, want: ignore},
+		{name: "FeatureBranch/UsrRepo/WithPullRequest", repo: usrRepo, pushEvent: pushFeat, pullRequest: pullFeat, want: ignore},
+		{name: "FeatureBranch/GrpRepo/WithPullRequest", repo: grpRepo, pushEvent: pushFeat, pullRequest: pullFeat, want: !ignore},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.pullRequest != nil {
+				tt.pullRequest.ID = uint64(i)
+				if err := db.CreatePullRequest(tt.pullRequest); err != nil {
+					t.Fatal(err)
+				}
+				// Clean up between subtests to avoid pull requests being processed in other subtests.
+				t.Cleanup(func() {
+					if err := db.UpdatePullRequest(&qf.PullRequest{ID: tt.pullRequest.ID}); err != nil {
+						t.Fatal(err)
+					}
+				})
+			}
+			if got := wh.ignorePush(tt.pushEvent, tt.repo); got != tt.want {
+				t.Errorf("ignorePush(%s, %s) = %t, want %t", branchName(tt.pushEvent.GetRef()), tt.repo.Name(), got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This ignores push events on group repo's non-default branch. That is, unless the group repo has an associated pull request, in
which case we don't ignore the push event, and run tests and record the results.

Fixes #1053.