### PR TITLE
feat: add file watcher for live-reloading in development environment

### DIFF
--- a/.vscode/quickfeed-words.txt
+++ b/.vscode/quickfeed-words.txt
@@ -61,6 +61,7 @@ extldflags
 fileop
 Fornavn
 Frøyland
+fsnotify
 fullchain
 Getwd
 githubv

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alta/protopatch v0.5.3
 	github.com/beatlabs/github-auth v0.0.0-20240615135342-292f72d79b19
 	github.com/docker/docker v27.1.1+incompatible
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.6.0
@@ -44,7 +45,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -1,0 +1,113 @@
+package reload
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type Watcher struct {
+	clients map[chan string]bool
+	mu      sync.Mutex
+}
+
+// NewWatcher creates a new watcher for the given path.
+// The watcher listens for file changes and broadcasts them to all connected clients.
+// Note: Usually you only ever have one client as this is intended for live-reloading
+// a web page in a development environment.
+func NewWatcher(path string) *Watcher {
+	watcher := &Watcher{
+		clients: make(map[chan string]bool),
+	}
+	go watcher.watch(path)
+	return watcher
+}
+
+func (w *Watcher) watch(path string) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+	// Start watching the given path.
+	err = watcher.Add(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start listening for events.
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// We only care about writes and creates.
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				// Broadcast event to all clients.
+				w.broadcastMessage(event.Name)
+			}
+
+		case err := <-watcher.Errors:
+			if err != nil {
+				log.Println("error:", err)
+			}
+		}
+	}
+}
+
+func (w *Watcher) addClient(ch chan string) {
+	w.mu.Lock()
+	w.clients[ch] = true
+	w.mu.Unlock()
+}
+
+// Remove a disconnected client
+func (w *Watcher) removeClient(ch chan string) {
+	w.mu.Lock()
+	delete(w.clients, ch)
+	close(ch)
+	w.mu.Unlock()
+}
+
+// Broadcast a message to all clients
+func (w *Watcher) broadcastMessage(msg string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for ch := range w.clients {
+		select {
+		case ch <- msg:
+			continue
+		default:
+			log.Println("Failed to send message to client")
+		}
+	}
+}
+
+func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Create a new channel for this client
+	client := make(chan string)
+	watcher.addClient(client)
+
+	// Listen for changes and send updates
+	for {
+		select {
+		case msg, ok := <-client:
+			if !ok {
+				return
+			}
+			fmt.Fprintf(w, "data: %s\n\n", msg)
+			w.(http.Flusher).Flush()
+		case <-r.Context().Done(): // Client disconnected
+			watcher.removeClient(client)
+			return
+		}
+	}
+}

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -12,58 +12,53 @@ import (
 )
 
 type Watcher struct {
-	clients map[chan string]bool
-	mu      sync.Mutex
+	fsWatcher *fsnotify.Watcher
+	clients   map[chan string]bool
+	mu        sync.Mutex
 }
 
 // NewWatcher creates a new watcher for the given path.
 // The watcher listens for file changes and broadcasts them to all connected clients.
-// Note: Usually you only ever have one client as this is intended for live-reloading
-// a web page in a development environment.
+// While a single client is the most common use case, multiple clients can connect to
+// the same watcher, e.g., for live-reloading the web page in different browsers.
 func NewWatcher(ctx context.Context, path string) (*Watcher, error) {
-	watcher := &Watcher{
-		clients: make(map[chan string]bool),
-	}
-	watchFunc, err := watcher.start(path)
+	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
-	go watchFunc(ctx) // Start watching for file changes
-	go webpack()      // Start webpack in watch mode
+	if err = fsWatcher.Add(path); err != nil {
+		return nil, err
+	}
+	watcher := &Watcher{
+		fsWatcher: fsWatcher,
+		clients:   make(map[chan string]bool),
+	}
+	go watcher.start(ctx) // Start watching for file changes
+	go webpack()          // Start webpack in watch mode
 	return watcher, nil
 }
 
