### PR TITLE
Feat: Support for hardcoded go module cache via host-mounted volume

### DIFF
--- a/.vscode/quickfeed-words.txt
+++ b/.vscode/quickfeed-words.txt
@@ -1,4 +1,5 @@
 addstore
+adduser
 agpath
 alecthomas
 Alloc
@@ -14,6 +15,7 @@ autograde
 Autograder
 backports
 beatlabs
+binutils
 bitlab
 Bobsen
 Buf's
@@ -55,6 +57,7 @@ espeland
 Etternavn
 excelize
 extendee
+extldflags
 fileop
 Fornavn
 Frøyland
@@ -71,15 +74,18 @@ gofumpt
 goimports
 golangci
 Gollum
+GOMODCACHE
 googleapis
 gopath
 gopb
 gopls
 Gorm
 gormlogger
+GOROOT
 gosecret
 gosimple
 gotest
+GOTOOLCHAIN
 goveralls
 Grafana
 Grafana's
@@ -115,6 +121,7 @@ keyout
 killall
 labstack
 Lamport
+ldflags
 letsencrypt
 Lindhom
 linuxbrew
@@ -137,6 +144,7 @@ npmtools
 npmwebpack
 NTNU
 oneof
+openrc
 Operativsystemer
 opsys
 orgs

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -26,6 +26,7 @@ import (
 var (
 	DefaultContainerTimeout = time.Duration(10 * time.Minute)
 	QuickFeedPath           = "/quickfeed"
+	GoModCache              = "/quickfeed-go-mod-cache"
 	maxToScan               = 1_000_000 // bytes
 	maxLogSize              = 30_000    // bytes
 	lastSegmentSize         = 1_000     // bytes
@@ -137,12 +138,21 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*container.CreateRe
 
 	var hostConfig *container.HostConfig
 	if job.BindDir != "" {
+		goModCacheSrc, err := moduleCachePath()
+		if err != nil {
+			return nil, err
+		}
 		hostConfig = &container.HostConfig{
 			Mounts: []mount.Mount{
 				{
 					Type:   mount.TypeBind,
 					Source: job.BindDir,
 					Target: QuickFeedPath,
+				},
+				{
+					Type:   mount.TypeBind,
+					Source: goModCacheSrc,
+					Target: GoModCache,
 				},
 			},
 		}

--- a/ci/module_cache.go
+++ b/ci/module_cache.go
@@ -1,0 +1,22 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// moduleCachePath returns quickfeed's go module cache.
+// If the directory does not exist, it will be created.
+func moduleCachePath() (string, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	goModCacheSrc := filepath.Join(homedir, GoModCache)
+	if ok, _ := exists(goModCacheSrc); !ok {
+		if err := os.MkdirAll(goModCacheSrc, 0o755); err != nil {
+			return "", err
+		}
+	}
+	return goModCacheSrc, nil
+}

--- a/ci/module_cache_test.go
+++ b/ci/module_cache_test.go
@@ -1,0 +1,29 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestModuleCachePath(t *testing.T) {
+	// Uncomment the following line to run the test locally; do not commit the change
+	t.Skip("Only for local testing; should not be run on quickfeed server")
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(filepath.Join(homedir, GoModCache))
+
+	path, err := moduleCachePath()
+	if err != nil {
+		t.Error(err)
+	}
+	if path != filepath.Join(homedir, GoModCache) {
+		t.Errorf("moduleCachePath() = %s, want %s", path, filepath.Join(homedir, GoModCache))
+	}
+	if ok, err := exists(path); !ok {
+		t.Errorf("%s does not exist: %v", path, err)
+	}
+	t.Logf("path: %s", path)
+}

--- a/doc/templates/go-course/scripts/Dockerfile-dat520
+++ b/doc/templates/go-course/scripts/Dockerfile-dat520
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+# Stage 1: Build golangci-lint
+FROM golang:1.24-rc-alpine as builder
+
+# Install bash and git (and build-base to get gcc)
+# (this is required when building FROM: golang:alpine)
+# RUN apk update && apk add --no-cache git bash build-base binutils docker openrc
+
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev git mercurial binutils binutils-gold bash docker openrc
+
+# related to https://github.com/golangci/golangci-lint/issues/3107
+ENV GOROOT /usr/local/go
+ENV GOTOOLCHAIN auto
+# Set Go module cache location in the builder stage
+ENV GOMODCACHE=/go-build-cache
+
+# Install golangci-lint
+RUN go install -ldflags="-extldflags=-fuse-ld=bfd" github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+# Stage 2: Final image
+FROM golang:1.24-rc-alpine
+
+# Install runtime dependencies
+RUN apk add --no-cache bash git docker openrc
+
+ENV GOROOT /usr/local/go
+ENV GOTOOLCHAIN auto
+# Set Go module cache location in the runtime stage
+ENV GOMODCACHE=/quickfeed-go-mod-cache
+
+# Create a quickfeed user with UID 1001 to match the host user
+RUN adduser -D -u 1001 quickfeed
+
+# Copy the golangci-lint binary from the builder stage
+COPY --from=builder /go/bin/golangci-lint /usr/local/bin/golangci-lint
+
+WORKDIR /quickfeed
+USER quickfeed

--- a/doc/templates/go-course/scripts/README.md
+++ b/doc/templates/go-course/scripts/README.md
@@ -1,0 +1,60 @@
+# Debugging and Testing the Dockerfile (for dat520)
+
+The main command is this one:
+
+```console
+docker run -it --rm -v /tmp/go-mod-cache:/quickfeed-go-mod-cache -v ~/work/distsys/2025/meling-labs:/quickfeed dat520:latest /bin/bash
+```
+
+This provides a temporary directory for the go mod cache and mounts a course repo into the image.
+These are mapped to these locations in the image:
+
+- `/quickfeed-go-mod-cache`
+- `/quickfeed`
+
+Note that the quickfeed server will set up these mounts automatically when running the tests.
+
+Below are some relevant commands to test the image.
+
+```console
+# Build the image
+$ cd scripts
+$ docker build -t dat520:latest .
+# Check that the image is built
+$ docker images
+# Make a temporary directory for the go mod cache
+$ mkdir /tmp/go-mod-cache
+# Run the image interactively and remove it when done
+# Mount the go mod cache and the course repo (~/work/distsys/2025/meling-labs)
+$ docker run -it --rm -v /tmp/go-mod-cache:/quickfeed-go-mod-cache -v ~/work/distsys/2025/meling-labs:/quickfeed dat520:latest /bin/bash
+# Inside the container
+$ alias l='ls -la'
+# Poke around in the image
+$ l /quickfeed
+$ l /quickfeed-go-mod-cache
+# Check the go version and golangci-lint version
+$ which golangci-lint
+$ golangci-lint --version
+$ which go
+$ go version
+# Move to the uecho lab and run the tests
+$ cd /quickfeed/lab1/uecho
+$ go test -v
+go: downloading golang.org/x/text v0.21.0
+go: downloading golang.org/x/sync v0.10.0
+=== RUN   TestEchoServerProtocol
+2025/01/17 21:41:48 waiting connection...
+--- PASS: TestEchoServerProtocol (0.00s)
+=== RUN   TestPreAndPostSetup
+2025/01/17 21:41:48 waiting connection...
+--- PASS: TestPreAndPostSetup (0.00s)
+=== RUN   TestMalformedRequest
+2025/01/17 21:41:48 waiting connection...
+--- PASS: TestMalformedRequest (0.00s)
+PASS
+ok  	dat520/lab1/uecho	0.004s
+# Check that the go mod cache is populated
+$ ls /quickfeed-go-mod-cache/
+cache       golang.org
+$ exit
+```


### PR DESCRIPTION
This adds hardcoded support for host-mounted go module cache.
The current implementation creates a folder for the module cache
in $HOME/quickfeed-go-mod-cache. We may consider making this a
configuration option in the future.

Fixes #1187

