### PR TITLE
Use domain sockets for passing score objects separated from test log output

### DIFF
--- a/kit/score/registry.go
+++ b/kit/score/registry.go
@@ -3,6 +3,7 @@ package score
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 
@@ -14,6 +15,7 @@ import (
 type registry struct {
 	testNames []string          // testNames in registration order
 	scores    map[string]*Score // map from TestName to score object
+	conn      net.Conn          // connection to session socket
 }
 
 func NewRegistry() *registry { // skipcq: RVV-B0011
@@ -56,7 +58,7 @@ func (s *registry) PrintTestInfo(sorted ...bool) {
 	// iterate over the test names in registration or sorted order
 	for _, name := range s.testNames {
 		if sc, ok := s.scores[name]; ok {
-			fmt.Println(sc.json())
+			fmt.Println(sc.JSON())
 		}
 	}
 	// force exit after printing test info if SCORE_INIT is set

--- a/kit/score/registry_socket.go
+++ b/kit/score/registry_socket.go
@@ -1,0 +1,32 @@
+package score
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+)
+
+// NewSocketRegistry creates a new score registry that connects to the session socket
+// for the current session. If the connection fails, it falls back to standard stdout
+// score reporting.
+func NewSocketRegistry() *registry { // skipcq: RVV-B0011
+	socketPath := filepath.Join(rootSocketDir, sessionSecret+".sock")
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		fmt.Printf("failed to connect to session socket: %v\n", err)
+		// if we failed to connect, we fall back to standard stdout score reporting
+	}
+	return &registry{
+		testNames: make([]string, 0),
+		scores:    make(map[string]*Score),
+		conn:      conn,
+	}
+}
+
+// PrintToSocket prints the score object to the session socket.
+func (s *registry) PrintToSocket(t *testing.T, sc *Score) {
+	// print JSON score object: {"Secret":"my secret code","TestName": ...}
+	fmt.Fprintln(s.conn, sc.JSON())
+	s.conn.Close()
+}

--- a/kit/score/score.go
+++ b/kit/score/score.go
@@ -91,7 +91,7 @@ func (s *Score) Print(t *testing.T, msg ...string) {
 	// scanning long student generated output lines can be costly.
 	fmt.Println()
 	// print JSON score object: {"Secret":"my secret code","TestName": ...}
-	fmt.Println(s.json())
+	fmt.Println(s.JSON())
 }
 
 // PanicHandler recovers from a panicking test, resets the score to zero and
@@ -120,8 +120,8 @@ func (s *Score) internalFail(t *testing.T) {
 	t.Fail()
 }
 
-// json returns a JSON string for the score object.
-func (s *Score) json() string {
+// JSON returns a JSON string for the score object.
+func (s *Score) JSON() string {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Sprintf("json.Marshal error: %v\n", err)

--- a/kit/score/session.go
+++ b/kit/score/session.go
@@ -1,0 +1,118 @@
+package score
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// rootSocketDir is the root directory for the Unix domain sockets.
+const rootSocketDir = "/tmp/quickfeed-sessions"
+
+// session encapsulates the state of a session.
+type session struct {
+	wg                sync.WaitGroup
+	mu                sync.Mutex
+	activeConnections int
+	socketPath        string
+	listener          net.Listener
+}
+
+// newSession creates a new session for the given socketPath.
+func newSession(sessionSecret string) (*session, error) {
+	socketPath := filepath.Join(rootSocketDir, sessionSecret+".sock")
+	// remove an existing socket file, if it exists (shouldn't happen)
+	_ = os.Remove(socketPath)
+
+	// create listener for the session-specific Unix domain socket
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener: %w", err)
+	}
+
+	return &session{
+		socketPath: socketPath,
+		listener:   listener,
+	}, nil
+}
+
+// incActiveConnections increments the active connection count.
+func (s *session) incActiveConnections() {
+	s.wg.Add(1)
+	s.mu.Lock()
+	s.activeConnections++
+	s.mu.Unlock()
+}
+
+// decActiveConnections decrements the active connection count.
+// If no connections remain, it cleans up the socket file.
+func (s *session) decActiveConnections() {
+	s.mu.Lock()
+	s.activeConnections--
+	if s.activeConnections == 0 {
+		// fmt.Println("No active connections; cleaning up socket and closing listener.")
+		// close the listener to stop accepting new connections and remove the socket file
+		_ = s.listener.Close()
+		_ = os.Remove(s.socketPath)
+	}
+	s.mu.Unlock()
+	s.wg.Done()
+}
+
+// NewSocket creates a new Unix domain socket for the session.
+// This will block until the listener is closed by the last client,
+// or the context is canceled.
+func NewSocket(ctx context.Context, sessionSecret string) error {
+	// ensure the root socket directory exists
+	if err := os.MkdirAll(rootSocketDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create root socket directory: %w", err)
+	}
+
+	// create Unix domain socket for the session
+	sess, err := newSession(sessionSecret)
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		// fmt.Println("Context canceled; shutting down listener.")
+		// Close the listener to break the accept loop
+		_ = sess.listener.Close()
+	}()
+
+	for {
+		conn, err := sess.listener.Accept()
+		if err != nil {
+			// fmt.Printf("Error accepting connection on socket %s: %v\n", sess.socketPath, err)
+			// if the listener is closed, stop accepting new connections
+			return nil
+		}
+
+		sess.incActiveConnections()
+
+		go func(conn net.Conn) {
+			defer sess.decActiveConnections()
+			defer conn.Close()
+
+			scanner := bufio.NewScanner(conn)
+			for scanner.Scan() {
+				line := scanner.Text()
+				score, err := parse(line, sessionSecret)
+				if err != nil {
+					// fmt.Printf("Connection closed: invalid message: %s (error: %v)\n", line, err)
+					// invalid message; closing connection
+					return
+				}
+				fmt.Printf("Valid score received: %v\n", score)
+			}
+			if err := scanner.Err(); err != nil {
+				fmt.Printf("Error reading from connection: %v\n", err)
+			}
+		}(conn)
+	}
+}

--- a/kit/score/session_test.go
+++ b/kit/score/session_test.go
@@ -1,0 +1,48 @@
+package score
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/quickfeed/quickfeed/kit/sh"
+)
+
+// To run this test, use this command:
+//
+//	QUICKFEED_SESSION_SECRET=just-testing go test -v -run TestNewSocket
+func TestNewSocket(t *testing.T) {
+	go func() {
+		if err := NewSocket(context.Background(), sessionSecret); err != nil {
+			t.Error(err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	env := []string{"QUICKFEED_SESSION_SECRET=" + sessionSecret}
+	sh.MustRunEnv(true, env, "testdata/session", "go", "test", "-v", "-run", "TestFibonacci")
+}
+
+func TestNewSocketTimeout(t *testing.T) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		if err := NewSocket(ctx, sessionSecret); err != nil {
+			t.Error(err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// try to dial the socket after it should have been closed
+	socketPath := filepath.Join(rootSocketDir, sessionSecret+".sock")
+	_, err := net.Dial("unix", socketPath)
+	wantErr := fmt.Sprintf("dial unix %s: connect: no such file or directory", socketPath)
+	if err == nil {
+		t.Errorf("socket should not be available, want error: %s", wantErr)
+	}
+	if err.Error() != wantErr {
+		t.Errorf("got error: %v, want error: %s", err, wantErr)
+	}
+}

--- a/kit/score/testdata/session/fib.go
+++ b/kit/score/testdata/session/fib.go
@@ -1,0 +1,13 @@
+package session
+
+// fibonacci(n) returns the n-th Fibonacci number, and is defined by the
+// recurrence relation F_n = F_n-1 + F_n-2, with seed values F_0=0 and F_1=1.
+func fibonacci(n uint) uint {
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return 1
+	}
+	return fibonacci(n-1) + fibonacci(n-2)
+}

--- a/kit/score/testdata/session/fib_test.go
+++ b/kit/score/testdata/session/fib_test.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+	"testing"
+)
+
+func init() {
+	scores.Add(TestFibonacci, len(fibonacciTests), 5)
+}
+
+var fibonacciTests = []struct {
+	in, want uint
+}{
+	{1, 1},
+	{2, 1},
+	{3, 2},
+	{4, 3},
+	{5, 5},
+	{6, 8},
+	{7, 13},
+	{8, 21},
+	{9, 34},
+	{10, 55},
+	{12, 144},
+	{16, 987},
+	{20, 6765},
+}
+
+func TestFibonacci(t *testing.T) {
+	sc := scores.Max()
+	defer scores.PrintToSocket(t, sc)
+
+	for _, ft := range fibonacciTests {
+		got := fibonacci(ft.in)
+		if got != ft.want {
+			t.Errorf("fibonacci(%d) = %d, want %d", ft.in, got, ft.want)
+			sc.Dec()
+		}
+	}
+}

--- a/kit/score/testdata/session/main_test.go
+++ b/kit/score/testdata/session/main_test.go
@@ -1,0 +1,20 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/kit/score"
+)
+
+var scores = score.NewSocketRegistry()
+
+func TestMain(m *testing.M) {
+	scores.PrintTestInfo()
+	exitCode := m.Run()
+	if err := scores.Validate(); err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(exitCode)
+}

--- a/kit/sh/cmd.go
+++ b/kit/sh/cmd.go
@@ -29,6 +29,23 @@ func MustRun(output bool, wd, cmd string, args ...string) {
 	}
 }
 
