### PR TITLE
Updated the parameter in delete repository to only require ID instead of the whole opt object

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -239,7 +239,7 @@ func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentO
 	if _, err := s.client.Organizations.RemoveMember(ctx, org.ScmOrganizationName, opt.User); err != nil {
 		return E(op, m, fmt.Errorf("failed to remove user: %w", err))
 	}
-	if err := s.deleteRepository(ctx, &RepositoryOptions{ID: opt.RepositoryID}); err != nil {
+	if err := s.deleteRepository(ctx, opt.RepositoryID); err != nil {
 		return E(op, m, err)
 	}
 	return nil
@@ -321,11 +321,11 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 }
 
 // DeleteGroup deletes a group's repository.
-func (s *GithubSCM) DeleteGroup(ctx context.Context, opt *RepositoryOptions) error {
+func (s *GithubSCM) DeleteGroup(ctx context.Context, id uint64) error {
 	const op Op = "DeleteGroup"
 
 	// options will be checked in deleteRepository
-	if err := s.deleteRepository(ctx, opt); err != nil {
+	if err := s.deleteRepository(ctx, id); err != nil {
 		return E(op, M("failed to delete group repository"), err)
 	}
 	return nil
@@ -388,25 +388,27 @@ func (s *GithubSCM) createRepository(ctx context.Context, opt *CreateRepositoryO
 }
 
 // deleteRepository deletes repository by name or ID.
-func (s *GithubSCM) deleteRepository(ctx context.Context, opt *RepositoryOptions) error {
+func (s *GithubSCM) deleteRepository(ctx context.Context, id uint64) error {
 	const op Op = "deleteRepository"
 	m := M("failed to delete repository")
-	if !opt.valid() {
+	/*if !opt.valid() {
 		return E(op, m, fmt.Errorf("missing fields: %+v", *opt))
-	}
+	}*/
 
 	// if ID provided, get path and owner from github
-	if opt.ID > 0 {
-		repo, _, err := s.client.Repositories.GetByID(ctx, int64(opt.ID))
+	var repo_name string
+	var repo_owner string
+	if id > 0 {
+		repo, _, err := s.client.Repositories.GetByID(ctx, int64(id))
 		if err != nil {
-			return E(op, m, fmt.Errorf("failed to get repository %d: %w", opt.ID, err))
+			return E(op, m, fmt.Errorf("failed to get repository %d: %w", id, err))
 		}
-		opt.Repo = repo.GetName()
-		opt.Owner = repo.Owner.GetLogin()
+		repo_name = repo.GetName()
+		repo_owner = repo.Owner.GetLogin()
 	}
 
-	if _, err := s.client.Repositories.Delete(ctx, opt.Owner, opt.Repo); err != nil {
-		return E(op, M("failed to delete repository %s/%s", opt.Owner, opt.Repo), err)
+	if _, err := s.client.Repositories.Delete(ctx, repo_owner, repo_name); err != nil {
+		return E(op, M("failed to delete repository %s/%s", repo_owner, repo_name), err)
 	}
 	return nil
 }

--- a/scm/github_mock_test.go
+++ b/scm/github_mock_test.go
@@ -583,10 +583,10 @@ func TestMockDeleteGroup(t *testing.T) {
 		{name: "CompleteRequest/NotFound", opt: &RepositoryOptions{Owner: "bar", Repo: "foo"}, wantErr: true},
 		{name: "CompleteRequest/NotFound", opt: &RepositoryOptions{ID: 432}, wantErr: true}, // Repo ID 432 does not exist
 
-		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{Owner: "foo", Repo: "groupX"}, wantErr: false}, // ID 6
-		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 5}, wantErr: false},                        // ID 5 is josie-labs
-		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{Owner: "bar", Repo: "groupY"}, wantErr: false}, // ID 7
-		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 8}, wantErr: false},                        // ID 8 is groupZ
+		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 6, Owner: "foo", Repo: "groupX"}, wantErr: false}, // ID 6
+		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 5}, wantErr: false},                               // ID 5 is josie-labs
+		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 7, Owner: "bar", Repo: "groupY"}, wantErr: false}, // ID 7
+		{name: "CompleteRequest/GroupDeleted", opt: &RepositoryOptions{ID: 8}, wantErr: false},                               // ID 8 is groupZ
 
 		{name: "CompleteRequest/AlreadyDeleted", opt: &RepositoryOptions{ID: 6}, wantErr: true},                        // ID 6 already deleted
 		{name: "CompleteRequest/AlreadyDeleted", opt: &RepositoryOptions{ID: 7}, wantErr: true},                        // ID 7 already deleted
@@ -596,7 +596,7 @@ func TestMockDeleteGroup(t *testing.T) {
 	for _, tt := range tests {
 		name := qtest.Name(tt.name, []string{"Owner", "Path"}, tt.opt.Owner, tt.opt.Repo)
 		t.Run(name, func(t *testing.T) {
-			if err := s.DeleteGroup(context.Background(), tt.opt); (err != nil) != tt.wantErr {
+			if err := s.DeleteGroup(context.Background(), tt.opt.ID); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteGroup() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			// verify the state of the groups after the test

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -31,7 +31,7 @@ type SCM interface {
 	// UpdateGroupMembers adds or removes members of an existing group.
 	UpdateGroupMembers(context.Context, *GroupOptions) error
 	// DeleteGroup deletes group's repository.
-	DeleteGroup(context.Context, *RepositoryOptions) error
+	DeleteGroup(context.Context, uint64) error
 
 	// Clone clones the given repository and returns the path to the cloned repository.
 	// The returned path is the provided destination directory joined with the


### PR DESCRIPTION
The entries in the TestMockDeleteGroup can be reduced since the method delete group does not require opt anymore and therefore is only used when confirming the deletion of a group in the test itself