### PR TITLE
fix: delete SCM repos before database repos when removing groups, enrollments

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -281,8 +281,9 @@ func (s *GithubSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentO
 	return nil, E(op, m, fmt.Errorf("invalid enrollment status: %s", opt.Status))
 }
 
-// RejectEnrollment removes user's repository and revokes user's membership in the course organization.
-// If the user was already removed from the organization an error is returned, and the repository deletion is skipped.
+// RejectEnrollment deletes the user's course repository and revokes their
+// organization membership. Revoking the membership (not just removing a member)
+// also cancels a pending invitation. Both steps are idempotent and retry-safe.
 func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentOptions) error {
 	const op Op = "RejectEnrollment"
 	m := M("failed to reject enrollment")
@@ -294,12 +295,13 @@ func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentO
 	if err != nil {
 		return E(op, m, err)
 	}
-	// If user was already removed we report the error and skip the repository deletion
-	if _, err := s.client.Organizations.RemoveMember(ctx, org.GetScmOrganizationName(), opt.User); err != nil {
-		return E(op, m, fmt.Errorf("failed to remove user: %w", err))
-	}
-	if err := s.deleteRepository(ctx, opt.RepositoryID); err != nil {
+	// tolerate an already-deleted repository so reject is idempotent
+	if err := s.deleteRepository(ctx, opt.RepositoryID); err != nil && !errors.Is(err, ErrNotFound) {
 		return E(op, m, err)
+	}
+	// tolerate 404 (no such membership) so reject is idempotent
+	if resp, err := s.client.Organizations.RemoveOrgMembership(ctx, opt.User, org.GetScmOrganizationName()); err != nil && !hasStatus(resp, http.StatusNotFound) {
+		return E(op, m, fmt.Errorf("failed to remove user: %w", err))
 	}
 	return nil
 }

--- a/scm/github.go
+++ b/scm/github.go
@@ -585,7 +585,7 @@ func (s *GithubSCM) createForkedRepo(ctx context.Context, opt *CreateRepositoryO
 	return toRepository(repo), nil
 }
 
-// deleteRepository deletes repository by name or ID.
+// deleteRepository deletes repository by ID.
 func (s *GithubSCM) deleteRepository(ctx context.Context, id uint64) error {
 	const op Op = "deleteRepository"
 	m := M("failed to delete repository")

--- a/scm/github.go
+++ b/scm/github.go
@@ -559,8 +559,13 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, id uint64) error {
 		return E(op, m, fmt.Errorf("missing ID"))
 	}
 
-	repo, _, err := s.client.Repositories.GetByID(ctx, int64(id))
+	repo, resp, err := s.client.Repositories.GetByID(ctx, int64(id))
 	if err != nil {
+		if hasStatus(resp, http.StatusNotFound) {
+			// wrap ErrNotFound to allow callers to detect that the repository
+			// is already gone, e.g., from a previously interrupted delete
+			return E(op, m, fmt.Errorf("repository %d: %w", id, ErrNotFound))
+		}
 		return E(op, m, fmt.Errorf("failed to get repository %d: %w", id, err))
 	}
 

--- a/scm/github.go
+++ b/scm/github.go
@@ -571,7 +571,12 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, id uint64) error {
 		return E(op, m, fmt.Errorf("failed to get repository %d: %w", id, err))
 	}
 
-	if _, err := s.client.Repositories.Delete(ctx, repo.GetOwner().GetLogin(), repo.GetName()); err != nil {
+	if deleteResp, err := s.client.Repositories.Delete(ctx, repo.GetOwner().GetLogin(), repo.GetName()); err != nil {
+		if hasStatus(deleteResp, http.StatusNotFound) {
+			// The repository was deleted after GetByID succeeded.
+			// Treat this as success so delete remains idempotent.
+			return nil
+		}
 		return E(op, M("failed to delete repository %s/%s", repo.GetOwner().GetLogin(), repo.GetName()), err)
 	}
 

--- a/scm/github_mock.go
+++ b/scm/github_mock.go
@@ -277,12 +277,12 @@ func NewMockedGithubSCMClient(logger *zap.SugaredLogger, opts ...MockOption) *Mo
 			}
 		}),
 	)
