### PR TITLE
Make `new` and `secret` flags compatible

### DIFF
--- a/internal/env/auth_secret.go
+++ b/internal/env/auth_secret.go
@@ -1,9 +1,24 @@
 package env
 
-import "os"
+import (
+	"os"
+
+	"github.com/quickfeed/quickfeed/internal/rand"
+)
+
+const authSecret = "QUICKFEED_AUTH_SECRET" // skipcq: SCT-A000
 
 // AuthSecret returns the JWT signing secret obtained from
 // the QUICKFEED_AUTH_SECRET environment variable.
 func AuthSecret() string {
-	return os.Getenv("QUICKFEED_AUTH_SECRET")
+	return os.Getenv(authSecret)
+}
+
+// NewAuthSecret generates a new random JWT signing secret,
+// and saves it to the given environment file for future use.
+// It returns an error if the environment file cannot be updated.
+func NewAuthSecret(envFile string) error {
+	return Save(RootEnv(envFile), map[string]string{
+		authSecret: rand.String(),
+	})
 }

--- a/main.go
+++ b/main.go
@@ -93,9 +93,11 @@ func main() {
 		}
 	}
 
-	// Refresh environment variables
-	if err := env.Load(env.RootEnv(envFile)); err != nil {
-		log.Fatal(err)
+	if *secret || *newApp {
+		// Refresh environment variables
+		if err := env.Load(env.RootEnv(envFile)); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	logger, err := qlog.Zap()

--- a/main.go
+++ b/main.go
@@ -93,6 +93,11 @@ func main() {
 		}
 	}
 
+	// Refresh environment variables
+	if err := env.Load(env.RootEnv(envFile)); err != nil {
+		log.Fatal(err)
+	}
+
 	logger, err := qlog.Zap()
 	if err != nil {
 		log.Fatalf("Can't initialize logger: %v", err)

--- a/main.go
+++ b/main.go
@@ -53,21 +53,8 @@ func main() {
 		secret   = flag.Bool("secret", false, "create new secret for JWT signing")
 	)
 	flag.Parse()
-	const envFile = ".env"
-	if *secret {
-		log.Println("Generating new random secret for signing JWT tokens...")
-		if err := env.Save(env.RootEnv(envFile), map[string]string{
-			"QUICKFEED_AUTH_SECRET": rand.String(),
-		}); err != nil {
-			log.Fatal(err)
-		}
-	}
-	// Load environment variables from $QUICKFEED/.env.
-	// Will not override variables already defined in the environment.
-	if err := env.Load(env.RootEnv(envFile)); err != nil {
-		log.Fatal(err)
-	}
-	if env.AuthSecret() == "" {
+
+	if env.AuthSecret() == "" && !*secret {
 		log.Fatal("Required QUICKFEED_AUTH_SECRET is not set")
 	}
 

--- a/main.go
+++ b/main.go
@@ -53,11 +53,15 @@ func main() {
 		secret   = flag.Bool("secret", false, "create new secret for JWT signing")
 	)
 	flag.Parse()
-
+	const envFile = ".env"
+	// Load environment variables from $QUICKFEED/.env.
+	// Will not override variables already defined in the environment.
+	if err := env.Load(env.RootEnv(envFile)); err != nil {
+		log.Fatal(err)
+	}
 	if env.AuthSecret() == "" && !*secret {
 		log.Fatal("Required QUICKFEED_AUTH_SECRET is not set")
 	}
-
 	if env.Domain() == "localhost" {
 		log.Fatal(`Domain "localhost" is unsupported; use "127.0.0.1" instead.`)
 	}
@@ -67,12 +71,6 @@ func main() {
 		srvFn = web.NewDevelopmentServer
 	} else {
 		srvFn = web.NewProductionServer
-	}
-	const envFile = ".env"
-	// Load environment variables from $QUICKFEED/.env.
-	// Will not override variables already defined in the environment.
-	if err := env.Load(env.RootEnv(envFile)); err != nil {
-		log.Fatal(err)
 	}
 	log.Printf("Starting QuickFeed on %s%s", env.Domain(), *httpAddr)
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	if *secret {
 		log.Println("Generating new random secret for signing JWT tokens...")
 		if err := env.NewAuthSecret(envFile); err != nil {
-			log.Fatalf("Failed to generate new secret: %v", err)
+			log.Fatalf("Failed to save secret: %v", err)
 		}
 	}
 	if *secret || *newApp {

--- a/main.go
+++ b/main.go
@@ -81,6 +81,12 @@ func main() {
 	} else {
 		srvFn = web.NewProductionServer
 	}
+	const envFile = ".env"
+	// Load environment variables from $QUICKFEED/.env.
+	// Will not override variables already defined in the environment.
+	if err := env.Load(env.RootEnv(envFile)); err != nil {
+		log.Fatal(err)
+	}
 	log.Printf("Starting QuickFeed on %s%s", env.Domain(), *httpAddr)
 
 	if *newApp {
@@ -88,6 +94,15 @@ func main() {
 			log.Fatal(err)
 		}
 		if err := manifest.CreateNewQuickFeedApp(srvFn, *httpAddr, envFile); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *secret {
+		log.Println("Generating new random secret for signing JWT tokens...")
+		if err := env.Save(env.RootEnv(envFile), map[string]string{
+			"QUICKFEED_AUTH_SECRET": rand.String(),
+		}); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -102,10 +102,7 @@ func (m *Manifest) StartAppCreationFlow(server *web.Server) error {
 	if err := <-m.done; err != nil {
 		return err
 	}
-	if err := server.Shutdown(context.Background()); err != nil {
-		return err
-	}
-	return nil
+	return server.Shutdown(context.Background())
 }
 
 func (m *Manifest) conversion() http.HandlerFunc {

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -105,8 +105,7 @@ func (m *Manifest) StartAppCreationFlow(server *web.Server) error {
 	if err := server.Shutdown(context.Background()); err != nil {
 		return err
 	}
-	// Refresh environment variables
-	return env.Load(env.RootEnv(m.envFile))
+	return nil
 }
 
 func (m *Manifest) conversion() http.HandlerFunc {


### PR DESCRIPTION
The case of wanting to both create a new github app and generate a secret was restricted because the modification of the env variable `QUICKFEED_AUTH_SECRET` with the save function creates the backup file: `.env.bak`, happens before creating the app.

The restriction of creating an app when the `.env.bak` file exists is intentional, as Hein mentioned in the related issue. But is in this case problematic since when a user wants to create a new app with a new secret its not possible because the secret generation occurs before the instance of creating the app.

The secret is required to be generated before the [NewTokenManager](https://github.com/quickfeed/quickfeed/blob/master/main.go#L117), because it is used when creating the [Token manager](https://github.com/quickfeed/quickfeed/blob/master/web/auth/jwt.go#L41)

The auth secret is required when a user doesn't use the `secret` flag

Resolves: #1210 