+// MustRun runs the given command with wd as the working directory,
+// and prints the output to stdout/stderr if output is true.
+// If the command fails, MustRun panics.
+func MustRunEnv(output bool, env []string, wd, cmd string, args ...string) {
+	c := exec.Command(cmd, args...)
+	c.Env = append(c.Environ(), env...)
+	c.Dir = wd
+	if output {
+		c.Stderr = os.Stderr
+		c.Stdout = os.Stdout
+		log.Println("running:", cmd, strings.Join(args, " "))
+	}
+	if err := c.Run(); err != nil {
+		panic(fmt.Sprintf("failed to run %s %v: %v", cmd, args, err))
+	}
+}
+
 // Run runs the given command, directing stderr to the command's stderr and
 // printing stdout to stdout. Run returns an error if any.
 func Run(cmd string) error {


### PR DESCRIPTION
This adds NewSocket() for server-side (quickfeed server) to create
a new unix domain socket for sending score JSON objects on a
separate channel from the vanilla stdout we currently use.
To take advantage of this, the main_test.go file need to use the
NewSocketRegistry() and instead of doing defer sc.Print(t), we must
do defer scores.PrintToSocket(t, sc).

Note, we can avoid doing NewSocketRegistry by adding its code into
the current NewRegistry() and ignore the error and fall back to the
stdout version if the domain socket isn't available. I'm undecided
if we want to do that or not. Letting it brew for a while.

Fixes #385

