### PR TITLE
chore: Remove LastActivityDate and rename CountApprovedSubmissions to UpdateTotalApproved and 

### DIFF
--- a/cmd/approvelist/main.go
+++ b/cmd/approvelist/main.go
@@ -76,7 +76,7 @@ func main() {
 		}
 		quickfeedStudents[studID] = student
 
-		enroll.CountApprovedSubmissions(courseSubmissions.For(enroll.GetID()))
+		enroll.UpdateTotalApproved(courseSubmissions.For(enroll.GetID()))
 		numApproved := int(enroll.GetTotalApproved())
 		approvedValue := fail
 		if approved(numApproved, *passLimit) {

--- a/qf/enrollment.go
+++ b/qf/enrollment.go
@@ -137,12 +137,20 @@ func (m *Enrollments) UserIDs() []uint64 {
 	return userIDs
 }
 
+// UpdateTotalApproved updates the total approved assignments for the current enrollment
+// based on the provided submissions.
 func (m *Enrollment) UpdateTotalApproved(submissions []*Submission) {
-	duplicateAssignments := make(map[uint64]bool)
+	var totalApproved uint64
+	duplicateAssignments := make(map[uint64]struct{})
 	for _, s := range submissions {
-		if s.IsApproved(m.GetUserID()) && !duplicateAssignments[s.GetAssignmentID()] {
-			duplicateAssignments[s.GetAssignmentID()] = true
-			m.TotalApproved++
+		// Ignore duplicate approved assignments
+		if _, ok := duplicateAssignments[s.GetAssignmentID()]; ok {
+			continue
+		}
+		if s.IsApproved(m.GetUserID()) {
+			duplicateAssignments[s.GetAssignmentID()] = struct{}{}
+			totalApproved++
 		}
 	}
+	m.TotalApproved = totalApproved
 }

--- a/qf/submission_test.go
+++ b/qf/submission_test.go
@@ -139,7 +139,7 @@ func TestByGroup(t *testing.T) {
 	}
 }
 
-func TestCountApprovedSubmissions(t *testing.T) {
+func TestUpdateTotalApproved(t *testing.T) {
 	enroll1 := &qf.Enrollment{ID: 10, UserID: 1}
 	enroll2 := &qf.Enrollment{ID: 20, UserID: 2}
 	enroll3 := &qf.Enrollment{ID: 30, UserID: 3}
@@ -202,7 +202,7 @@ func TestCountApprovedSubmissions(t *testing.T) {
 
 	for _, test := range tests {
 		enrollment := test.enrollment
-		enrollment.CountApprovedSubmissions(submissions.For(enrollment.GetID()))
+		enrollment.UpdateTotalApproved(submissions.For(enrollment.GetID()))
 		if enrollment.GetTotalApproved() != test.want {
 			t.Errorf("expected enrollment(id=%d) total approved %d, got %d", enrollment.GetID(), test.want, enrollment.GetTotalApproved())
 		}

--- a/web/courses.go
+++ b/web/courses.go
@@ -319,7 +319,7 @@ func (s *QuickFeedService) getEnrollmentsWithActivity(courseID uint64) ([]*qf.En
 		return nil, err
 	}
 	for _, enrollment := range course.GetEnrollments() {
-		enrollment.CountApprovedSubmissions(submissions.For(enrollment.GetID()))
+		enrollment.UpdateTotalApproved(submissions.For(enrollment.GetID()))
 	}
 	return course.GetEnrollments(), nil
 }


### PR DESCRIPTION
Closes: #1155 

- Rename CountApprovedSubmissions to UpdateTotalApproved
- Remove unnecessary total approved counter
- Simplify and merge if statements

Im not sure if reseting the `m.TotalApproved` to `0` in the beginning of the method is necessary. I couldn't quite understand if this method is only called with the value as zero or not. Previously it was overwritten by a separate counter variable, which I think is redundant, the increments can be done directly.

I switched out the struct map with a bool map to merge the if statements. Im not sure if this type of mapping is buggy, but the tests pass and there aren't any compling or runtime errors.