-	deleteOrgsMembersByOrgByUsernameHandler := WithRequestMatchHandler(
-		deleteOrgsMembersByOrgByUsername,
+	deleteOrgsMembershipsByOrgByUsernameHandler := WithRequestMatchHandler(
+		deleteOrgsMembershipsByOrgByUsername,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			org := r.PathValue("org")
 			username := r.PathValue("username")
-			logger.Debug(replaceArgs(deleteOrgsMembersByOrgByUsername, org, username))
+			logger.Debug(replaceArgs(deleteOrgsMembershipsByOrgByUsername, org, username))
 
 			found := s.matchOrgFunc(org, func(o github.Organization) {
 				for i, m := range s.members {
@@ -292,7 +292,7 @@ func NewMockedGithubSCMClient(logger *zap.SugaredLogger, opts ...MockOption) *Mo
 						return
 					}
 				}
-				w.WriteHeader(http.StatusNotFound) // member not found
+				w.WriteHeader(http.StatusNotFound) // no membership record
 			})
 			if !found {
 				w.WriteHeader(http.StatusNotFound) // org not found
@@ -792,7 +792,7 @@ func NewMockedGithubSCMClient(logger *zap.SugaredLogger, opts ...MockOption) *Mo
 		getOrgsMembershipsByOrgByUsernameHandler,
 		putOrgsMembershipsByOrgByUsernameHandler,
 		patchUserMembershipsOrgsByOrgHandler,
-		deleteOrgsMembersByOrgByUsernameHandler,
+		deleteOrgsMembershipsByOrgByUsernameHandler,
 		getReposByOwnerByRepoHandler,
 		deleteReposByOwnerByRepoHandler,
 		getRepositoriesByIDHandler,

--- a/scm/github_mock_patterns.go
+++ b/scm/github_mock_patterns.go
@@ -10,7 +10,7 @@ const (
 	getOrgsMembershipsByOrgByUsername                         = "GET /orgs/{org}/memberships/{username}"                             // GetOrganization
 	putOrgsMembershipsByOrgByUsername                         = "PUT /orgs/{org}/memberships/{username}"                             // UpdateEnrollment, DemoteTeacherToStudent
 	patchUserMembershipsOrgsByOrg                             = "PATCH /user/memberships/orgs/{org}"                                 // acceptOrgInvitation
-	deleteOrgsMembersByOrgByUsername                          = "DELETE /orgs/{org}/members/{username}"                              // RejectEnrollment
+	deleteOrgsMembershipsByOrgByUsername                      = "DELETE /orgs/{org}/memberships/{username}"                          // RejectEnrollment
 	getReposByOwnerByRepo                                     = "GET /repos/{owner}/{repo}"                                          // CreateCourse, CreateGroup, getRepository, createCourseRepo, createForkedRepo, waitForRepository
 	deleteReposByOwnerByRepo                                  = "DELETE /repos/{owner}/{repo}"                                       // DeleteGroup, RejectEnrollment, deleteRepository
 	getRepositoriesByID                                       = "GET /repositories/{repository_id}"                                  // getRepository, deleteRepository

--- a/scm/github_mock_test.go
+++ b/scm/github_mock_test.go
@@ -393,12 +393,14 @@ func TestMockRejectEnrollment(t *testing.T) {
 		{name: "IncompleteRequest", opt: &RejectEnrollmentOptions{OrganizationID: 123, User: "meling"}, wantErr: true},
 		{name: "IncompleteRequest", opt: &RejectEnrollmentOptions{RepositoryID: 1, User: "meling"}, wantErr: true},
 
-		{name: "CompleteRequest/OrgNotFound", opt: &RejectEnrollmentOptions{OrganizationID: 789, RepositoryID: 1, User: "meling"}, wantErr: true},     // 789 does not exist
-		{name: "CompleteRequest/RepoNotFound", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"}, wantErr: true}, // 999 does not exist; note that jostein will be removed from foo
-		{name: "CompleteRequest/UserNotFound", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "frank"}, wantErr: true},     // frank is not a member of foo
+		{name: "CompleteRequest/OrgNotFound", opt: &RejectEnrollmentOptions{OrganizationID: 789, RepositoryID: 4, User: "meling"}, wantErr: true}, // 789 does not exist
 
+		// happy path: member and their repo both exist and are removed
 		{name: "CompleteRequest/SuccessfullyRejected", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 4, User: "meling"}, wantErr: false},
-		{name: "CompleteRequest/SuccessfullyRejected", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 5, User: "jostein"}, wantErr: true}, // jostein was already removed
+		// repo already gone (404) is tolerated; jostein is still a member and is removed
+		{name: "CompleteRequest/RepoAlreadyDeleted", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"}, wantErr: false},
+		// membership already gone (404) is tolerated; jostein was removed above, repo 5 still exists
+		{name: "CompleteRequest/MembershipAlreadyGone", opt: &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 5, User: "jostein"}, wantErr: false},
 	}
 	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
 	for _, tt := range tests {

--- a/scm/scm_errors.go
+++ b/scm/scm_errors.go
@@ -6,12 +6,14 @@ import (
 )
 
 var (
-	// ErrNotFound indicates that the user is not member of the organization.
+	// ErrNotMember indicates that the user is not member of the organization.
 	ErrNotMember = errors.New("not a member of organization")
 	// ErrNotOwner indicates that the user is not an owner of the organization.
 	ErrNotOwner = errors.New("not an owner of organization")
 	// ErrAlreadyExists indicates that a repository already exist in the organization.
 	ErrAlreadyExists = errors.New("already exist")
+	// ErrNotFound indicates that a repository does not exist in the organization.
+	ErrNotFound = errors.New("not found")
 )
 
 // SCMError holds the operation, user error message and the original error.

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -392,7 +392,7 @@ func TestErrorRejectEnrollment(t *testing.T) {
 		{
 			name:        "CompleteRequest/RepoNotFound",
 			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"},
-			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: scm.deleteRepository: failed to delete repository: failed to get repository 999: GET http://127.0.0.1/repositories/999: 404  []",
+			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: scm.deleteRepository: failed to delete repository: repository 999: not found",
 			wantUserErr: userErrPrefix + " for jostein",
 		},
 		{

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -364,13 +364,10 @@ func TestErrorUpdateEnrollment(t *testing.T) {
 }
 
 func TestErrorRejectEnrollment(t *testing.T) {
-	members := []github.Membership{
-		{Organization: &ghOrgFoo, User: &meling},
-		{Organization: &ghOrgFoo, User: &jostein},
-		{Organization: &ghOrgBar, User: &meling},
-	}
 	const userErrPrefix = "failed to reject enrollment"
 
+	// Only error cases belong here; idempotency-success cases are covered by
+	// TestMockRejectEnrollment.
 	tests := []struct {
 		name        string
 		opt         *RejectEnrollmentOptions // cannot be nil
@@ -389,32 +386,8 @@ func TestErrorRejectEnrollment(t *testing.T) {
 			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for meling: scm.GetOrganization: failed to get organization by ID: 789: GET http://127.0.0.1/organizations/789: 404  []",
 			wantUserErr: userErrPrefix + " for meling",
 		},
-		{
-			name:        "CompleteRequest/RepoNotFound",
-			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 999, User: "jostein"},
-			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: scm.deleteRepository: failed to delete repository: repository 999: not found",
-			wantUserErr: userErrPrefix + " for jostein",
-		},
-		{
-			name:        "CompleteRequest/UserNotFound",
-			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "frank"},
-			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for frank: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/frank: 404  []",
-			wantUserErr: userErrPrefix + " for frank",
-		},
-		{
-			name:        "CompleteRequest/UserAlreadyRemoved",
-			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 5, User: "jostein"},
-			wantErr:     "scm.RejectEnrollment: failed to reject enrollment for jostein: failed to remove user: DELETE http://127.0.0.1/orgs/foo/members/jostein: 404  []",
-			wantUserErr: userErrPrefix + " for jostein",
-		},
-		{
-			name:        "CompleteRequest/Success",
-			opt:         &RejectEnrollmentOptions{OrganizationID: 123, RepositoryID: 1, User: "meling"},
-			wantErr:     "",
-			wantUserErr: "",
-		},
 	}
-	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...), WithMembers(members...))
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo, ghOrgBar), WithRepos(repos...))
 	for _, tt := range tests {
 		name := qtest.Name(tt.name, []string{"OrganizationID", "RepositoryID", "User"}, tt.opt.OrganizationID, tt.opt.RepositoryID, tt.opt.User)
 		t.Run(name, func(t *testing.T) {

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -183,6 +184,31 @@ func TestErrorGetOrganization(t *testing.T) {
 			_, gotErr := s.GetOrganization(context.Background(), tt.opt)
 			chkErrMsg(t, "GetOrganization()", gotErr, tt.wantErr, tt.wantUserErr)
 		})
+	}
+}
+
+func TestDeleteRepositoryTreatsDelete404AsSuccess(t *testing.T) {
+	calls := 0
+	s := NewGithubUserClient(qtest.Logger(t), "token")
+	s.client = github.NewClient(&http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			switch r.Method + " " + r.URL.Path {
+			case http.MethodGet + " /repositories/1":
+				return githubResponse(http.StatusOK, `{"id":1,"name":"groupX","owner":{"login":"foo"}}`, nil), nil
+			case http.MethodDelete + " /repos/foo/groupX":
+				return githubResponse(http.StatusNotFound, "", nil), nil
+			default:
+				return nil, fmt.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		}),
+	})
+
+	if err := s.deleteRepository(context.Background(), 1); err != nil {
+		t.Fatalf("deleteRepository() error = %v, want nil", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 requests, got %d", calls)
 	}
 }
 

