### PR TITLE
Deepsource, backend and secret issues, 16 in total.

### DIFF
--- a/ci/record_results.go
+++ b/ci/record_results.go
@@ -13,7 +13,7 @@ import (
 
 // RecordResults for the course and assignment given by the run data structure.
 // If the results argument is nil, then the submission is considered to be a manual review.
-func (r RunData) RecordResults(logger *zap.SugaredLogger, db database.Database, results *score.Results) (*qf.Submission, error) {
+func (r *RunData) RecordResults(logger *zap.SugaredLogger, db database.Database, results *score.Results) (*qf.Submission, error) {
 	defer func() {
 		if m := recover(); m != nil {
 			logger.Errorf("Recovered from panic: %v", m)
@@ -45,7 +45,7 @@ func (r RunData) RecordResults(logger *zap.SugaredLogger, db database.Database, 
 	return newSubmission, nil
 }
 
-func (r RunData) previousSubmission(db database.Database) (*qf.Submission, error) {
+func (r *RunData) previousSubmission(db database.Database) (*qf.Submission, error) {
 	submissionQuery := &qf.Submission{
 		AssignmentID: r.Assignment.GetID(),
 		UserID:       r.Repo.GetUserID(),
@@ -54,14 +54,14 @@ func (r RunData) previousSubmission(db database.Database) (*qf.Submission, error
 	return db.GetSubmission(submissionQuery)
 }
 
-func (r RunData) newSubmission(previous *qf.Submission, results *score.Results) (string, *qf.Submission) {
+func (r *RunData) newSubmission(previous *qf.Submission, results *score.Results) (string, *qf.Submission) {
 	if results != nil {
 		return "test execution", r.newTestRunSubmission(previous, results)
 	}
 	return "manual review", r.newManualReviewSubmission(previous)
 }
 
-func (r RunData) newManualReviewSubmission(previous *qf.Submission) *qf.Submission {
+func (r *RunData) newManualReviewSubmission(previous *qf.Submission) *qf.Submission {
 	return &qf.Submission{
 		ID:           previous.GetID(),
 		AssignmentID: r.Assignment.GetID(),
@@ -80,7 +80,7 @@ func (r RunData) newManualReviewSubmission(previous *qf.Submission) *qf.Submissi
 	}
 }
 
-func (r RunData) newTestRunSubmission(previous *qf.Submission, results *score.Results) *qf.Submission {
+func (r *RunData) newTestRunSubmission(previous *qf.Submission, results *score.Results) *qf.Submission {
 	if r.Rebuild && previous != nil && previous.BuildInfo != nil {
 		// Keep previous submission's delivery date if this is a rebuild.
 		results.BuildInfo.SubmissionDate = previous.BuildInfo.SubmissionDate
@@ -99,7 +99,7 @@ func (r RunData) newTestRunSubmission(previous *qf.Submission, results *score.Re
 	}
 }
 
-func (r RunData) updateSlipDays(db database.Database, submission *qf.Submission) error {
+func (r *RunData) updateSlipDays(db database.Database, submission *qf.Submission) error {
 	enrollments := make([]*qf.Enrollment, 0)
 	if submission.GroupID > 0 {
 		group, err := db.GetGroup(submission.GroupID)
@@ -129,7 +129,7 @@ func (r RunData) updateSlipDays(db database.Database, submission *qf.Submission)
 // GetOwners returns the UserIDs of a user or group repository's owners.
 // Returns an error if no owners could be found.
 // This method should only be called for a user or group repository.
-func (r RunData) GetOwners(db database.Database) ([]uint64, error) {
+func (r *RunData) GetOwners(db database.Database) ([]uint64, error) {
 	var owners []uint64
 	if r.Repo.IsUserRepo() {
 		owners = []uint64{r.Repo.GetUserID()}

--- a/ci/run_tests_clone_test.go
+++ b/ci/run_tests_clone_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCloneAndCopyRunTests(t *testing.T) {
-	t.Setenv("QUICKFEED_REPOSITORY_PATH", "QUICKFEED_REPOSITORY_PATH")
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", "$HOME/tmp/courses")
 	qfTestOrg := scm.GetTestOrganization(t)
 	sc, qfUserName := scm.GetTestSCM(t)
 

--- a/ci/run_tests_clone_test.go
+++ b/ci/run_tests_clone_test.go
@@ -2,7 +2,6 @@ package ci
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -11,11 +10,8 @@ import (
 	"github.com/quickfeed/quickfeed/scm"
 )
 
-func init() {
-	os.Setenv("QUICKFEED_REPOSITORY_PATH", "$HOME/tmp/courses")
-}
-
 func TestCloneAndCopyRunTests(t *testing.T) {
+	t.Setenv("QUICKFEED_REPOSITORY_PATH", "QUICKFEED_REPOSITORY_PATH")
 	qfTestOrg := scm.GetTestOrganization(t)
 	sc, qfUserName := scm.GetTestSCM(t)
 

--- a/database/gormdb_tasks.go
+++ b/database/gormdb_tasks.go
@@ -16,7 +16,7 @@ func (db *GormDB) GetTasks(query *qf.Task) ([]*qf.Task, error) {
 		return nil, err
 	}
 	if len(tasks) == 0 {
-		return tasks, gorm.ErrRecordNotFound
+		return nil, gorm.ErrRecordNotFound
 	}
 	return tasks, err
 }
@@ -31,8 +31,6 @@ func (db *GormDB) CreateIssues(issues []*qf.Issue) error {
 
 // SynchronizeAssignmentTasks synchronizes all tasks of each assignment in a given course. Returns created, updated and deleted tasks
 func (db *GormDB) SynchronizeAssignmentTasks(course *qf.Course, taskMap map[uint32]map[string]*qf.Task) (createdTasks, updatedTasks []*qf.Task, err error) {
-	createdTasks = []*qf.Task{}
-	updatedTasks = []*qf.Task{}
 	assignments, err := db.GetAssignmentsByCourse(course.GetID())
 	if err != nil {
 		return nil, nil, err

--- a/database/gormdb_tasks_test.go
+++ b/database/gormdb_tasks_test.go
@@ -195,7 +195,7 @@ func TestGormDBSynchronizeAssignmentTasks(t *testing.T) {
 			previousTasks := make(map[uint32]map[string]*qf.Task)
 
 			for _, foundAssignments := range tt.foundAssignmentSequence {
-				wantTasks := []*qf.Task{}
+				var wantTasks []*qf.Task
 				for _, assignment := range foundAssignments {
 					assignment.CourseID = course.GetID()
 					if err := db.CreateAssignment(assignment); err != nil {
@@ -212,8 +212,8 @@ func TestGormDBSynchronizeAssignmentTasks(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				wantCreatedTasks := []*qf.Task{}
-				wantUpdatedTasks := []*qf.Task{}
+				var wantCreatedTasks []*qf.Task
+				var wantUpdatedTasks []*qf.Task
 				for _, wantTask := range wantTasks {
 					taskMap, ok := previousTasks[wantTask.GetAssignmentOrder()]
 					if !ok {

--- a/qf/group.go
+++ b/qf/group.go
@@ -28,7 +28,7 @@ func (g *Group) ContainsAll(group *Group) bool {
 
 // GetUsersExcept returns a list of all users in a group, except the one with the given userID.
 func (g *Group) GetUsersExcept(userID uint64) []*User {
-	subset := []*User{}
+	var subset []*User
 	for _, user := range g.Users {
 		if user.GetID() == userID {
 			continue

--- a/qf/submission.go
+++ b/qf/submission.go
@@ -115,7 +115,7 @@ func (s *Submission) BeforeCreate(tx *gorm.DB) error {
 	if s.GetGroupID() > 0 {
 		// If the submission is for a group, create a new grade for each user in the group.
 		// Get all the user IDs in the group
-		userIDs := []uint64{}
+		var userIDs []uint64
 		tx.Model(&Enrollment{}).Where("group_id = ?", s.GetGroupID()).Pluck("user_id", &userIDs)
 
 		if len(userIDs) == 0 {

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -22,8 +22,8 @@ const (
 	appID         = "QUICKFEED_APP_ID"
 	appKey        = "QUICKFEED_APP_KEY"
 	clientID      = "QUICKFEED_CLIENT_ID"
-	clientSecret  = "QUICKFEED_CLIENT_SECRET"
-	webhookSecret = "QUICKFEED_WEBHOOK_SECRET"
+	clientSecret  = "QUICKFEED_CLIENT_SECRET"  // skipcq: SCT-A000
+	webhookSecret = "QUICKFEED_WEBHOOK_SECRET" // skipcq: SCT-A000
 )
 
 // ReadyForAppCreation returns nil if the environment configuration (envFile)
@@ -181,7 +181,7 @@ func (m *Manifest) conversion() http.HandlerFunc {
 }
 
 func (m *Manifest) createApp() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if err := form(w, m.domain); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Partially Resolves: #1202

RVV-B0012 was commited with SCT-A000, my bad.

GO-W1027 involved updating the `GetTasks` to return nil when tasks array is empty, and remove unnecessary initialization in `SynchronizeAssignmentTasks`

Codes for issues:
- SCT-A000: Possible hardcoded secrets detected in source code
- RVV-B0012: Unused parameter in function
- GO-W1027: Empty slice literal used to declare a variable
- GO-W1032: Use t.Setenv and friends instead of os.Setenv for test file(s)
- GO-W1029: Usage of both value and pointer receivers
