### PR TITLE
Fix nil pointer issue when recording results without previous submission

### DIFF
--- a/ci/record_results.go
+++ b/ci/record_results.go
@@ -88,7 +88,7 @@ func (r RunData) newTestRunSubmission(previous *qf.Submission, results *score.Re
 		GroupID:      r.Repo.GetGroupID(),
 		CommitHash:   r.CommitID,
 		Score:        score,
-		Grades:       r.Assignment.IsApproved(previous, score),
+		Grades:       r.Assignment.SubmissionStatus(previous, score),
 		BuildInfo:    results.BuildInfo,
 		Scores:       results.Scores,
 	}

--- a/ci/record_results.go
+++ b/ci/record_results.go
@@ -14,6 +14,11 @@ import (
 // RecordResults for the course and assignment given by the run data structure.
 // If the results argument is nil, then the submission is considered to be a manual review.
 func (r RunData) RecordResults(logger *zap.SugaredLogger, db database.Database, results *score.Results) (*qf.Submission, error) {
+	defer func() {
+		if m := recover(); m != nil {
+			logger.Errorf("Recovered from panic: %v", m)
+		}
+	}()
 	logger.Debugf("Fetching (if any) previous submission for %s", r)
 	previous, err := r.previousSubmission(db)
 	if err != nil && err != gorm.ErrRecordNotFound {

--- a/qf/assignment.go
+++ b/qf/assignment.go
@@ -29,21 +29,10 @@ func (a *Assignment) WithTimeout(timeout time.Duration) (context.Context, contex
 	return context.WithTimeout(context.Background(), timeout)
 }
 
-// IsApproved returns an approved submission status if this assignment is already approved
-// for the latest submission, or if the score of the latest submission is sufficient
-// to autoapprove the assignment.
-func (a *Assignment) IsApproved(latest *Submission, score uint32) []*Grade {
-	switch {
-	case latest.GetGroupID() > 0 && !a.IsGroupLab:
-		// If a group submits to a student assignment, ignore the submission.
-		latest.SetGradeAll(Submission_NONE)
-	case latest.GetUserID() > 0 && a.IsGroupLab:
-		// If a student submits to a group assignment, ignore the submission.
-		latest.SetGradeAll(Submission_NONE)
-	case latest.GetUserID() > 0 && latest.GetGroupID() > 0:
-		// submission cannot be both group and individual
-		return nil
-	case a.GetAutoApprove() && score >= a.GetScoreLimit():
+// SubmissionStatus returns the existing grade submission status, or an approved submission status
+// if the score of the latest submission is sufficient to autoapprove the assignment.
+func (a *Assignment) SubmissionStatus(latest *Submission, score uint32) []*Grade {
+	if a.GetAutoApprove() && score >= a.GetScoreLimit() {
 		latest.SetGradeAll(Submission_APPROVED)
 	}
 	// keep existing status if already approved/revision/rejected

--- a/qf/assignment_test.go
+++ b/qf/assignment_test.go
@@ -4,282 +4,118 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-func TestIsApproved(t *testing.T) {
-	a := &qf.Assignment{}
-	b := &qf.Assignment{
-		ScoreLimit: 80,
+func TestSubmissionStatus(t *testing.T) {
+	const (
+		T = true
+		F = false
+	)
+	auto := &qf.Assignment{AutoApprove: T, ScoreLimit: 80}
+	manual := &qf.Assignment{AutoApprove: F, ScoreLimit: 80}
+	sub := func(status qf.Submission_Status, score uint32) *qf.Submission {
+		return &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: status}}, Score: score}
 	}
-	c := &qf.Assignment{
-		AutoApprove: true,
-		ScoreLimit:  80,
+	grade := func(status qf.Submission_Status) []*qf.Grade {
+		return []*qf.Grade{{UserID: 1, Status: status}}
 	}
-	d := &qf.Assignment{
-		IsGroupLab:  false, // making it explicit that it isn't a group lab
-		AutoApprove: true,
-		ScoreLimit:  90,
-	}
-	e := &qf.Assignment{
-		IsGroupLab:  true, // making it explicit that it is a group lab
-		AutoApprove: true,
-		ScoreLimit:  90,
-	}
-	isApprovedTests := []struct {
+	tests := []struct {
 		name       string
 		assignment *qf.Assignment
 		submission *qf.Submission
 		score      uint32
-		expected   []*qf.Grade
+		want       []*qf.Grade
 	}{
-		{
-			name:       "Assignment:ScoreLimit=0:NoAutoApprove,Submission:Status=NONE:OldScore=50,NewScore:55",
-			assignment: a,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50},
-			score:      55,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=NONE:OldScore=50,NewScore:55",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50},
-			score:      55,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=NONE:OldScore=50,NewScore:80",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50},
-			score:      80,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=NONE:OldScore=80,NewScore:75",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 80},
-			score:      75,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=NONE:OldScore=80,NewScore:85",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 80},
-			score:      85,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=REJECTED:OldScore=50,NewScore:80",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_REJECTED}}, Score: 50},
-			score:      80,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_REJECTED}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=REVISION:OldScore=50,NewScore:80",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_REVISION}}, Score: 50},
-			score:      80,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_REVISION}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=APPROVED:OldScore=50,NewScore:80",
-			assignment: b,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}}, Score: 50},
-			score:      80,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=NONE:OldScore=50,NewScore:55",
-			assignment: c,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50},
-			score:      55,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=NONE:OldScore=50,NewScore:79",
-			assignment: c,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50},
-			score:      79,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=NONE:OldScore=50,NewScore:80",
-			assignment: c,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}}, Score: 50},
-			score:      80,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=APPROVED:OldScore=50,NewScore:0",
-			assignment: c,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}}, Score: 50},
-			score:      0,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_APPROVED}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=APPROVED:OldScore=50,NewScore:80",
-			assignment: c,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_APPROVED},
-					{UserID: 2, Status: qf.Submission_APPROVED},
-				},
-				Score: 50,
-			},
-			score: 80,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_APPROVED},
-				{UserID: 2, Status: qf.Submission_APPROVED},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=APPROVED:OldScore=50,NewScore:0",
-			assignment: c,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_APPROVED},
-				},
-				Score: 50,
-			},
-			score: 0,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_NONE},
-				{UserID: 2, Status: qf.Submission_APPROVED},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=APPROVED:OldScore=50,NewScore:80",
-			assignment: c,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_NONE},
-				},
-				Score: 50,
-			},
-			score: 80,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_APPROVED},
-				{UserID: 2, Status: qf.Submission_APPROVED},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=0:NoAutoApprove,Submission:Status=NONE:OldScore=50,NewScore:95",
-			assignment: a,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_NONE},
-					{UserID: 3, Status: qf.Submission_NONE},
-				},
-				Score: 50,
-			},
-			score: 95,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_NONE},
-				{UserID: 2, Status: qf.Submission_NONE},
-				{UserID: 3, Status: qf.Submission_NONE},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:NoAutoApprove,Submission:Status=NONE:OldScore=50,NewScore:95",
-			assignment: b,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_NONE},
-					{UserID: 3, Status: qf.Submission_NONE},
-				},
-				Score: 50,
-			},
-			score: 95,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_NONE},
-				{UserID: 2, Status: qf.Submission_NONE},
-				{UserID: 3, Status: qf.Submission_NONE},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=NONE:OldScore=0,NewScore:79",
-			assignment: c,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_NONE},
-					{UserID: 3, Status: qf.Submission_NONE},
-				},
-				Score: 0,
-			},
-			score: 79,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_NONE},
-				{UserID: 2, Status: qf.Submission_NONE},
-				{UserID: 3, Status: qf.Submission_NONE},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=80:AutoApprove,Submission:Status=NONE:OldScore=0,NewScore:100",
-			assignment: c,
-			submission: &qf.Submission{
-				Grades: []*qf.Grade{
-					{UserID: 1, Status: qf.Submission_NONE},
-					{UserID: 2, Status: qf.Submission_NONE},
-					{UserID: 3, Status: qf.Submission_NONE},
-				},
-				Score: 0,
-			},
-			score: 100,
-			expected: []*qf.Grade{
-				{UserID: 1, Status: qf.Submission_APPROVED},
-				{UserID: 2, Status: qf.Submission_APPROVED},
-				{UserID: 3, Status: qf.Submission_APPROVED},
-			},
-		},
-		{
-			name:       "Assignment:ScoreLimit=90:AutoApprove,Submission:GroupId=5:Status=NONE:OldScore=0,NewScore:50",
-			assignment: d,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50, GroupID: 5},
-			score:      50,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=90:AutoApprove,Submission:GroupId=5:Status=NONE:OldScore=0,NewScore:95",
-			assignment: d,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 95, GroupID: 5},
-			score:      95,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=90:AutoApprove:IsGroupLab,Submission:UserId=15:Status=NONE:OldScore=0,NewScore:50",
-			assignment: e,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 50, UserID: 15},
-			score:      50,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=90:AutoApprove:IsGroupLab,Submission:UserId=15:Status=NONE:OldScore=0,NewScore:95",
-			assignment: e,
-			submission: &qf.Submission{Grades: []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}}, Score: 95, UserID: 15},
-			score:      95,
-			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
-		},
-		{
-			name:       "Assignment:ScoreLimit=90:AutoApprove:IsGroupLab,Submission:nil,Expected:nil",
-			assignment: e,
-			submission: nil,
-			score:      95,
-			expected:   nil,
-		},
+		// Nil submission
+		{name: "NilSubmission", assignment: auto, submission: nil, score: 85, want: nil},
+		{name: "NilSubmission", assignment: manual, submission: nil, score: 85, want: nil},
+		{name: "NilSubmission", assignment: auto, submission: nil, score: 75, want: nil},
+		{name: "NilSubmission", assignment: manual, submission: nil, score: 75, want: nil},
+		// AutoApprove = true
+		{name: "Approved", assignment: auto, submission: sub(qf.Submission_NONE, 85), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "None", assignment: auto, submission: sub(qf.Submission_NONE, 75), score: 75, want: grade(qf.Submission_NONE)},
+		{name: "AlreadyApproved", assignment: auto, submission: sub(qf.Submission_APPROVED, 75), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: auto, submission: sub(qf.Submission_REVISION, 75), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRejected", assignment: auto, submission: sub(qf.Submission_REJECTED, 75), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyApproved", assignment: auto, submission: sub(qf.Submission_APPROVED, 85), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: auto, submission: sub(qf.Submission_REVISION, 85), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRejected", assignment: auto, submission: sub(qf.Submission_REJECTED, 85), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyApproved", assignment: auto, submission: sub(qf.Submission_APPROVED, 75), score: 79, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: auto, submission: sub(qf.Submission_REVISION, 75), score: 79, want: grade(qf.Submission_REVISION)},
+		{name: "AlreadyRejected", assignment: auto, submission: sub(qf.Submission_REJECTED, 75), score: 79, want: grade(qf.Submission_REJECTED)},
+		// AutoApprove = false
+		{name: "None", assignment: manual, submission: sub(qf.Submission_NONE, 85), score: 85, want: grade(qf.Submission_NONE)},
+		{name: "None", assignment: manual, submission: sub(qf.Submission_NONE, 75), score: 75, want: grade(qf.Submission_NONE)},
+		{name: "AlreadyApproved", assignment: manual, submission: sub(qf.Submission_APPROVED, 85), score: 85, want: grade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: manual, submission: sub(qf.Submission_REVISION, 85), score: 85, want: grade(qf.Submission_REVISION)},
+		{name: "AlreadyRejected", assignment: manual, submission: sub(qf.Submission_REJECTED, 85), score: 85, want: grade(qf.Submission_REJECTED)},
+	}
+	for _, test := range tests {
+		name := qtest.Name("User/"+test.name, []string{"AutoApprove", "ScoreLimit", "PrevStatus", "PrevScore", "Score"}, test.assignment.AutoApprove, test.assignment.ScoreLimit, test.submission.GetGrades(), test.submission.GetScore(), test.score)
+		t.Run(name, func(t *testing.T) {
+			got := test.assignment.SubmissionStatus(test.submission, test.score)
+			if diff := cmp.Diff(got, test.want, protocmp.Transform()); diff != "" {
+				t.Errorf("SubmissionStatus(%v, %v, %d) mismatch (-want +got):\n%s", test.assignment, test.submission, test.score, diff)
+			}
+		})
 	}
 
