### PR TITLE
Resolve http.addr bug and replace http.addr flag with env variable PORT

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -17,6 +17,8 @@ QUICKFEED_CERT_FILE=$QUICKFEED/internal/config/certs/fullchain.pem
 
 # Quickfeed server domain or ip
 DOMAIN="example.com"
+# Quickfeed server port
+PORT="443"
 
 # Comma-separated list of domains to allow certificates for.
 # IP addresses and "localhost" are *not* valid.

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -6,6 +6,7 @@
   - [Setup](#setup)
     - [Install Tools for Deployment](#install-tools-for-deployment)
     - [Install Tools for Development](#install-tools-for-development)
+    - [The PORT environment variable](#the-port-environment-variable)
     - [Preparing the Environment for Production](#preparing-the-environment-for-production)
     - [Preparing the Environment for Testing](#preparing-the-environment-for-testing)
     - [First-time Installation](#first-time-installation)
@@ -63,6 +64,14 @@ To install:
 
 The `devtools` make target will download and install various Protobuf compiler plugins and the grpcweb Protobuf compiler.
 
+### The PORT environment variable
+
+The `PORT` environment variable can be changed to any valid port, and we strongly advise running Quickfeed a secure port in production.
+It can be set to an unprivileged port and prevent permission issues when [running on a privileged port](#running-server-on-a-privileged-port).
+This is helpful for debugging, as it allows you to run Quickfeed directly by setting program to `"${workspaceFolder}/main.go"`, in the launch profile.
+Alternatively, you can grant the Quickfeed binary access to the privileged port and run it as an executable.
+The launch profile program should then be set to `"${env:GOPATH}/bin/quickfeed"`.
+
 ### Preparing the Environment for Production
 
 QuickFeed expects the `.env` file to contain certain environment variables.
@@ -80,6 +89,8 @@ QUICKFEED_WEBHOOK_SECRET=""
 
 # QuickFeed server domain or ip
 DOMAIN="example.com"
+# Quickfeed server port
+PORT="443"
 
 # Comma-separated list of domains to allow certificates for.
 # IP addresses and "localhost" are *not* valid.
@@ -103,6 +114,8 @@ QUICKFEED_CERT_FILE=$QUICKFEED/internal/config/certs/fullchain.pem
 
 # QuickFeed server domain or ip
 DOMAIN="127.0.0.1"
+# Quickfeed server port
+PORT="443"
 ```
 
 The [QuickFeed App installation process](#first-time-installation) will guide you through the rest of the setup,
@@ -218,14 +231,15 @@ To view the full usage details:
 | **Flag**        | **Description**                                      | **Example** |
 | --------------- | ---------------------------------------------------- | ----------- |
 | `database.file` | Path to QuickFeed database                           | `qf.db`     |
-| `http.addr`     | Listener address for HTTP service                    | `:8081`     |
+| `http.public`   | Path to content to serve                             |             |
 | `dev`           | Run development server with self-signed certificates |             |
 | `new`           | Create a new QuickFeed App                           |             |
+| `watch`         | Watch for changes and reload frontend                |             |
+| `secret`        | Create new secret for JWT signing                    |             |
 
 ### Running Server on a Privileged Port
 
-It is possible to run server in development mode on different ports by setting the `http.addr` flag.
-However, by default the server will run on port `:443`.
+It is possible to run server in development mode on different ports by updating the environment variable `PORT`, which is by default the standard HTTPS port: `443`.
 If the quickfeed binary cannot access port `:443` on your Linux system, you can enable it by running:
 
 ```sh

--- a/internal/env/cert.go
+++ b/internal/env/cert.go
@@ -26,6 +26,10 @@ func Domain() string {
 	return domain
 }
 
+func DomainWithPort(httpAddr string) string {
+	return Domain() + httpAddr
+}
+
 // WhiteList returns a list of domains that the server will create certificates for.
 func Whitelist() ([]string, error) {
 	domains := os.Getenv("QUICKFEED_WHITELIST")

--- a/internal/env/cert.go
+++ b/internal/env/cert.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	defaultDomain   = "127.0.0.1"
+	defaultPort     = "443"
 	defaultCertFile = "fullchain.pem"
 	defaultKeyFile  = "privkey.pem"
 )
@@ -26,8 +27,16 @@ func Domain() string {
 	return domain
 }
 
-func DomainWithPort(httpAddr string) string {
-	return Domain() + httpAddr
+func HttpAddr() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+	return fmt.Sprintf(":%s", port)
+}
+
+func DomainWithPort() string {
+	return Domain() + HttpAddr()
 }
 
 // WhiteList returns a list of domains that the server will create certificates for.

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	authConfig := auth.NewGitHubConfig(env.Domain(), scmConfig)
+	authConfig := auth.NewGitHubConfig(fmt.Sprintf("%s%s", env.Domain(), *httpAddr), scmConfig)
 	log.Print("Callback: ", authConfig.RedirectURL)
 	scmManager := scm.NewSCMManager(scmConfig)
 

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	authConfig := auth.NewGitHubConfig(fmt.Sprintf("%s%s", env.Domain(), *httpAddr), scmConfig)
+	authConfig := auth.NewGitHubConfig(env.DomainWithPort(*httpAddr), scmConfig)
 	log.Print("Callback: ", authConfig.RedirectURL)
 	scmManager := scm.NewSCMManager(scmConfig)
 

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 		if err := manifest.ReadyForAppCreation(envFile, checkDomain); err != nil {
 			log.Fatal(err)
 		}
-		if err := manifest.CreateNewQuickFeedApp(srvFn, env.HttpAddr(), envFile); err != nil {
+		if err := manifest.CreateNewQuickFeedApp(srvFn, envFile); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -144,7 +144,7 @@ func main() {
 		handler = web.WatchHandler(ctx, handler)
 	}
 
-	srv, err := srvFn(env.HttpAddr(), handler)
+	srv, err := srvFn(handler)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -44,13 +44,12 @@ func init() {
 
 func main() {
 	var (
-		dbFile   = flag.String("database.file", env.DatabasePath(), "database file")
-		public   = flag.String("http.public", env.PublicDir(), "path to content to serve")
-		httpAddr = flag.String("http.addr", ":443", "HTTP listen address")
-		dev      = flag.Bool("dev", false, "run development server with self-signed certificates")
-		watch    = flag.Bool("watch", false, "watch for changes and reload")
-		newApp   = flag.Bool("new", false, "create new GitHub app")
-		secret   = flag.Bool("secret", false, "create new secret for JWT signing")
+		dbFile = flag.String("database.file", env.DatabasePath(), "database file")
+		public = flag.String("http.public", env.PublicDir(), "path to content to serve")
+		dev    = flag.Bool("dev", false, "run development server with self-signed certificates")
+		watch  = flag.Bool("watch", false, "watch for changes and reload")
+		newApp = flag.Bool("new", false, "create new GitHub app")
+		secret = flag.Bool("secret", false, "create new secret for JWT signing")
 	)
 	flag.Parse()
 
@@ -70,13 +69,13 @@ func main() {
 	} else {
 		srvFn = web.NewProductionServer
 	}
-	log.Printf("Starting QuickFeed on %s%s", env.Domain(), *httpAddr)
+	log.Printf("Starting QuickFeed on %s", env.DomainWithPort())
 
 	if *newApp {
 		if err := manifest.ReadyForAppCreation(envFile, checkDomain); err != nil {
 			log.Fatal(err)
 		}
-		if err := manifest.CreateNewQuickFeedApp(srvFn, *httpAddr, envFile); err != nil {
+		if err := manifest.CreateNewQuickFeedApp(srvFn, env.HttpAddr(), envFile); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -122,7 +121,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	authConfig := auth.NewGitHubConfig(env.DomainWithPort(*httpAddr), scmConfig)
+	authConfig := auth.NewGitHubConfig(env.DomainWithPort(), scmConfig)
 	log.Print("Callback: ", authConfig.RedirectURL)
 	scmManager := scm.NewSCMManager(scmConfig)
 
@@ -145,7 +144,7 @@ func main() {
 		handler = web.WatchHandler(ctx, handler)
 	}
 
-	srv, err := srvFn(*httpAddr, handler)
+	srv, err := srvFn(env.HttpAddr(), handler)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -49,9 +49,9 @@ func ReadyForAppCreation(envFile string, chkFns ...func() error) error {
 	return nil
 }
 
-func CreateNewQuickFeedApp(srvFn web.ServerType, httpAddr, envFile string) error {
+func CreateNewQuickFeedApp(srvFn web.ServerType, envFile string) error {
 	m := New(env.DomainWithPort(), envFile)
-	server, err := srvFn(httpAddr, m.Handler())
+	server, err := srvFn(m.Handler())
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (m *Manifest) StartAppCreationFlow(server *web.Server) error {
 		}
 	}()
 	log.Println("Important: The GitHub user that installs the QuickFeed App will become the server's admin user.")
-	log.Printf("Go to https://%s/manifest to install the QuickFeed GitHub App.\n", env.Domain())
+	log.Printf("Go to https://%s/manifest to install the QuickFeed GitHub App.\n", env.DomainWithPort())
 	if err := <-m.done; err != nil {
 		return err
 	}

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -50,7 +50,7 @@ func ReadyForAppCreation(envFile string, chkFns ...func() error) error {
 }
 
 func CreateNewQuickFeedApp(srvFn web.ServerType, httpAddr, envFile string) error {
-	m := New(env.DomainWithPort(httpAddr), envFile)
+	m := New(env.DomainWithPort(), envFile)
 	server, err := srvFn(httpAddr, m.Handler())
 	if err != nil {
 		return err

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -50,7 +50,7 @@ func ReadyForAppCreation(envFile string, chkFns ...func() error) error {
 }
 
 func CreateNewQuickFeedApp(srvFn web.ServerType, httpAddr, envFile string) error {
-	m := New(env.Domain(), envFile)
+	m := New(env.DomainWithPort(httpAddr), envFile)
 	server, err := srvFn(httpAddr, m.Handler())
 	if err != nil {
 		return err

--- a/web/manifest/manifest_test.go
+++ b/web/manifest/manifest_test.go
@@ -28,7 +28,7 @@ func TestCreateQuickFeedApp(t *testing.T) {
 	if err := manifest.ReadyForAppCreation(envFile); err != nil {
 		t.Fatal(err)
 	}
-	if err := manifest.CreateNewQuickFeedApp(web.NewDevelopmentServer, ":443", envFile); err != nil {
+	if err := manifest.CreateNewQuickFeedApp(web.NewDevelopmentServer, envFile); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/web/server.go
+++ b/web/server.go
@@ -28,9 +28,9 @@ type Server struct {
 	certFile       string
 }
 
-type ServerType func(addr string, handler http.Handler) (*Server, error)
+type ServerType func(handler http.Handler) (*Server, error)
 
-func NewProductionServer(addr string, handler http.Handler) (*Server, error) {
+func NewProductionServer(handler http.Handler) (*Server, error) {
 	whitelist, err := env.Whitelist()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get whitelist: %w", err)
@@ -45,7 +45,7 @@ func NewProductionServer(addr string, handler http.Handler) (*Server, error) {
 
 	httpServer := &http.Server{
 		Handler:           handler,
-		Addr:              addr,
+		Addr:              env.HttpAddr(),
 		ReadHeaderTimeout: 3 * time.Second, // to prevent Slowloris (CWE-400)
 		WriteTimeout:      2 * time.Minute,
 		ReadTimeout:       2 * time.Minute,
@@ -65,7 +65,7 @@ func NewProductionServer(addr string, handler http.Handler) (*Server, error) {
 	}, nil
 }
 
-func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
+func NewDevelopmentServer(handler http.Handler) (*Server, error) {
 	certificate, err := tls.LoadX509KeyPair(env.CertFile(), env.KeyFile())
 	if err != nil {
 		// Couldn't load credentials; generate self-signed certificates.
@@ -88,7 +88,7 @@ func NewDevelopmentServer(addr string, handler http.Handler) (*Server, error) {
 
 	httpServer := &http.Server{
 		Handler:           handler,
-		Addr:              addr,
+		Addr:              env.HttpAddr(),
 		ReadHeaderTimeout: 3 * time.Second, // to prevent Slowloris (CWE-400)
 		WriteTimeout:      2 * time.Minute,
 		ReadTimeout:       2 * time.Minute,


### PR DESCRIPTION
Closes: #1195 

The baseUrl for the redirect url on `master branch` does not include the http address. I made a simple method which combines the domain and the http address. Default callback url will thereby be: `https://localhost:443/auth/callback/` which is the same as `https://localhost/auth/callback/`

`https://uis.itest.run/` runs on the default https port and the port is therefore hidden. If you add the port `443` and enter the url: `https://uis.itest.run:443/`, will the port number be removed. Attempting to connect on a different port will fail unless Quickfeed is active there as well.

A user of Quickfeed can now specify their own port to run the Quickfeed server on, the default port is 443, and you can possibly ignore the port when its the default https port, but doing so will most likely cause issues when creating the server, as the http address would then be `:`.

The port will now persist over multiple instances rather then resetting to `443` when the `http.addr` flag is not used.