### PR TITLE
DeepSource(Docker): Resolve bug risk issues

### DIFF
--- a/assignments/testdata/tests/scripts/Dockerfile
+++ b/assignments/testdata/tests/scripts/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.19-alpine
-RUN apk update && apk add --no-cache git bash build-base
+FROM golang:1.24-alpine
+RUN apk update && apk add --no-cache git=~2.47 bash=~5.2.37 build-base=~0.5
 WORKDIR /quickfeed

--- a/ci/testdata/Dockerfile
+++ b/ci/testdata/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.19-alpine
+FROM golang:1.24-alpine
 
 # Install bash and git (and build-base to get gcc)
 # (this is required when building FROM: golang:alpine)
-RUN apk update && apk add --no-cache git bash build-base
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
+RUN apk update && apk add --no-cache git=~2.47 bash=~5.2.37 build-base=~0.5 golangci-lint=~1.61
 
 WORKDIR /quickfeed

--- a/doc/templates/go-course/scripts/Dockerfile
+++ b/doc/templates/go-course/scripts/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.19-alpine
+FROM golang:1.24-alpine
 
 # Install bash and git (and build-base to get gcc)
 # (this is required when building FROM: golang:alpine)
-RUN apk update && apk add --no-cache git bash build-base
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
+RUN apk update && apk add --no-cache git=~2.47 bash=~5.2.37 build-base=~0.5 golangci-lint=~1.61
 
 WORKDIR /quickfeed

--- a/testdata/courses/qf104-2022/tests/scripts/Dockerfile
+++ b/testdata/courses/qf104-2022/tests/scripts/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.19-alpine
+FROM golang:1.24-alpine
 
 # Install bash and git (and build-base to get gcc)
 # (this is required when building FROM: golang:alpine)
-RUN apk update && apk add --no-cache git bash build-base docker openrc
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
+RUN apk update && apk add --no-cache git=~2.47 bash=~5.2.37 build-base=~0.5 golangci-lint=~1.61 docker=~27.3.1 openrc=~0.55
 
 WORKDIR /quickfeed


### PR DESCRIPTION
Closes #1247

I don't know how to solve [Pin versions in apk add DOK-DL3018](https://app.deepsource.com/gh/quickfeed/quickfeed/issue/DOK-DL3018/occurrences?listindex=0), because I get this type of error when setting specific versions:

```bash
ERROR: unable to select packages:
  git-2.40.4-r0:
    breaks: world[git~2.4]
```

You can ignore it, but thats just annoying as well. I recommend just removing this from DeepSource by [ignoring it on DeepSoruce](https://docs.deepsource.com/docs/repository-view-issues#ignore-issues-in-files) 