-func (w *Watcher) start(path string) (func(ctx context.Context), error) {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	err = watcher.Add(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// Start listening for events.
-	return func(ctx context.Context) {
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return // Watcher closed
-				}
-				// We only care about writes and creates.
-				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-					// Broadcast event to all clients.
-					w.broadcastMessage(event.Name)
-				}
-			case err := <-watcher.Errors:
-				log.Println("error watching files:", err)
-			case <-ctx.Done():
-				watcher.Close()
-				return
+// start listening for events and broadcast them to clients.
+// The watcher will stop when the context is canceled.
+func (w *Watcher) start(ctx context.Context) {
+	for {
+		select {
+		case event, ok := <-w.fsWatcher.Events:
+			if !ok {
+				return // Watcher closed
 			}
+			// We only care about writes and creates.
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				// Broadcast event to all clients.
+				w.broadcastMessage(event.Name)
+			}
+		case err := <-w.fsWatcher.Errors:
+			log.Println("error watching files:", err)
+		case <-ctx.Done():
+			w.fsWatcher.Close()
+			return
 		}
-	}, nil
+	}
 }
 
 // Add a new client
@@ -107,7 +102,7 @@ func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case msg := <-client:
-			fmt.Fprintf(w, "data: %s\n\n", msg)
+			fmt.Fprintf(w, "data: %s\n", msg)
 			w.(http.Flusher).Flush()
 		case <-r.Context().Done(): // Client disconnected
 			watcher.removeClient(client)
