### PR TITLE
feat: improve docker performance by introducing language specific caching

### DIFF
--- a/ci/ci.go
+++ b/ci/ci.go
@@ -11,7 +11,6 @@ type Job struct {
 	// Image names the image to use to run the job.
 	Image string
 	// Language specifies the programming language for the job.
-	// When set to LanguageGo, Go-specific cache directories are mounted.
 	// Parsed from the #language/ directive in the run script.
 	Language string
 	// BuildContext is a list of files to include in the Docker build context.

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -18,6 +18,9 @@ type Job struct {
 	BuildContext map[string]string
 	// BindDir is the directory to bind to the container's /quickfeed directory.
 	BindDir string
+	// ReadOnlyMounts maps host source paths to container target paths for read-only bind mounts.
+	// These are mounted in addition to BindDir and are not affected by changes in the container.
+	ReadOnlyMounts map[string]string
 	// Env is a list of environment variables to set for the job.
 	Env []string
 	// Commands is a list of shell commands to run as part of the job.

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -10,6 +10,10 @@ type Job struct {
 	Name string
 	// Image names the image to use to run the job.
 	Image string
+	// Language specifies the programming language for the job.
+	// When set to LanguageGo, Go-specific cache directories are mounted.
+	// Parsed from the #language/ directive in the run script.
+	Language string
 	// BuildContext is a list of files to include in the Docker build context.
 	// These files are available to the Dockerfile (e.g. via COPY/ADD) and can be
 	// copied into the image, such as into the /quickfeed directory, if desired.

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -29,7 +29,6 @@ var DefaultContainerTimeout = time.Duration(10 * time.Minute)
 const (
 	Dockerfile      = "Dockerfile"
 	QuickFeedPath   = "/quickfeed"
-	GoModCache      = "/quickfeed-go-mod-cache"
 	maxToScan       = 1_000_000 // bytes
 	maxLogSize      = 30_000    // bytes
 	lastSegmentSize = 1_000     // bytes
@@ -146,7 +145,19 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*client.ContainerCr
 				Target: QuickFeedPath,
 			},
 		}
+		if cfg, ok := languages[job.Language]; ok {
+			for target, pathFn := range cfg.cacheDirs {
+				src, err := pathFn()
+				if err != nil {
+					return nil, err
+				}
+				mounts = append(mounts, mount.Mount{
 					Type:   mount.TypeBind,
+					Source: src,
+					Target: target,
+				})
+			}
+		}
 		for _, src := range slices.Sorted(maps.Keys(job.ReadOnlyMounts)) {
 			mounts = append(mounts, mount.Mount{
 				Type:     mount.TypeBind,

--- a/ci/docker.go
+++ b/ci/docker.go
@@ -139,23 +139,24 @@ func (d *Docker) createImage(ctx context.Context, job *Job) (*client.ContainerCr
 
 	var hostConfig *container.HostConfig
 	if job.BindDir != "" {
-		goModCacheSrc, err := moduleCachePath()
-		if err != nil {
-			return nil, err
+		mounts := []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: job.BindDir,
+				Target: QuickFeedPath,
+			},
+		}
+					Type:   mount.TypeBind,
+		for _, src := range slices.Sorted(maps.Keys(job.ReadOnlyMounts)) {
+			mounts = append(mounts, mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   src,
+				Target:   job.ReadOnlyMounts[src],
+				ReadOnly: true,
+			})
 		}
 		hostConfig = &container.HostConfig{
-			Mounts: []mount.Mount{
-				{
-					Type:   mount.TypeBind,
-					Source: job.BindDir,
-					Target: QuickFeedPath,
-				},
-				{
-					Type:   mount.TypeBind,
-					Source: goModCacheSrc,
-					Target: GoModCache,
-				},
-			},
+			Mounts: mounts,
 		}
 	}
 

--- a/ci/languages.go
+++ b/ci/languages.go
@@ -1,0 +1,39 @@
+package ci
+
+// Language constants for supported languages.
+// These are used in run scripts via the #language/ directive.
+const (
+	LanguageGo = "go"
+)
+
+// Go-specific container cache paths.
+const (
+	GoModCache        = "/quickfeed-go-mod-cache"
+	GoCache           = "/quickfeed-go-cache"
+	GolangciLintCache = "/quickfeed-golangci-lint-cache"
+)
+
+// languageConfig defines language-specific cache mounts and environment variables.
+type languageConfig struct {
+	// cacheDirs maps container target paths to host cache directory resolver functions.
+	cacheDirs map[string]func() (string, error)
+	// envVars lists additional environment variables to set in the container.
+	envVars []string
+}
+
+// languages maps language identifiers to their cache configurations.
+// To add support for a new language, add an entry here with the relevant
+// cache directories and environment variables.
+var languages = map[string]languageConfig{
+	LanguageGo: {
+		cacheDirs: map[string]func() (string, error){
+			GoModCache:        moduleCachePath,
+			GoCache:           goCachePath,
+			GolangciLintCache: golangciLintCachePath,
+		},
+		envVars: []string{
+			"GOCACHE=" + GoCache,
+			"GOLANGCI_LINT_CACHE=" + GolangciLintCache,
+		},
+	},
+}

--- a/ci/languages.go
+++ b/ci/languages.go
@@ -32,6 +32,7 @@ var languages = map[string]languageConfig{
 			GolangciLintCache: golangciLintCachePath,
 		},
 		envVars: []string{
+			"GOMODCACHE=" + GoModCache,
 			"GOCACHE=" + GoCache,
 			"GOLANGCI_LINT_CACHE=" + GolangciLintCache,
 		},

--- a/ci/languages.go
+++ b/ci/languages.go
@@ -7,7 +7,7 @@ const (
 	languageDotNet = "dotnet"
 )
 
-// Go-specific container cache paths.
+// Language-specific container cache paths.
 const (
 	GoModCache        = "/quickfeed-go-mod-cache"
 	GoCache           = "/quickfeed-go-cache"

--- a/ci/languages.go
+++ b/ci/languages.go
@@ -3,7 +3,8 @@ package ci
 // Language constants for supported languages.
 // These are used in run scripts via the #language/ directive.
 const (
-	LanguageGo = "go"
+	languageGo     = "go"
+	languageDotNet = "dotnet"
 )
 
 // Go-specific container cache paths.
@@ -11,6 +12,7 @@ const (
 	GoModCache        = "/quickfeed-go-mod-cache"
 	GoCache           = "/quickfeed-go-cache"
 	GolangciLintCache = "/quickfeed-golangci-lint-cache"
+	NuGetCache        = "/quickfeed-nuget-cache"
 )
 
 // languageConfig defines language-specific cache mounts and environment variables.
@@ -25,7 +27,7 @@ type languageConfig struct {
 // To add support for a new language, add an entry here with the relevant
 // cache directories and environment variables.
 var languages = map[string]languageConfig{
-	LanguageGo: {
+	languageGo: {
 		cacheDirs: map[string]func() (string, error){
 			GoModCache:        moduleCachePath,
 			GoCache:           goCachePath,
@@ -35,6 +37,14 @@ var languages = map[string]languageConfig{
 			"GOMODCACHE=" + GoModCache,
 			"GOCACHE=" + GoCache,
 			"GOLANGCI_LINT_CACHE=" + GolangciLintCache,
+		},
+	},
+	languageDotNet: {
+		cacheDirs: map[string]func() (string, error){
+			NuGetCache: nugetCachePath,
+		},
+		envVars: []string{
+			"NUGET_PACKAGES=" + NuGetCache,
 		},
 	},
 }

--- a/ci/module_cache.go
+++ b/ci/module_cache.go
@@ -23,6 +23,10 @@ func golangciLintCachePath() (string, error) {
 	return hostCacheDir(GolangciLintCache)
 }
 
+func nugetCachePath() (string, error) {
+	return hostCacheDir(NuGetCache)
+}
+
 // hostCacheDir returns a cache directory under $HOME with the given name,
 // creating it if necessary. Directories are created owned by the current user,
 // which ensures containers running as that user can read and write them.

--- a/ci/module_cache.go
+++ b/ci/module_cache.go
@@ -5,18 +5,37 @@ import (
 	"path/filepath"
 )
 
-// moduleCachePath returns quickfeed's go module cache.
+// moduleCachePath returns quickfeed's go module cache path on the host.
 // If the directory does not exist, it will be created.
 func moduleCachePath() (string, error) {
+	return hostCacheDir(GoModCache)
+}
+
+// goCachePath returns quickfeed's Go build cache path on the host.
+// If the directory does not exist, it will be created.
+func goCachePath() (string, error) {
+	return hostCacheDir(GoCache)
+}
+
+// golangciLintCachePath returns quickfeed's golangci-lint cache path on the host.
+// If the directory does not exist, it will be created.
+func golangciLintCachePath() (string, error) {
+	return hostCacheDir(GolangciLintCache)
+}
+
+// hostCacheDir returns a cache directory under $HOME with the given name,
+// creating it if necessary. Directories are created owned by the current user,
+// which ensures containers running as that user can read and write them.
+func hostCacheDir(name string) (string, error) {
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	goModCacheSrc := filepath.Join(homedir, GoModCache)
-	if ok, _ := exists(goModCacheSrc); !ok {
-		if err := os.MkdirAll(goModCacheSrc, 0o755); err != nil {
+	dir := filepath.Join(homedir, name)
+	if ok, _ := exists(dir); !ok {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return "", err
 		}
 	}
-	return goModCacheSrc, nil
+	return dir, nil
 }

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -26,7 +26,7 @@ func (r *RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	image, commands, err := parseRunScript(scriptContent)
+	image, language, commands, err := parseRunScript(scriptContent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
 	}
@@ -34,7 +34,11 @@ func (r *RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
 		// For docker runs, the home path is set to QuickFeedPath = /quickfeed
 		r.EnvVarsFn = func(secret, _ string) []string {
 			// QuickFeedPath is the home path (inside the container) bound to the temporary tests directory
-			return EnvVars(secret, QuickFeedPath, r.Repo.Name(), r.Assignment.GetName())
+			vars := EnvVars(secret, QuickFeedPath, r.Repo.Name(), r.Assignment.GetName())
+			if cfg, ok := languages[language]; ok {
+				vars = append(vars, cfg.envVars...)
+			}
+			return vars
 		}
 	}
 	testsDir := filepath.Join(r.Course.CloneDir(), qf.TestsRepo)
@@ -74,16 +78,24 @@ func (r *RunData) loadRunScript() (string, error) {
 	return string(b), nil
 }
 
-func parseRunScript(scriptContent string) (image string, commands []string, err error) {
-	s := strings.Split(scriptContent, "\n")
-	if len(s) < 3 {
-		return "", nil, errors.New("empty run script")
+func parseRunScript(scriptContent string) (image, language string, commands []string, err error) {
+	lines := strings.Split(scriptContent, "\n")
+	if len(lines) < 3 {
+		return "", "", nil, errors.New("empty run script")
 	}
-	parts := strings.Split(s[0], "#image/")
+	parts := strings.Split(lines[0], "#image/")
 	if len(parts) < 2 {
-		return "", nil, errors.New("no docker image specified in run script")
+		return "", "", nil, errors.New("no docker image specified in run script")
 	}
-	return strings.ToLower(parts[1]), s[1:], nil
+	image = strings.ToLower(parts[1])
+	for _, line := range lines[1:] {
+		if lang, found := strings.CutPrefix(line, "#language/"); found {
+			language = strings.ToLower(strings.TrimSpace(lang))
+			continue
+		}
+		commands = append(commands, line)
+	}
+	return image, language, commands, nil
 }
 
 func EnvVars(sessionSecret, home, repoName, currentAssignment string) []string {

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -37,10 +37,17 @@ func (r *RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
 			return EnvVars(secret, QuickFeedPath, r.Repo.Name(), r.Assignment.GetName())
 		}
 	}
+	testsDir := filepath.Join(r.Course.CloneDir(), qf.TestsRepo)
+	assignmentDir := filepath.Join(r.Course.CloneDir(), qf.AssignmentsRepo)
 	return &Job{
 		Name:     r.String(),
 		Image:    image,
+		Language: language,
 		BindDir:  destDir,
+		ReadOnlyMounts: map[string]string{
+			testsDir:      filepath.Join(QuickFeedPath, qf.TestsRepo),
+			assignmentDir: filepath.Join(QuickFeedPath, qf.AssignmentsRepo),
+		},
 		Env:      r.EnvVarsFn(secret, destDir),
 		Commands: commands,
 	}, nil

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -142,9 +142,5 @@ func (r *RunData) clone(ctx context.Context, sc scm.SCM, dstDir string) error {
 			return err
 		}
 	}
-	// Copy the tests and assignment repos to the destination directory
-	if err = fileop.CopyDir(testsDir, dstDir); err != nil {
-		return err
-	}
-	return fileop.CopyDir(assignmentDir, dstDir)
+	return nil
 }

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quickfeed/quickfeed/internal/fileop"
 	"github.com/quickfeed/quickfeed/internal/qlog"
 	"github.com/quickfeed/quickfeed/internal/rand"
 	"github.com/quickfeed/quickfeed/kit/score"

--- a/ci/run_tests_clone_test.go
+++ b/ci/run_tests_clone_test.go
@@ -66,9 +66,14 @@ func TestCloneAndCopyRunTests(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	for _, s := range []string{qf.TestsRepo, qf.AssignmentsRepo, qf.StudentRepoName(qfUserName)} {
-		if !strings.Contains(out, s) {
-			t.Errorf("expected %q to contain %q", out, s)
+	// After clone(), only the student repo is present in dstDir.
+	// The tests and assignments repos are mounted directly into the container as read-only bind mounts.
+	if !strings.Contains(out, qf.StudentRepoName(qfUserName)) {
+		t.Errorf("expected %q to contain %q", out, qf.StudentRepoName(qfUserName))
+	}
+	for _, s := range []string{qf.TestsRepo, qf.AssignmentsRepo} {
+		if strings.Contains(out, s) {
+			t.Errorf("expected %q not to contain %q (should be a read-only mount, not a copy)", out, s)
 		}
 	}
 }

--- a/testdata/courses/qf104-2022/tests/lab6-go/run.sh
+++ b/testdata/courses/qf104-2022/tests/lab6-go/run.sh
@@ -1,0 +1,7 @@
+#image/quickfeed:go
+#language/go
+echo "$TESTS"
+echo "$ASSIGNMENTS"
+echo "$SUBMITTED"
+echo "$CURRENT"
+echo "$QUICKFEED_SESSION_SECRET"


### PR DESCRIPTION
- feat: add support for read-only bind mounts in CI jobs
- feat: add support for Go language caching in Docker jobs

Individual courses can enable language specific settings by adding `#language/<language>` to their `run.sh`.
Currently only Go has custom settings, specifically for providing caches that persists between runs.

