### PR TITLE
Add helpful launch profiles for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,8 @@
             // Compound configuration to run both frontend and backend debug sessions
             "name": "Launch Quickfeed",
             "configurations": [
-                "Debug Frontend",
-                "Debug Backend - Quickfeed"
+                "Launch Quickfeed Frontend",
+                "Launch Quickfeed Backend"
             ],
         }
     ],
@@ -22,8 +22,7 @@
             "program": "${fileDirname}"
         },
         {
-            // Start a debugging session for the frontend
-            "name": "Debug Frontend",
+            "name": "Launch Quickfeed Frontend",
             "type": "chrome", // Others: "msedge", "firefox"
             "request": "launch",
             // The url is here for convenience, as you can also input the URL in the browser
@@ -31,14 +30,13 @@
             "webRoot": "${workspaceFolder}/public",
         },
         {
-            // Start a debugging session for the backend
             // Launches Quickfeed in dev and watch mode
-            // Debug Quickfeed directly by switching mode to "auto" and set program to "${workspaceFolder}/main.go"
-            "name": "Debug Backend - Quickfeed",
+            "name": "Launch Quickfeed Backend",
             "type": "go",
             "request": "launch",
-            "mode": "exec",
-            "program": "${env:GOPATH}/bin/quickfeed",
+            // You can debug a Quickfeed binary by switching mode to "exec" and set program to "${env:GOPATH}/bin/quickfeed"
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
             "args": [
                 "-dev",
                 "-watch"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,16 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
+    "compounds": [
+        {
+            // Compound configuration to run both frontend and backend debug sessions
+            "name": "Launch Quickfeed",
+            "configurations": [
+                "Debug Frontend",
+                "Debug Backend - Quickfeed"
+            ],
+        }
+    ],
     "configurations": [
         {
             "name": "Launch Package",
@@ -10,6 +20,29 @@
             "request": "launch",
             "mode": "auto",
             "program": "${fileDirname}"
+        },
+        {
+            // Start a debugging session for the frontend
+            "name": "Debug Frontend",
+            "type": "chrome", // Others: "msedge", "firefox"
+            "request": "launch",
+            // The url is here for convenience, as you can also input the URL in the browser
+            "url": "https://localhost:443", // Update PORT as needed. See .env file
+            "webRoot": "${workspaceFolder}/public",
+        },
+        {
+            // Start a debugging session for the backend
+            // Launches Quickfeed in dev and watch mode
+            // Debug Quickfeed directly by switching mode to "auto" and set program to "${workspaceFolder}/main.go"
+            "name": "Debug Backend - Quickfeed",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${env:GOPATH}/bin/quickfeed",
+            "args": [
+                "-dev",
+                "-watch"
+            ]
         }
     ]
 }


### PR DESCRIPTION
A launch profile is very useful for debugging, as it allows for developers to view the workflow and analyze different sections while the program is running. This is much more reliable and efficient than printing in-memory values to the console or the standard output.

"Launch Quickfeed" will let developers start Quickfeed in debug mode for both frontend and backend, which can in the future be combined with the Docker container, if that is diserable.

A user can run Quickfeed either directly or through the created binary or executable.