@@ -118,7 +113,7 @@ func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
 
 func webpack() {
 	log.Println("Running webpack...")
-	c := exec.Command("webpack", "--mode=development", "--watch")
+	c := exec.Command("npx", "webpack", "--mode=development", "--watch")
 	c.Dir = "public"
 	if err := c.Run(); err != nil {
 		log.Print(c.Output())

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -118,7 +118,7 @@ func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (w *Watcher) webpack() {
+func (*Watcher) webpack() {
 	log.Println("Running webpack...")
 	c := exec.Command("webpack", "--mode=development", "--watch")
 	c.Dir = "public"

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -102,7 +102,8 @@ func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case msg := <-client:
-			fmt.Fprintf(w, "data: %s\n", msg)
+			// message must end with \n\n to mark the end of the event
+			fmt.Fprintf(w, "data: %s\n\n", msg)
 			w.(http.Flusher).Flush()
 		case <-r.Context().Done(): // Client disconnected
 			watcher.removeClient(client)

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os/exec"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -23,6 +24,7 @@ func NewWatcher(path string) *Watcher {
 		clients: make(map[chan string]bool),
 	}
 	go watcher.watch(path)
+	go watcher.webpack() // Start webpack in watch mode
 	return watcher
 }
 
@@ -109,5 +111,15 @@ func (watcher *Watcher) Handler(w http.ResponseWriter, r *http.Request) {
 			watcher.removeClient(client)
 			return
 		}
+	}
+}
+
+func (w *Watcher) webpack() {
+	log.Println("Running webpack...")
+	c := exec.Command("webpack", "--mode=development", "--watch")
+	c.Dir = "public"
+	if err := c.Run(); err != nil {
+		log.Print(c.Output())
+		log.Print(err)
 	}
 }

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -14,7 +14,6 @@ import (
 type Watcher struct {
 	clients map[chan string]bool
 	mu      sync.Mutex
-	err     chan error
 }
 
 // NewWatcher creates a new watcher for the given path.

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -1,0 +1,91 @@
+package reload
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/quickfeed/quickfeed/internal/rand"
+)
+
+func TestWatcher(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, rand.String())
+
+	// create a file to modify later
+	// to trigger WRITE events in the watcher
+	file, err := os.Create(filename)
+	if err != nil {
+		t.Errorf("failed to create file: %v", err)
+	}
+	defer file.Close()
+
+	watcher, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+
+	// create a server with a handler the client can connect to
+	mux := http.NewServeMux()
+	mux.HandleFunc("/watch", watcher.Handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	go func() {
+		// wait some time before writing to the file
+		time.Sleep(2 * time.Second)
+		// try to write to the file multiple times
+		// in case the server is slow to start
+		for i := 0; i < 3; i++ {
+			// write to the file to trigger the watcher
+			// to send an event to the client
+			_, err = file.Write([]byte(rand.String()))
+			if err != nil {
+				t.Errorf("failed to write to file: %v", err)
+			}
+		}
+	}()
+
+	// connect to the server
+	resp, err := server.Client().Get(server.URL + "/watch")
+	if err != nil {
+		t.Fatalf("failed to get from server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// continously read from the response body
+	eventChan := make(chan string, 1)
+	go func() {
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				break
+			}
+			// ignore empty lines; not all received messages contain data
+			if line != "" {
+				// send the message to the event channel
+				eventChan <- line
+				break
+			}
+		}
+	}()
+
+	// we want the received message to contain the filename
+	want := fmt.Sprintf("data: %s\n", filename)
+	select {
+	case msg := <-eventChan:
+		if msg != want {
+			t.Fatalf("Expected event message: %s, got: %s", want, msg)
+		}
+		return
+	case <-time.After(10 * time.Second):
+		// if we don't receive an event in 10 seconds, fail the test
+		t.Fatal("Timeout: No event received")
+	}
+}

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -44,7 +44,7 @@ func TestWatcher(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			// write to the file to trigger the watcher
 			// to send an event to the client
-			_, err = file.Write([]byte(rand.String()))
+			_, err = file.WriteString(rand.String())
 			if err != nil {
 				t.Errorf("failed to write to file: %v", err)
 			}

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -81,11 +81,11 @@ func TestWatcher(t *testing.T) {
 	select {
 	case msg := <-eventChan:
 		if msg != want {
-			t.Fatalf("Expected event message: %s, got: %s", want, msg)
+			t.Error("Expected event message: %s, got: %s", want, msg)
 		}
 		return
 	case <-time.After(10 * time.Second):
 		// if we don't receive an event in 10 seconds, fail the test
-		t.Fatal("Timeout: No event received")
+		t.Error("Timeout: No event received")
 	}
 }

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -70,6 +70,9 @@ func TestWatcher(t *testing.T) {
 			if err != nil {
 				break
 			}
+			if line == "" {
+				continue
+			}
 			// send the message to the event channel
 			eventChan <- line
 			break

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -81,7 +81,7 @@ func TestWatcher(t *testing.T) {
 	select {
 	case msg := <-eventChan:
 		if msg != want {
-			t.Error("Expected event message: %s, got: %s", want, msg)
+			t.Errorf("Expected event message: %s, got: %s", want, msg)
 		}
 		return
 	case <-time.After(10 * time.Second):

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -2,6 +2,7 @@ package reload
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +26,9 @@ func TestWatcher(t *testing.T) {
 	}
 	defer file.Close()
 
-	watcher, err := NewWatcher(dir)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	watcher, err := NewWatcher(ctx, dir)
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -44,7 +44,7 @@ func TestWatcher(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		// try to write to the file multiple times
 		// in case the server is slow to start
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			// write to the file to trigger the watcher
 			// to send an event to the client
 			_, err = file.WriteString(rand.String())
@@ -61,7 +61,7 @@ func TestWatcher(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	// continously read from the response body
+	// continuously read from the response body
 	eventChan := make(chan string, 1)
 	go func() {
 		reader := bufio.NewReader(resp.Body)
@@ -70,12 +70,9 @@ func TestWatcher(t *testing.T) {
 			if err != nil {
 				break
 			}
-			// ignore empty lines; not all received messages contain data
-			if line != "" {
-				// send the message to the event channel
-				eventChan <- line
-				break
-			}
+			// send the message to the event channel
+			eventChan <- line
+			break
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	if *dev && *watch {
 		// Wrap handler with file watcher
 		// for live-reloading in development mode.
-		handler = web.DevHandler(ctx, handler)
+		handler = web.WatchHandler(ctx, handler)
 	}
 
 	srv, err := srvFn(*httpAddr, handler)

--- a/main.go
+++ b/main.go
@@ -122,10 +122,10 @@ func main() {
 	router := qfService.RegisterRouter(tokenManager, authConfig, *public)
 	handler := h2c.NewHandler(router, &http2.Server{})
 
-	if *dev {
+	if *dev && *watch {
 		// Wrap handler with file watcher
 		// for live-reloading in development mode.
-		handler = web.DevHandler(*watch, handler)
+		handler = web.DevHandler(handler)
 	}
 
 	srv, err := srvFn(*httpAddr, handler)

--- a/public/src/index.tsx
+++ b/public/src/index.tsx
@@ -19,13 +19,13 @@ const overmind = createOvermind(config, {
 })
 
 if (process.env.NODE_ENV === "development") {
+    // EventSource will automatically try to reconnect if the connection is lost
     const eventSource = new EventSource("/watch")
     eventSource.onmessage = () => {
         setTimeout(() => {
             location.reload()
         }, 500)
     }
-    // TODO: connection times out after 2 minutes, need to reconnect
     eventSource.onerror = () => console.error("could not connect to server-sent events")
 }
 

--- a/public/src/index.tsx
+++ b/public/src/index.tsx
@@ -18,6 +18,16 @@ const overmind = createOvermind(config, {
     devtools: "localhost:3301",
 })
 
+if (process.env.NODE_ENV === "development") {
+    const eventSource = new EventSource("/watch")
+    eventSource.onmessage = () => {
+        setTimeout(() => {
+            location.reload()
+        }, 500)
+    }
+    // TODO: connection times out after 2 minutes, need to reconnect
+    eventSource.onerror = () => console.error("could not connect to server-sent events")
+}
 
 render((
     <Provider value={overmind}>

--- a/web/server.go
+++ b/web/server.go
@@ -107,7 +107,7 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 	}, nil
 }
 
-func DevHandler(ctx context.Context, handler http.Handler) http.Handler {
+func WatchHandler(ctx context.Context, handler http.Handler) http.Handler {
 	watcher, err := reload.NewWatcher(ctx, filepath.Join(env.PublicDir(), "dist"))
 	if err != nil {
 		log.Printf("Failed to create watcher: %v", err)

--- a/web/server.go
+++ b/web/server.go
@@ -106,14 +106,8 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 	}, nil
 }
 
-func DevHandler(watch bool, handler http.Handler) http.Handler {
-	if !watch {
-		return handler
-	}
+func DevHandler(handler http.Handler) http.Handler {
 	mux := http.NewServeMux()
-	if handler != nil {
-		mux.Handle("/", handler)
-	}
 	// Initialize file watcher
 	watcher := reload.NewWatcher("./public/dist")
 	mux.HandleFunc("/watch", watcher.Handler)

--- a/web/server.go
+++ b/web/server.go
@@ -107,10 +107,13 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 }
 
 func DevHandler(handler http.Handler) http.Handler {
+	watcher, err := reload.NewWatcher("./public/dist")
+	if err != nil {
+		log.Printf("Failed to create watcher: %v", err)
+		return handler
+	}
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
-	// Initialize file watcher
-	watcher := reload.NewWatcher("./public/dist")
 	mux.HandleFunc("/watch", watcher.Handler)
 	return mux
 }

--- a/web/server.go
+++ b/web/server.go
@@ -108,6 +108,7 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 
 func DevHandler(handler http.Handler) http.Handler {
 	mux := http.NewServeMux()
+	mux.Handle("/", handler)
 	// Initialize file watcher
 	watcher := reload.NewWatcher("./public/dist")
 	mux.HandleFunc("/watch", watcher.Handler)

--- a/web/server.go
+++ b/web/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/quickfeed/quickfeed/internal/cert"
@@ -106,8 +107,8 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 	}, nil
 }
 
-func DevHandler(handler http.Handler) http.Handler {
-	watcher, err := reload.NewWatcher("./public/dist")
+func DevHandler(ctx context.Context, handler http.Handler) http.Handler {
+	watcher, err := reload.NewWatcher(ctx, filepath.Join(env.PublicDir(), "dist"))
 	if err != nil {
 		log.Printf("Failed to create watcher: %v", err)
 		return handler


### PR DESCRIPTION
This PR adds live reloading of the browser if changes are detected in the given folder (`/public/dist` in this case).

If QuickFeed starts in -dev mode, we add an endpoint `/watch` that the frontend can connect to. If a file change is detected, the server sends a message to the frontend client, which triggers a reload.

To activate this functionality the server has to run in development mode, and the frontend must be compiled in development mode.