### PR TITLE
Environment variables are now properly loaded before building frontend

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/quickfeed/quickfeed/internal/env"
 	"github.com/quickfeed/quickfeed/internal/ui"
 )
 
@@ -10,6 +11,11 @@ import (
 // The frontend src code is located in the public directory.
 // The compiled code is placed in the dist directory.
 func main() {
+	// Load environment variables from .env file
+	// This is necessary to ensure the build has access to the correct environment variables.
+	if err := env.Load(env.RootEnv(".env")); err != nil {
+		panic(err)
+	}
 	// Errors and warnings will be logged by Esbuild
 	_ = ui.Build("", true)
 }


### PR DESCRIPTION
Fixes building frontend with cmd esbuild does not include (load) environment variables
Fixes #1395
