### PR TITLE
Wrap ths inside of a "tr" element, to prevent HTML error in console

### DIFF
--- a/public/src/components/Groups.tsx
+++ b/public/src/components/Groups.tsx
@@ -112,22 +112,28 @@ const Groups = () => {
         return <GroupForm />
     }
 
+    const table = (
+        <table className="table table-striped table-grp table-hover">
+            <thead className="thead-dark">
+                <tr>
+                    <th>Name</th>
+                    <th>Members</th>
+                    <th>Manage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {PendingGroups}
+                {ApprovedGroups}
+            </tbody>
+        </table>
+    )
+
     return (
         <div className="box">
             <div className="pb-2">
                 <Search />
             </div>
-            <table className="table table-striped table-grp table-hover">
-                <thead className="thead-dark">
-                    <th>Name</th>
-                    <th>Members</th>
-                    <th>Manage</th>
-                </thead>
-                <tbody>
-                    {PendingGroups}
-                    {ApprovedGroups}
-                </tbody>
-            </table>
+            {table}
         </div>
     )
 }


### PR DESCRIPTION
Closes: #1283


Im not sure why DeepSource thinks this is deeply nested:

![image](https://github.com/user-attachments/assets/9618f09e-d452-4899-a83d-5e01b67d32f8)
