### PR TITLE
Avoid saving expanded QUICKFEED_APP_KEY env variable

### DIFF
--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -154,7 +154,6 @@ func (m *Manifest) conversion() http.HandlerFunc {
 		// Save the application configuration to the envFile
 		envToUpdate := map[string]string{
 			appID:         strconv.FormatInt(config.GetID(), 10),
-			appKey:        appKeyFile,
 			appUrl:        config.GetHTMLURL(),
 			clientID:      config.GetClientID(),
 			clientSecret:  config.GetClientSecret(),


### PR DESCRIPTION
This could cause problems inside docker containers. We don't need to replace `$QUICKFEED` when saving back `.env` since the `Load()` function will expand correctly when loading.

Fixes #1211 
