### PR TITLE
Fix bug due to too short pkg path matching pattern

### DIFF
--- a/kit/internal/test/callframe.go
+++ b/kit/internal/test/callframe.go
@@ -44,7 +44,7 @@ func unwindCallFrames() []runtime.Frame {
 	for {
 		frame, more := frames.Next()
 		// Stop unwinding when we reach package testing.
-		if strings.Contains(frame.File, "testing/") {
+		if strings.Contains(frame.File, "src/testing/testing.go") {
 			break
 		}
 		foundFrames = append(foundFrames, frame)

--- a/kit/internal/test/qf_testing/caller_test.go
+++ b/kit/internal/test/qf_testing/caller_test.go
@@ -1,0 +1,20 @@
+package qf_testing
+
+import (
+	"testing"
+
+	"github.com/quickfeed/quickfeed/kit/internal/test"
+)
+
+func callerName() string {
+	return test.CallerName()
+}
+
+func TestCallerName(t *testing.T) {
+	if callerName() != "callerName" {
+		t.Errorf("callerName()=%s, want callerName", callerName())
+	}
+	if test.CallerName() != "TestCallerName" {
+		t.Errorf("CallerName()=%s, want TestCallerName", test.CallerName())
+	}
+}


### PR DESCRIPTION
Fixes #1387

This checks for src/testing/testing.go instead of just testing/, which Jostein accidentally discovered to be too short, and easily matched a course name qf-testing/ or as in the test case, qf_testing would also match.
