### PR TITLE
feat: Pre-download dependencies inside the image by copying required files into the build context of docker

### DIFF
--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -49,7 +49,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, runner ci.Runner, db databas
 	logger.Debugf("Successfully cloned tests repository to: %s", clonedTestsRepo)
 
 	// walk the cloned tests repository and extract the assignments and the course's Dockerfile
-	assignments, dockerfile, err := readTestsRepositoryContent(clonedTestsRepo, course.ID)
+	assignments, dockerfile, buildContextFiles, err := readTestsRepositoryContent(clonedTestsRepo, course.ID)
 	if err != nil {
 		logger.Errorf("Failed to parse assignments from '%s' repository: %v", qf.TestsRepo, err)
 		return
@@ -57,7 +57,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, runner ci.Runner, db databas
 
 	if course.UpdateDockerfile(dockerfile) {
 		// Rebuild the Docker image for the course tagged with the course code
-		if err = buildDockerImage(ctx, logger, runner, course); err != nil {
+		if err = buildDockerImage(ctx, logger, runner, course, buildContextFiles); err != nil {
 			logger.Error(err)
 			return
 		}
@@ -85,13 +85,14 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, runner ci.Runner, db databas
 }
 
 // buildDockerImage builds the Docker image for the given course.
-func buildDockerImage(ctx context.Context, logger *zap.SugaredLogger, runner ci.Runner, course *qf.Course) error {
+func buildDockerImage(ctx context.Context, logger *zap.SugaredLogger, runner ci.Runner, course *qf.Course, buildContextFiles map[string]string) error {
 	logger.Debugf("Building %s's Dockerfile:\n%v", course.GetCode(), course.GetDockerfile())
 	out, err := runner.Run(ctx, &ci.Job{
-		Name:       course.JobName(),
-		Image:      course.DockerImage(),
-		Dockerfile: course.GetDockerfile(),
-		Commands:   []string{`echo -n "Hello from Dockerfile"`},
+		Name:              course.JobName(),
+		Image:             course.DockerImage(),
+		Dockerfile:        course.GetDockerfile(),
+		BuildContextFiles: buildContextFiles,
+		Commands:          []string{`echo -n "Hello from Dockerfile"`},
 	})
 	logger.Debugf("Build completed: %s", out)
 	if err != nil {

--- a/assignments/assignments_parser_test.go
+++ b/assignments/assignments_parser_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestParseWithInvalidDir(t *testing.T) {
 	const dir = "invalid/dir"
-	_, _, err := readTestsRepositoryContent(dir, 0)
+	_, _, _, err := readTestsRepositoryContent(dir, 0)
 	if err == nil {
 		t.Errorf("want no such file or directory error, got nil")
 	}
@@ -150,7 +150,7 @@ func TestParse(t *testing.T) {
 		GradingBenchmarks: wantCriteria,
 	}
 
-	assignments, dockerfile, err := readTestsRepositoryContent(testsDir, 0)
+	assignments, dockerfile, _, err := readTestsRepositoryContent(testsDir, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestParseOldAssignmentIDField(t *testing.T) {
 	} {
 		writeFile(t, testsDir, c.path, c.filename, c.content)
 	}
-	_, _, err := readTestsRepositoryContent(testsDir, 0)
+	_, _, _, err := readTestsRepositoryContent(testsDir, 0)
 	if err == nil {
 		t.Fatal("want error: 'assignment order must be greater than 0', got nil")
 	}
@@ -204,7 +204,7 @@ func TestParseOneBadAssignmentAmongCorrectOnes(t *testing.T) {
 	}
 
 	// Since lab3 contains an old assignmentid field, this will return an error
-	_, _, err := readTestsRepositoryContent(testsDir, 0)
+	_, _, _, err := readTestsRepositoryContent(testsDir, 0)
 	if err == nil {
 		t.Fatal("want error: 'assignment order must be greater than 0', got nil")
 	}
@@ -231,7 +231,7 @@ func TestParseUnknownFields(t *testing.T) {
 		ScoreLimit:  80,
 	}
 
-	assignments, _, err := readTestsRepositoryContent(testsDir, 0)
+	assignments, _, _, err := readTestsRepositoryContent(testsDir, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func TestParseAndSaveAssignment(t *testing.T) {
 	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Name: "admin", Login: "admin"})
 	qtest.CreateCourse(t, db, admin, course)
 
-	assignments, _, err := readTestsRepositoryContent(testsDir, course.ID)
+	assignments, _, _, err := readTestsRepositoryContent(testsDir, course.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +292,7 @@ func TestParseAndSaveAssignment(t *testing.T) {
 	writeFile(t, testsDir, "lab3", "assignment.yml", y3)
 
 	// Parse the new assignment
-	newAssignments, _, err := readTestsRepositoryContent(testsDir, course.ID)
+	newAssignments, _, _, err := readTestsRepositoryContent(testsDir, course.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -42,7 +42,7 @@ func TestFetchAssignments(t *testing.T) {
 		t.Fatal(err)
 	}
 	// walk the cloned tests repository and extract the assignments and the course's Dockerfile
-	assignments, dockerfile, err := readTestsRepositoryContent(clonedTestsRepo, course.ID)
+	assignments, dockerfile, _, err := readTestsRepositoryContent(clonedTestsRepo, course.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestFetchAssignments(t *testing.T) {
 	course.UpdateDockerfile(dockerfile)
 	docker, closeFn := dockerClient(t)
 	defer closeFn()
-	if err := buildDockerImage(context.Background(), qtest.Logger(t), docker, course); err != nil {
+	if err := buildDockerImage(context.Background(), qtest.Logger(t), docker, course, make(map[string]string)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/assignments/walk_tests_repo.go
+++ b/assignments/walk_tests_repo.go
@@ -16,6 +16,8 @@ const (
 	assignmentFileYaml = "assignment.yaml"
 	criteriaFile       = "criteria.json"
 	dockerfile         = "Dockerfile"
+	goMod              = "go.mod"
+	goSum              = "go.sum"
 	taskFilePattern    = "task-*.md"
 )
 
@@ -24,6 +26,8 @@ var patterns = []string{
 	assignmentFileYaml,
 	criteriaFile,
 	dockerfile,
+	goMod,
+	goSum,
 	taskFilePattern,
 }
 
@@ -48,10 +52,10 @@ func match(filename, pattern string) bool {
 // readTestsRepositoryContent reads dir and returns a list of assignments and
 // the course's Dockerfile content if there exists a 'tests/scripts/Dockerfile'.
 // Assignments are extracted from 'assignment.yml' files, one for each assignment.
-func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, string, error) {
+func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, string, map[string]string, error) {
 	files, err := walkTestsRepository(dir)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	// Process all assignment.yml files first
@@ -62,24 +66,26 @@ func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, 
 		case assignmentFile, assignmentFileYaml:
 			assignment, err := newAssignmentFromFile(contents, assignmentName, courseID)
 			if err != nil {
-				return nil, "", err
+				return nil, "", nil, err
 			}
 			assignmentsMap[assignmentName] = assignment
 		}
 	}
 
 	var courseDockerfile string
+	buildContextFiles := make(map[string]string)
 
 	// Process other files in tests repository
 	for path, contents := range files {
 		assignmentName := filepath.Base(filepath.Dir(path))
 		filename := filepath.Base(path)
+		fileContents := string(contents)
 
 		switch filename {
 		case criteriaFile:
 			var benchmarks []*qf.GradingBenchmark
 			if err := json.Unmarshal(contents, &benchmarks); err != nil {
-				return nil, "", fmt.Errorf("failed to unmarshal %q: %s", criteriaFile, err)
+				return nil, "", nil, fmt.Errorf("failed to unmarshal %q: %s", criteriaFile, err)
 			}
 			// Benchmarks and criteria must have courseID
 			// for access control checks.
@@ -92,7 +98,11 @@ func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, 
 			assignmentsMap[assignmentName].GradingBenchmarks = benchmarks
 
 		case dockerfile:
-			courseDockerfile = string(contents)
+			courseDockerfile = fileContents
+		case goMod:
+			buildContextFiles[goMod] = fileContents
+		case goSum:
+			buildContextFiles[goSum] = fileContents
 		}
 
 		if match(filename, taskFilePattern) {
@@ -100,7 +110,7 @@ func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, 
 			taskName := taskName(filename)
 			task, err := newTask(contents, assignment.GetOrder(), taskName)
 			if err != nil {
-				return nil, "", err
+				return nil, "", nil, err
 			}
 			assignmentsMap[assignmentName].Tasks = append(assignmentsMap[assignmentName].Tasks, task)
 		}
@@ -117,7 +127,7 @@ func readTestsRepositoryContent(dir string, courseID uint64) ([]*qf.Assignment, 
 		return assignments[i].Order < assignments[j].Order
 	})
 
-	return assignments, courseDockerfile, nil
+	return assignments, courseDockerfile, buildContextFiles, nil
 }
 
 // walkTestsRepository walks the tests repository and returns a map of file names and their contents.

--- a/assignments/walk_tests_repo_test.go
+++ b/assignments/walk_tests_repo_test.go
@@ -128,7 +128,7 @@ WORKDIR /quickfeed
 		},
 	}
 
-	gotAssignments, gotDockerfile, err := readTestsRepositoryContent(testsFolder, 1)
+	gotAssignments, gotDockerfile, _, err := readTestsRepositoryContent(testsFolder, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestReadTestsRepositoryContentForInvalidCriteriaFiles(t *testing.T) {
 }
 
 func checkLabWithInvalidCriteriaFile(t *testing.T, folder string) {
-	_, _, err := readTestsRepositoryContent(folder, 1)
+	_, _, _, err := readTestsRepositoryContent(folder, 1)
 	if err == nil {
 		t.Errorf("expected error")
 	}

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -14,6 +14,9 @@ type Job struct {
 	// If empty, the image is assumed to exist.
 	// If non-empty, the image is built from this Dockerfile.
 	Dockerfile string
+	// BuildContextFiles is a list of files to include in the build context.
+	// These files are copied to the image's /quickfeed directory.
+	BuildContextFiles map[string]string
 	// BindDir is the directory to bind to the container's /quickfeed directory.
 	BindDir string
 	// Env is a list of environment variables to set for the job.

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -229,21 +229,27 @@ func (d *Docker) pullImage(ctx context.Context, imageName string) error {
 
 // buildImage builds and installs an image locally to be reused in a future run.
 func (d *Docker) buildImage(ctx context.Context, job *Job) error {
-	dockerFileContents := []byte(job.Dockerfile)
-	header := &tar.Header{
-		Name:     "Dockerfile",
-		Mode:     0o777,
-		Size:     int64(len(dockerFileContents)),
-		Typeflag: tar.TypeReg,
-	}
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
-	if err := tarWriter.WriteHeader(header); err != nil {
-		return err
+
+	// Add Dockerfile to the build context to simplify the build preparation
+	job.BuildContextFiles["Dockerfile"] = job.Dockerfile
+	for name, content := range job.BuildContextFiles {
+		fileContents := []byte(content)
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o777,
+			Size:     int64(len(fileContents)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tarWriter.Write(fileContents); err != nil {
+			return err
+		}
 	}
-	if _, err := tarWriter.Write(dockerFileContents); err != nil {
-		return err
-	}
+
 	if err := tarWriter.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The go.mod and go.sum files can now be copied into the image and all the dependencies for the assignments can be pre-downloaded and cached in the image. This will speed up the build process for the assignments.

Supporting more files by updating the `patterns` slice with preferably a `const *name*` for the file you'ld want to add to the context. See [walk_tests_repo.go](https://github.com/quickfeed/quickfeed/blob/master/assignments/walk_tests_repo_test.go).

@meling I can add tests for `BuildContextFiles` if this implementation is desirable.