### PR TITLE
kit: add RunCounTest and more

### DIFF
--- a/kit/go.mod
+++ b/kit/go.mod
@@ -5,5 +5,5 @@ go 1.22.5
 require (
 	github.com/alta/protopatch v0.5.3
 	github.com/google/go-cmp v0.6.0
-	google.golang.org/protobuf v1.34.2
+	google.golang.org/protobuf v1.35.2
 )

--- a/kit/go.sum
+++ b/kit/go.sum
@@ -2,7 +2,5 @@ github.com/alta/protopatch v0.5.3 h1:U0/UzEeFFTLm0+zW7E/zCi9yjV6QIPPR3InZ/SakLdU
 github.com/alta/protopatch v0.5.3/go.mod h1:aD5JWR4D9s/sTBoTNoZDiFY2SUTYAWiQ8T9a1tttPYI=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
-google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
+google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/kit/sh/cmd_race_test.go
+++ b/kit/sh/cmd_race_test.go
@@ -1,0 +1,61 @@
+//go:build race
+
+package sh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/kit/internal/test"
+)
+
+func TestRunRaceTest(t *testing.T) {
+	tests := []struct {
+		testFn           func(*testing.T)
+		expectedRace     bool
+		expectedOutput   string
+		unexpectedOutput string
+	}{
+		{
+			testFn:           TestWithDataRace,
+			expectedRace:     true,
+			expectedOutput:   "WARNING: DATA RACE",
+			unexpectedOutput: "PASS",
+		},
+		{
+			testFn:           TestWithoutDataRace,
+			expectedRace:     false,
+			expectedOutput:   "PASS",
+			unexpectedOutput: "WARNING: DATA RACE",
+		},
+	}
+
+	// unexpected returns Unexpected if race is true, otherwise Expected.
+	// This is used to make the test output more readable.
+	// It should only be used together with race != expectedRace.
+	unexpected := func(race bool) string {
+		if race {
+			return "Unexpected"
+		}
+		return "Expected"
+	}
+
+	for _, tt := range tests {
+		testName := test.Name(tt.testFn)
+		t.Run(testName, func(t *testing.T) {
+			// The tags argument is the empty string; we are currently not testing it.
+			output, race := RunRaceTest(tt.testFn, "")
+			if race != tt.expectedRace {
+				t.Errorf("%s data race warning from %s", unexpected(race), testName)
+			}
+			if !strings.Contains(output, tt.expectedOutput) {
+				t.Errorf("Expected output with '%s' from %s", tt.expectedOutput, testName)
+				t.Log(output)
+			}
+			if strings.Contains(output, tt.unexpectedOutput) {
+				t.Errorf("Unexpected output with '%s' from %s", tt.unexpectedOutput, testName)
+				t.Log(output)
+			}
+		})
+	}
+}

--- a/kit/sh/cmd_test.go
+++ b/kit/sh/cmd_test.go
@@ -3,7 +3,6 @@ package sh_test
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/quickfeed/quickfeed/kit/sh"
@@ -48,67 +47,11 @@ func TestLintAG(t *testing.T) {
 	}
 
 	// check many things: probably too aggressive for DAT320
-	s, err = sh.Output("golangci-lint run --tests=true --disable structcheck --disable unused --disable deadcode --disable varcheck")
+	s, err = sh.Output("golangci-lint run --tests=true --disable unused")
 	if err != nil {
 		t.Error(err)
 	}
 	if s != "" {
 		fmt.Println(s)
-	}
-}
-
-func TestRunRaceTest(t *testing.T) {
-	tests := []struct {
-		testName         string
-		expectedRace     bool
-		expectedOutput   string
-		unexpectedOutput string
-	}{
-		{
-			testName:         "TestWithDataRace",
-			expectedRace:     true,
-			expectedOutput:   "WARNING: DATA RACE",
-			unexpectedOutput: "PASS",
-		},
-		{
-			testName:         "TestWithoutDataRace",
-			expectedRace:     false,
-			expectedOutput:   "PASS",
-			unexpectedOutput: "WARNING: DATA RACE",
-		},
-		{
-			testName:         "TestThatDoesNotExist",
-			expectedRace:     false,
-			expectedOutput:   "warning: no tests to run",
-			unexpectedOutput: "WARNING: DATA RACE",
-		},
-	}
-
-	// unexpected returns Unexpected if race is true, otherwise Expected.
-	// This is used to make the test output more readable.
-	// It should only be used together with race != expectedRace.
-	unexpected := func(race bool) string {
-		if race {
-			return "Unexpected"
-		}
-		return "Expected"
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			// The tags argument is the empty string; we are currently not testing it.
-			output, race := sh.RunRaceTest(tt.testName, "")
-			if race != tt.expectedRace {
-				t.Errorf("%s data race warning from %s", unexpected(race), tt.testName)
-			}
-			if !strings.Contains(output, tt.expectedOutput) {
-				t.Errorf("Expected output with '%s' from %s", tt.expectedOutput, tt.testName)
-				t.Log(output)
-			}
-			if strings.Contains(output, tt.unexpectedOutput) {
-				t.Errorf("Unexpected output with '%s' from %s", tt.unexpectedOutput, tt.testName)
-				t.Log(output)
-			}
-		})
 	}
 }


### PR DESCRIPTION
This is in preparation for releasing **QuickFeed's kit module release v0.11.0**.

# github.com/quickfeed/quickfeed/kit/sh
## incompatible changes
RunRaceTest: changed from func(string, string) (string, bool) to func(func(*testing.T), string) (string, bool)
## compatible changes
MustRun: added
RunCountTest: added

