### PR TITLE
Add script for creating docker group and update related docker docs,

### DIFF
--- a/.vscode/quickfeed-words.txt
+++ b/.vscode/quickfeed-words.txt
@@ -62,6 +62,7 @@ fileop
 Fornavn
 Frøyland
 fullchain
+getent
 Getwd
 githubv
 GOBIN

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -3,6 +3,10 @@
 Code submitted by students is being built and run inside Docker containers.
 After a container exits, the output is parsed and saved as a new submission entry in the database.
 
+To be able to run docker on linux, and WSL or macOS without docker desktop, the user that is running docker either has to be running as sudo user, execute commands with `sudo`, or must be a part of the docker group. See [Configure a docker group](#configure-a-docker-group) for details.
+
+## Freeing up space on Docker
+
 If suddenly out of space on the production server, there are few Docker-related steps that can be taken:
 
 - Check if there are containers running for too long with `docker ps`; if necessary, kill them with `docker rm <name/id>`
@@ -12,76 +16,104 @@ If suddenly out of space on the production server, there are few Docker-related 
 - Restart Docker daemon with `sudo service docker restart`
 - Clean up all unused Docker objects with `docker system prune` (warning: can take a few minutes)
 
-To be able to run docker, the user that is running docker either has to be running as sudo user, or must be a part of the docker group.
+## Useful Docker Commands
 
-## Linux
+To display images:
 
-First check that the `docker` group exists:
-
-```console
-% cat /etc/group | grep docker
+```sh
+% docker images
 ```
 
-This command can also be used to check which users are in the docker group, and thus can run docker containers.
+To display all containers:
+
+```sh
+% docker ps -a
+```
 
 To stop (or delete) **all containers**, use one of these commands:
 
-```console
+```sh
 % docker stop $(docker ps -a -q)
 % docker rm $(docker ps -a -q)
 ```
 
-### Useful Docker Commands
+## Helpful Tools for dealing with Docker containers and too many open file descriptors
 
-```console
-% docker images
-```
-
-### Helpful Tools for dealing with docker containers and too many open file descriptors
-
-```console
+```sh
 % pgrep quickfeed | ls /proc/$(xargs)/fd | wc -l
 % docker ps -a
 % docker stats
 % docker rm $(docker ps -q -f status=exited)
 ```
 
-### Missing docker group
+## Configure a Docker group
 
-If there is no docker group, add it manually with the command:
+There are two sections for setting up a Docker group, a guide and a setup script, choose whichever works best for you.
 
-```console
+Once a group is configured and a user gains access to Docker daemon, deleting the Docker group or removing the user from the group will revoke the access. However, the changes will only take effect after the user terminates their session.
+
+### Setup script
+
+To setup Docker daemon move to root directory and run:
+
+```sh
+% bash ./doc/scripts/setup-docker-group.sh
+```
+
+For details, see [setup-script](../setup-daemon.sh)
+
+### Guide
+
+First check that the `docker` group exists:
+
+```sh
+% cat /etc/group | grep docker
+```
+
+or:
+
+```sh
+% getent group docker
+```
+
+These commands can also be used to check which users are in the Docker group, and thus can run Docker containers.
+
+#### Missing Docker group
+
+If there isn't a Docker group, add it manually with the command:
+
+```sh
 % sudo groupadd docker
 ```
 
-After this command is executed please restart your machine or restart the docker daemon with the commands:
+After this command is executed please restart your machine or restart the Docker daemon with the commands:
 
-```console
+```sh
 % sudo systemctl restart docker.service
 ```
 
 or
 
-```console
+```sh
 % sudo service docker restart
 ```
 
-### Docker group exists
+#### Docker group exists
 
-If it does add the user that should be running docker to this group with the given command
+If it does add the user that should be running Docker to this group with the given command
 
-```console
+```sh
 % sudo usermod -aG docker [username]
 ```
 
-Also make sure that the docker daemon is running,
+Also make sure that the Docker daemon is running,
 
-```console
+```sh
 % systemctl status docker.service
 ```
 
 or with the command
 
-```console
+```sh
 % service docker status
 ```

--- a/doc/scripts/setup-docker-group.sh
+++ b/doc/scripts/setup-docker-group.sh
@@ -21,8 +21,8 @@ fi
 
 # Check if user does not have access, and if the group is configured correctly
 # The three last statements are opposites of previous statements
-if ! docker ps > /dev/null 2>&1 && [ -n "$(getent group docker | grep $USER)" ] && systemctl is-active --quiet docker && [ -n "$(cat /etc/group | grep docker)" ]; then
-    echo "The group was configured, please restart your system for the changes to take effect"
+if ! docker ps > /dev/null 2>&1; then
+    echo "The group is configured, but you may need to restart your system for the changes to take effect"
 else
-    echo "Docker daemon was configured successfully!"
+    echo "Docker is running and properly configured"
 fi

--- a/doc/scripts/setup-docker-group.sh
+++ b/doc/scripts/setup-docker-group.sh
@@ -1,0 +1,28 @@
+if [ "$(uname)" != "Linux" ]; then
+	echo "This is only for linux"
+	exit 1
+fi
+
+if [ -z "$(getent group docker)" ]; then
+    # Create docker group
+    sudo groupadd docker
+fi
+
+if ! systemctl is-active --quiet docker; then
+    sudo systemctl start docker;
+fi
+
+if [ -z "$(getent group docker | grep $USER)" ]; then
+    # Add user
+    sudo usermod -aG docker $USER
+    # Restart docker
+    sudo systemctl restart docker;
+fi
+
+# Check if user does not have access, and if the group is configured correctly
+# The three last statements are opposites of previous statements
+if ! docker ps > /dev/null 2>&1 && [ -n "$(getent group docker | grep $USER)" ] && systemctl is-active --quiet docker && [ -n "$(cat /etc/group | grep docker)" ]; then
+    echo "The group was configured, please restart your system for the changes to take effect"
+else
+    echo "Docker daemon was configured successfully!"
+fi

--- a/doc/scripts/setup-docker-group.sh
+++ b/doc/scripts/setup-docker-group.sh
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 if [ "$(uname)" != "Linux" ]; then
-	echo "This is only for linux"
-	exit 1
+    echo "This is only for linux"
+    exit 1
 fi
 
 if [ -z "$(getent group docker)" ]; then
@@ -9,19 +11,19 @@ if [ -z "$(getent group docker)" ]; then
 fi
 
 if ! systemctl is-active --quiet docker; then
-    sudo systemctl start docker;
+    sudo systemctl start docker
 fi
 
 if [ -z "$(getent group docker | grep $USER)" ]; then
     # Add user
     sudo usermod -aG docker $USER
     # Restart docker
-    sudo systemctl restart docker;
+    sudo systemctl restart docker
 fi
 
 # Check if user does not have access, and if the group is configured correctly
 # The three last statements are opposites of previous statements
-if ! docker ps > /dev/null 2>&1; then
+if ! docker ps >/dev/null 2>&1; then
     echo "The group is configured, but you may need to restart your system for the changes to take effect"
 else
     echo "Docker is running and properly configured"


### PR DESCRIPTION
Resolves #518

This PR contains a script for linux,  WSL (windows) or mac without docker desktop. It configures a docker group which Docker use to determine if a user has access.

[As mentioned](https://github.com/quickfeed/quickfeed/issues/518#issuecomment-2627684935), does docker desktop bypass the permission issue.