--- a/web/courses.go
+++ b/web/courses.go
@@ -39,26 +39,22 @@ func (s *QuickFeedService) updateEnrollment(ctx context.Context, sc scm.SCM, cur
 }
 
 // rejectEnrollment rejects a student enrollment, if a student repo exists for the given course, removes it from the SCM and database.
+// The GitHub repository and organization membership are removed before the database
+// records, so that an interrupted reject leaves the database still referencing the
+// repository, allowing the operation to be retried rather than orphaning the repo.
 func (s *QuickFeedService) rejectEnrollment(ctx context.Context, sc scm.SCM, enrolled *qf.Enrollment) error {
 	// course and user are both preloaded, no need to query the database
 	course, user := enrolled.GetCourse(), enrolled.GetUser()
-	if err := s.db.RejectEnrollment(user.GetID(), course.GetID()); err != nil {
-		s.logger.Debugf("Failed to delete %s enrollment for %q from database: %v", course.GetCode(), user.GetLogin(), err)
-		// continue with other delete operations
-	}
 	repo, err := s.getRepo(course, user.GetID(), qf.Repository_USER)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("failed to get %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 	if repo == nil {
 		s.logger.Debugf("No %s repository found for %q: %v", course.GetCode(), user.GetLogin(), err)
-		// cannot continue without repository information
-		return nil
+		// no repository to delete; only remove the enrollment from the database
+		return s.db.RejectEnrollment(user.GetID(), course.GetID())
 	}
-	if err = s.db.DeleteRepository(repo.GetScmRepositoryID()); err != nil {
-		s.logger.Debugf("Failed to delete %s repository for %q from database: %v", course.GetCode(), user.GetLogin(), err)
-		// continue with other delete operations
-	}
+
 	// when deleting a user, remove github repository and organization membership as well
 	opt := &scm.RejectEnrollmentOptions{
 		User:           user.GetLogin(),
@@ -66,9 +62,17 @@ func (s *QuickFeedService) rejectEnrollment(ctx context.Context, sc scm.SCM, enr
 		RepositoryID:   repo.GetScmRepositoryID(),
 	}
 	if err := sc.RejectEnrollment(ctx, opt); err != nil {
-		s.logger.Debugf("rejectEnrollment: failed to remove %s from %q (expected behavior): %v", user.GetLogin(), course.GetCode(), err)
+		if !errors.Is(err, scm.ErrNotFound) {
+			return fmt.Errorf("failed to remove %s from %q: %w", user.GetLogin(), course.GetCode(), err)
+		}
+		// repository or membership already removed on GitHub, e.g., by a previously interrupted reject
+		s.logger.Debugf("rejectEnrollment: %s already removed from %q on GitHub: %v", user.GetLogin(), course.GetCode(), err)
 	}
-	return nil
+	if err = s.db.DeleteRepository(repo.GetScmRepositoryID()); err != nil {
+		s.logger.Debugf("Failed to delete %s repository for %q from database: %v", course.GetCode(), user.GetLogin(), err)
+		// continue with other delete operations
+	}
+	return s.db.RejectEnrollment(user.GetID(), course.GetID())
 }
 
 // enrollStudent enrolls the given user as a student into the given course.

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -559,6 +559,59 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 	}
 }
 
