### PR TITLE
Adjust members page to be displayed over the whole page

### DIFF
--- a/public/src/components/Members.tsx
+++ b/public/src/components/Members.tsx
@@ -93,7 +93,7 @@ const Members = () => {
     })
 
     return (
-        <div className='container'>
+        <>
             <div className="row no-gutters pb-2">
                 <div className="col-md-6">
                     <Search />
@@ -120,7 +120,7 @@ const Members = () => {
             <div>
                 <DynamicTable header={header} data={members} />
             </div>
-        </div>
+        </>
     )
 }
 


### PR DESCRIPTION
Resolves: #1289 

This is a different solution from the planned one in the related issue, but I kinda like it and it was a very minimal change. Only downside is maybe the width on large screens, but you atleast won't make people with a small screen frustrated.

Before:

![image](https://github.com/user-attachments/assets/fecf966b-5486-4504-9b6b-70fbb0d26c30)


After:

![image](https://github.com/user-attachments/assets/f9387e6a-b03e-483a-9982-cec55b9e8d95)

Can optionally reduce it to 75% width and aligned to the left;

![image](https://github.com/user-attachments/assets/61445637-f3ed-413d-8788-08176b5a4440)

Only need to add: "div className="w-75" inside of <> and in the end add a close tag for the div: `</div>`

