### PR TITLE
Remove extra whitespace in .env file

### DIFF
--- a/internal/env/save.go
+++ b/internal/env/save.go
@@ -67,7 +67,7 @@ func update(filename, content string, env map[string]string) error {
 	updated := make(map[string]bool)
 
 	// Scan existing file's content and update existing environment variables.
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(content), "\n") {
 		key, val, found := strings.Cut(line, "=")
 		if !found {
 			// Leave non-environment and blank lines unchanged.


### PR DESCRIPTION
This removes any whitespace (blank lines) before and after the content of .env files.

Fixes #1362