+// TestRejectEnrollmentRepoAlreadyDeleted verifies that rejecting an enrollment
+// succeeds even if the student's repository and org membership are already gone
+// on SCM, so that database cleanup can still complete.
+func TestRejectEnrollmentRepoAlreadyDeleted(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+
+	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Login: "admin", ScmRemoteID: 1})
+	student := qtest.CreateFakeCustomUser(t, db, &qf.User{Login: "student", ScmRemoteID: 2})
+
+	client := web.NewMockClient(t, db, scm.WithMockOptions(
+		scm.WithMockOrgs("admin", "student"),
+	), web.WithInterceptors())
+
+	course := qtest.MockCourses[0]
+	qtest.CreateCourse(t, db, admin, course)
+	qtest.EnrollStudent(t, db, student, course)
+
+	// Repository record referring to a repository that does not exist on SCM.
+	repo := &qf.Repository{
+		ScmOrganizationID: course.GetScmOrganizationID(),
+		ScmRepositoryID:   999,
+		UserID:            student.GetID(),
+		RepoType:          qf.Repository_USER,
+	}
+	if err := db.CreateRepository(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	adminCtx := client.Context(t, admin)
+	if _, err := client.UpdateEnrollments(adminCtx, &qf.Enrollments{
+		Enrollments: []*qf.Enrollment{{
+			CourseID: course.GetID(),
+			UserID:   student.GetID(),
+			Status:   qf.Enrollment_NONE,
+		}},
+	}); err != nil {
+		t.Errorf("UpdateEnrollments() failed for missing SCM repository: %v", err)
+	}
+
+	if _, err := db.GetEnrollmentByCourseAndUser(course.GetID(), student.GetID()); err == nil {
+		t.Error("enrollment still exists in database after reject")
+	}
+
+	repos, err := db.GetRepositories(&qf.Repository{UserID: student.GetID(), RepoType: qf.Repository_USER})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) > 0 {
+		t.Error("repository record still exists in database after reject")
+	}
+}
+
 func TestUpdateCourseVisibility(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()

--- a/web/groups.go
+++ b/web/groups.go
@@ -37,14 +37,13 @@ func (s *QuickFeedService) getGroupByUserAndCourse(request *qf.GroupRequest) (*q
 }
 
 // DeleteGroup deletes group with the provided ID.
+// The group's GitHub repository is deleted before the database records, so that
+// an interrupted delete leaves the database still referencing the repository,
+// allowing the delete operation to be retried.
 func (s *QuickFeedService) internalDeleteGroup(ctx context.Context, sc scm.SCM, request *qf.GroupRequest) error {
 	course, group, err := s.getCourseGroup(request)
 	if err != nil {
 		return err
-	}
-	if err := s.db.DeleteGroup(request.GetGroupID()); err != nil {
-		s.logger.Debugf("Failed to delete %s group %q from database: %v", course.GetCode(), group.GetName(), err)
-		// continue with other delete operations
 	}
 	repo, err := s.getRepo(course, group.GetID(), qf.Repository_GROUP)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -52,19 +51,23 @@ func (s *QuickFeedService) internalDeleteGroup(ctx context.Context, sc scm.SCM, 
 	}
 	if repo == nil {
 		s.logger.Debugf("No %s repository found for group %q: %v", course.GetCode(), group.GetName(), err)
-		// cannot continue without repository information
-		return nil
+		// no repository to delete; only remove the group from the database
+		return s.db.DeleteGroup(request.GetGroupID())
 	}
 
 	// when deleting an approved group, remove github repository as well
-	if err = s.db.DeleteRepository(repo.GetScmRepositoryID()); err != nil {
+	if err := sc.DeleteGroup(ctx, repo.GetScmRepositoryID()); err != nil {
+		if !errors.Is(err, scm.ErrNotFound) {
+			return fmt.Errorf("failed to delete %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
+		}
+		// repository already deleted on GitHub, e.g., by a previously interrupted delete
+		s.logger.Debugf("No %s repository found for group %q on GitHub: %v", course.GetCode(), group.GetName(), err)
+	}
+	if err := s.db.DeleteRepository(repo.GetScmRepositoryID()); err != nil {
 		s.logger.Debugf("Failed to delete %s repository for %q from database: %v", course.GetCode(), group.GetName(), err)
 		// continue with other delete operations
 	}
-	opt := &scm.RepositoryOptions{
-		ID: repo.GetScmRepositoryID(),
-	}
-	return sc.DeleteGroup(ctx, opt.ID)
+	return s.db.DeleteGroup(request.GetGroupID())
 }
 
 // updateGroup updates the group for the given group request.

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -628,6 +628,62 @@ func TestDeleteApprovedGroup(t *testing.T) {
 	}
 }
 
+// TestDeleteGroupRepoAlreadyDeleted verifies that DeleteGroup succeeds when the
+// group's repository no longer exists on GitHub, e.g., after a previously
+// interrupted delete operation, so that the database records can still be cleaned up.
+func TestDeleteGroupRepoAlreadyDeleted(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+
+	admin := qtest.CreateFakeCustomUser(t, db, &qf.User{Login: "admin", ScmRemoteID: 1})
+	user1 := qtest.CreateFakeCustomUser(t, db, &qf.User{Login: "user1", ScmRemoteID: 2})
+
+	client := web.NewMockClient(t, db, scm.WithMockOptions(
+		scm.WithMockOrgs("admin", "user1"),
+	), web.WithInterceptors())
+
+	course := qtest.MockCourses[0]
+	qtest.CreateCourse(t, db, admin, course)
+	qtest.EnrollStudent(t, db, user1, course)
+
+	group := &qf.Group{
+		CourseID: course.GetID(),
+		Name:     "TestGroup",
+		Users:    []*qf.User{user1},
+	}
+	if err := db.CreateGroup(group); err != nil {
+		t.Fatal(err)
+	}
+	// repository record referring to a repository that does not exist on GitHub
+	repo := &qf.Repository{
+		ScmOrganizationID: course.GetScmOrganizationID(),
+		ScmRepositoryID:   999,
+		GroupID:           group.GetID(),
+		RepoType:          qf.Repository_GROUP,
+	}
+	if err := db.CreateRepository(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	adminCtx := client.Context(t, admin)
+	if _, err := client.DeleteGroup(adminCtx, &qf.GroupRequest{
+		CourseID: course.GetID(),
+		GroupID:  group.GetID(),
+	}); err != nil {
+		t.Errorf("DeleteGroup() failed for group with missing GitHub repository: %v", err)
+	}
+	if _, err := db.GetGroup(group.GetID()); err == nil {
+		t.Error("group still exists in the database after DeleteGroup()")
+	}
+	repos, err := db.GetRepositories(&qf.Repository{GroupID: group.GetID(), RepoType: qf.Repository_GROUP})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) > 0 {
+		t.Error("repository record still exists in the database after DeleteGroup()")
+	}
+}
+
 func TestGetGroups(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()


### PR DESCRIPTION
- **refactor: improve error handling and repository deletion logic in SCM operations**
- **test(groups): add TestDeleteGroupRepoAlreadyDeleted to verify deletion logic for non-existent repositories**