-	for _, test := range isApprovedTests {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.assignment.IsApproved(test.submission, test.score)
-			if diff := cmp.Diff(got, test.expected, protocmp.Transform()); diff != "" {
-				t.Errorf("IsApproved(%v, %v, %d) mismatch (-want +got):\n%s", test.assignment, test.submission, test.score, diff)
+	groupAuto := &qf.Assignment{AutoApprove: T, ScoreLimit: 80, IsGroupLab: T}
+	groupManual := &qf.Assignment{AutoApprove: F, ScoreLimit: 80, IsGroupLab: T}
+	groupSub := func(status qf.Submission_Status, score uint32) *qf.Submission {
+		return &qf.Submission{Grades: []*qf.Grade{
+			{UserID: 1, Status: status},
+			{UserID: 2, Status: status},
+			{UserID: 3, Status: status},
+		}, Score: score, GroupID: 1}
+	}
+	groupGrade := func(status qf.Submission_Status) []*qf.Grade {
+		return []*qf.Grade{
+			{UserID: 1, Status: status},
+			{UserID: 2, Status: status},
+			{UserID: 3, Status: status},
+		}
+	}
+	groupTests := []struct {
+		name       string
+		assignment *qf.Assignment
+		submission *qf.Submission
+		score      uint32
+		want       []*qf.Grade
+	}{
+		// Nil submission
+		{name: "NilSubmission", assignment: groupAuto, submission: nil, score: 85, want: nil},
+		{name: "NilSubmission", assignment: groupManual, submission: nil, score: 85, want: nil},
+		{name: "NilSubmission", assignment: groupAuto, submission: nil, score: 75, want: nil},
+		{name: "NilSubmission", assignment: groupManual, submission: nil, score: 75, want: nil},
+		// AutoApprove = true
+		{name: "Approved", assignment: groupAuto, submission: groupSub(qf.Submission_NONE, 85), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "None", assignment: groupAuto, submission: groupSub(qf.Submission_NONE, 75), score: 75, want: groupGrade(qf.Submission_NONE)},
+		{name: "AlreadyApproved", assignment: groupAuto, submission: groupSub(qf.Submission_APPROVED, 75), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: groupAuto, submission: groupSub(qf.Submission_REVISION, 75), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRejected", assignment: groupAuto, submission: groupSub(qf.Submission_REJECTED, 75), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyApproved", assignment: groupAuto, submission: groupSub(qf.Submission_APPROVED, 85), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: groupAuto, submission: groupSub(qf.Submission_REVISION, 85), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRejected", assignment: groupAuto, submission: groupSub(qf.Submission_REJECTED, 85), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyApproved", assignment: groupAuto, submission: groupSub(qf.Submission_APPROVED, 75), score: 79, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: groupAuto, submission: groupSub(qf.Submission_REVISION, 75), score: 79, want: groupGrade(qf.Submission_REVISION)},
+		{name: "AlreadyRejected", assignment: groupAuto, submission: groupSub(qf.Submission_REJECTED, 75), score: 79, want: groupGrade(qf.Submission_REJECTED)},
+		// AutoApprove = false
+		{name: "None", assignment: groupManual, submission: groupSub(qf.Submission_NONE, 85), score: 85, want: groupGrade(qf.Submission_NONE)},
+		{name: "None", assignment: groupManual, submission: groupSub(qf.Submission_NONE, 75), score: 75, want: groupGrade(qf.Submission_NONE)},
+		{name: "AlreadyApproved", assignment: groupManual, submission: groupSub(qf.Submission_APPROVED, 85), score: 85, want: groupGrade(qf.Submission_APPROVED)},
+		{name: "AlreadyRevision", assignment: groupManual, submission: groupSub(qf.Submission_REVISION, 85), score: 85, want: groupGrade(qf.Submission_REVISION)},
+		{name: "AlreadyRejected", assignment: groupManual, submission: groupSub(qf.Submission_REJECTED, 85), score: 85, want: groupGrade(qf.Submission_REJECTED)},
+	}
+	for _, test := range groupTests {
+		name := qtest.Name("Group/"+test.name, []string{"AutoApprove", "ScoreLimit", "PrevStatus", "PrevScore", "Score"}, test.assignment.AutoApprove, test.assignment.ScoreLimit, test.submission.GetGrades(), test.submission.GetScore(), test.score)
+		t.Run(name, func(t *testing.T) {
+			got := test.assignment.SubmissionStatus(test.submission, test.score)
+			if diff := cmp.Diff(got, test.want, protocmp.Transform()); diff != "" {
+				t.Errorf("SubmissionStatus(%v, %v, %d) mismatch (-want +got):\n%s", test.assignment, test.submission, test.score, diff)
 			}
 		})
 	}

--- a/qf/assignment_test.go
+++ b/qf/assignment_test.go
@@ -266,6 +266,13 @@ func TestIsApproved(t *testing.T) {
 			score:      95,
 			expected:   []*qf.Grade{{UserID: 1, Status: qf.Submission_NONE}},
 		},
+		{
+			name:       "Assignment:ScoreLimit=90:AutoApprove:IsGroupLab,Submission:nil,Expected:nil",
+			assignment: e,
+			submission: nil,
+			score:      95,
+			expected:   nil,
+		},
 	}
 
 	for _, test := range isApprovedTests {

--- a/qf/submission.go
+++ b/qf/submission.go
@@ -52,7 +52,7 @@ func (s *Submission) SetGrade(userID uint64, status Submission_Status) {
 }
 
 func (s *Submission) SetGradeAll(status Submission_Status) {
-	for idx := range s.Grades {
+	for idx := range s.GetGrades() {
 		s.Grades[idx].Status = status
 	}
 }


### PR DESCRIPTION
Fixes #1142

In addition, we replace IsApproved with a simpler function SubmissionStatus that ignore invalid submissions; instead we record such submissions in the database. That is, if a user submits to a group assignment or a group submits to a user assignment, we still record these results in the database, rather than ignoring them.

This also adds a recovery handler for catching a panic in RecordResult.

