### PR TITLE
errors: phrase internal error strings as the operation attempted

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -2,7 +2,7 @@
 # WARNING: Do not push your file with secret values to GitHub or elsewhere.
 # See doc/deploy.md for more information about deployment and configuration.
 
-# The URL for the installed QuickFeed GitHub app.
+# The URL for the installed QuickFeed GitHub App.
 QUICKFEED_APP_URL=""
 # GitHub App IDs and secrets for deployment
 QUICKFEED_APP_ID=""

--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -97,7 +97,7 @@ func buildDockerImage(ctx context.Context, runner ci.Runner, course *qf.Course, 
 	})
 	logger.Debug("course image build completed", "output", out)
 	if err != nil {
-		return fmt.Errorf("failed to build image from %s's Dockerfile: %w", course.GetCode(), err)
+		return fmt.Errorf("building image from %s's Dockerfile: %w", course.GetCode(), err)
 	}
 	return nil
 }

--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -29,7 +29,7 @@ func newAssignmentFromFile(contents []byte, assignmentName string, courseID uint
 	var newAssignment assignmentData
 	err := json.Unmarshal(contents, &newAssignment)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling assignment: %w", err)
+		return nil, fmt.Errorf("unmarshaling assignment: %w", err)
 	}
 	if newAssignment.Order < 1 {
 		return nil, fmt.Errorf("assignment order must be greater than 0")
@@ -40,7 +40,7 @@ func newAssignmentFromFile(contents []byte, assignmentName string, courseID uint
 	}
 	deadline, err := FixDeadline(newAssignment.Deadline)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing deadline: %w", err)
+		return nil, fmt.Errorf("parsing deadline: %w", err)
 	}
 	// AssignmentID field from the parsed json is used to set Order, not assignment ID,
 	// or it will cause a database constraint violation (IDs must be unique)

--- a/assignments/pull_requests.go
+++ b/assignments/pull_requests.go
@@ -37,7 +37,7 @@ func AssignReviewers(ctx context.Context, sc scm.SCM, db database.Database, cour
 		return err
 	}
 	if teacherReviewer == nil || studentReviewer == nil {
-		return fmt.Errorf("failed to get reviewers for pull request %d", pullRequest.GetNumber())
+		return fmt.Errorf("no reviewers available for pull request %d", pullRequest.GetNumber())
 	}
 
 	opt := &scm.RequestReviewersOptions{
@@ -83,7 +83,7 @@ func getNextReviewer(users []*qf.User, reviewCounter map[uint64]int) *qf.User {
 func getNextTeacherReviewer(db database.Database, course *qf.Course) (*qf.User, error) {
 	teachers, err := db.GetCourseTeachers(course)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get teachers from database: %w", err)
+		return nil, fmt.Errorf("getting teachers from database: %w", err)
 	}
 	teacherReviewCounter.initialize(course.GetID())
 	teacherReviewer := getNextReviewer(teachers, teacherReviewCounter[course.GetID()])
@@ -94,7 +94,7 @@ func getNextTeacherReviewer(db database.Database, course *qf.Course) (*qf.User, 
 func getNextStudentReviewer(db database.Database, groupID, ownerID uint64) (*qf.User, error) {
 	group, err := db.GetGroup(groupID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get group from database: %w", err)
+		return nil, fmt.Errorf("getting group from database: %w", err)
 	}
 	groupReviewCounter.initialize(group.GetID())
 	// We exclude the PR owner from the search.

--- a/assignments/tasks.go
+++ b/assignments/tasks.go
@@ -22,11 +22,11 @@ func taskName(filename string) string {
 // starting with the "# " character sequence, followed by two new line characters.
 func newTask(contents []byte, assignmentOrder uint32, name string) (*qf.Task, error) {
 	if !bytes.HasPrefix(contents, []byte("# ")) {
-		return nil, fmt.Errorf("task with name: %s, does not start with a # title marker", name)
+		return nil, fmt.Errorf("task %q does not start with a # title marker", name)
 	}
 	bodyIndex := bytes.Index(contents, []byte("\n\n"))
 	if bodyIndex == -1 {
-		return nil, fmt.Errorf("task with name: %s, does not have a body", name)
+		return nil, fmt.Errorf("task %q does not have a body", name)
 	}
 
 	return &qf.Task{

--- a/assignments/tasks.go
+++ b/assignments/tasks.go
@@ -26,7 +26,7 @@ func newTask(contents []byte, assignmentOrder uint32, name string) (*qf.Task, er
 	}
 	bodyIndex := bytes.Index(contents, []byte("\n\n"))
 	if bodyIndex == -1 {
-		return nil, fmt.Errorf("failed to find task body in task: %s", name)
+		return nil, fmt.Errorf("task with name: %s, does not have a body", name)
 	}
 
 	return &qf.Task{

--- a/assignments/walk_tests_repo.go
+++ b/assignments/walk_tests_repo.go
@@ -77,7 +77,7 @@ type fileProcessor func(filename string, contents []byte, assignment *qf.Assignm
 func processCriteriaFile(_ string, contents []byte, assignment *qf.Assignment, courseID uint64) error {
 	var benchmarks []*qf.GradingBenchmark
 	if err := json.Unmarshal(contents, &benchmarks); err != nil {
-		return fmt.Errorf("failed to unmarshal %q: %w", criteriaFile, err)
+		return fmt.Errorf("unmarshaling %q: %w", criteriaFile, err)
 	}
 	// Benchmarks and criteria must have courseID for access control checks
 	for _, bm := range benchmarks {
@@ -94,7 +94,7 @@ func processCriteriaFile(_ string, contents []byte, assignment *qf.Assignment, c
 func processTestsFile(_ string, contents []byte, assignment *qf.Assignment, _ uint64) error {
 	var expectedTests []*qf.TestInfo
 	if err := json.Unmarshal(contents, &expectedTests); err != nil {
-		return fmt.Errorf("failed to unmarshal %q: %w", testsFile, err)
+		return fmt.Errorf("unmarshaling %q: %w", testsFile, err)
 	}
 	assignment.ExpectedTests = expectedTests
 	return nil

--- a/assignments/walk_tests_repo_test.go
+++ b/assignments/walk_tests_repo_test.go
@@ -236,5 +236,5 @@ func checkLabWithInvalidCriteriaFile(t *testing.T, folder string, chkUnmarshal b
 
 // Check if the error is related to invalid JSON unmarshalling.
 func isUnmarshalError(e error) bool {
-	return strings.Contains(e.Error(), "failed to unmarshal")
+	return strings.Contains(e.Error(), "unmarshaling")
 }

--- a/ci/clone_repositories.go
+++ b/ci/clone_repositories.go
@@ -27,7 +27,7 @@ func cloneMissingRepositories(ctx context.Context, scmClient scm.SCM, course *qf
 			DestDir:      course.CloneDir(),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to clone %q repository: %w", qf.TestsRepo, err)
+			return fmt.Errorf("cloning %q repository: %w", qf.TestsRepo, err)
 		}
 	}
 	if !assignmentsExists {
@@ -38,7 +38,7 @@ func cloneMissingRepositories(ctx context.Context, scmClient scm.SCM, course *qf
 			DestDir:      course.CloneDir(),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to clone %q repository: %w", qf.AssignmentsRepo, err)
+			return fmt.Errorf("cloning %q repository: %w", qf.AssignmentsRepo, err)
 		}
 	}
 	return nil

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -28,7 +28,7 @@ func (r *RunData) parseTestRunnerScript(secret, destDir string) (*Job, error) {
 	}
 	image, language, commands, err := parseRunScript(scriptContent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
+		return nil, fmt.Errorf("parsing run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
 	}
 	if r.EnvVarsFn == nil {
 		// For docker runs, the home path is set to QuickFeedPath = /quickfeed

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -129,7 +129,7 @@ func TestParseBadTestRunnerScript(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got nil: %+v", job)
 	}
-	const wantMsg = "failed to parse run script for assignment lab4-bad-run-script in https://github.com/qf104-2022/tests: empty run script"
+	const wantMsg = "parsing run script for assignment lab4-bad-run-script in https://github.com/qf104-2022/tests: empty run script"
 	if err.Error() != wantMsg {
 		t.Errorf("err = '%s', want '%s'", err, wantMsg)
 	}
@@ -139,7 +139,7 @@ func TestParseBadTestRunnerScript(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got nil: %+v", job)
 	}
-	const wantMsg2 = "failed to parse run script for assignment lab5-bad-run-script in https://github.com/qf104-2022/tests: no docker image specified in run script"
+	const wantMsg2 = "parsing run script for assignment lab5-bad-run-script in https://github.com/qf104-2022/tests: no docker image specified in run script"
 	if err.Error() != wantMsg2 {
 		t.Errorf("err = '%s', want '%s'", err, wantMsg2)
 	}

--- a/ci/record_results.go
+++ b/ci/record_results.go
@@ -31,7 +31,7 @@ func (r *RunData) RecordResults(ctx context.Context, db database.Database, resul
 	logger.Debug("fetching previous submission")
 	previous, err := r.previousSubmission(db)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, fmt.Errorf("failed to get previous submission: %w", err)
+		return nil, fmt.Errorf("getting previous submission: %w", err)
 	}
 	if previous == nil {
 		logger.Debug("recording new submission")
@@ -41,13 +41,13 @@ func (r *RunData) RecordResults(ctx context.Context, db database.Database, resul
 
 	resType, newSubmission := r.newSubmission(previous, results)
 	if err = db.CreateSubmission(newSubmission); err != nil {
-		return nil, fmt.Errorf("failed to record submission %d for %s: %w", previous.GetID(), r, err)
+		return nil, fmt.Errorf("recording submission %d for %s: %w", previous.GetID(), r, err)
 	}
 	logger.Debug("recorded submission", "result_type", resType, "status", newSubmission.GetStatuses(), "score", newSubmission.GetScore())
 
 	if !r.Rebuild {
 		if err := r.updateSlipDays(logger, db, newSubmission); err != nil {
-			return nil, fmt.Errorf("failed to update slip days for %s: %w", r, err)
+			return nil, fmt.Errorf("updating slip days for %s: %w", r, err)
 		}
 		logger.Debug("updated slip days")
 	}
@@ -126,19 +126,19 @@ func (r *RunData) updateSlipDays(logger *slog.Logger, db database.Database, subm
 		}
 		holder, err = db.GetGroup(submission.GetGroupID())
 		if err != nil {
-			return fmt.Errorf("failed to get group %d: %w", submission.GetGroupID(), err)
+			return fmt.Errorf("getting group %d: %w", submission.GetGroupID(), err)
 		}
 	} else {
 		holder, err = db.GetEnrollmentByCourseAndUser(r.Assignment.GetCourseID(), submission.GetUserID())
 		if err != nil {
-			return fmt.Errorf("failed to get enrollment for user %d in course %d: %w", submission.GetUserID(), r.Assignment.GetCourseID(), err)
+			return fmt.Errorf("getting enrollment for user %d in course %d: %w", submission.GetUserID(), r.Assignment.GetCourseID(), err)
 		}
 	}
 	if err := holder.UpdateSlipDays(r.Assignment, submission); err != nil {
-		return fmt.Errorf("failed to update slip days for %s (id %d) in course %d: %w", r, holder.GetID(), r.Assignment.GetCourseID(), err)
+		return fmt.Errorf("updating slip days for %s (id %d) in course %d: %w", r, holder.GetID(), r.Assignment.GetCourseID(), err)
 	}
 	if err := db.UpdateSlipDays(holder.GetUsedSlipDays()); err != nil {
-		return fmt.Errorf("failed to update slip days for %s (id %d) in course %d: %w", r, holder.GetID(), r.Assignment.GetCourseID(), err)
+		return fmt.Errorf("updating slip days for %s (id %d) in course %d: %w", r, holder.GetID(), r.Assignment.GetCourseID(), err)
 	}
 	return nil
 }
@@ -158,7 +158,7 @@ func (r *RunData) GetOwners(db database.Database) ([]uint64, error) {
 		}
 	}
 	if len(owners) == 0 {
-		return nil, fmt.Errorf("failed to get owners for %s", r)
+		return nil, fmt.Errorf("no owners for %s", r)
 	}
 	return owners, nil
 }

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -85,7 +85,7 @@ func (r *RunData) RunTests(ctx context.Context, sc scm.SCM, runner Runner) (*sco
 	randomSecret := rand.String()
 	job, err := r.parseTestRunnerScript(randomSecret, dstDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
+		return nil, fmt.Errorf("parsing run script for assignment %s in %s: %w", r.Assignment.GetName(), r.Repo.GetTestURL(), err)
 	}
 
 	defer timer(r.JobOwner, r.Course.GetCode(), testExecutionTimeGauge)()
@@ -141,7 +141,7 @@ func (r *RunData) clone(ctx context.Context, sc scm.SCM, dstDir string) error {
 		Branch:       r.BranchName,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to clone %s/%s repository: %w", r.Course.GetScmOrganizationName(), r.Repo.Name(), err)
+		return fmt.Errorf("cloning %s/%s repository: %w", r.Course.GetScmOrganizationName(), r.Repo.Name(), err)
 	}
 
 	// Clone the course's tests and assignments repositories if they are missing.

--- a/cmd/approvelist/main.go
+++ b/cmd/approvelist/main.go
@@ -238,7 +238,7 @@ func getSubmissions(serverURL, courseCode string, year uint32) (*qf.CourseSubmis
 	}
 	submissions, err := client.GetSubmissionsByCourse(ctx, submissionCourseRequest)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get submissions for course %s: %w", courseCode, err)
+		return nil, nil, fmt.Errorf("getting submissions for course %s: %w", courseCode, err)
 	}
 	enrollments, err := client.GetEnrollments(ctx, &qf.EnrollmentRequest{
 		FetchMode: &qf.EnrollmentRequest_CourseID{
@@ -246,7 +246,7 @@ func getSubmissions(serverURL, courseCode string, year uint32) (*qf.CourseSubmis
 		},
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get enrollments for course %s: %w", courseCode, err)
+		return nil, nil, fmt.Errorf("getting enrollments for course %s: %w", courseCode, err)
 	}
 	return submissions, enrollments.GetEnrollments(), err
 }

--- a/database/gormdb.go
+++ b/database/gormdb.go
@@ -21,7 +21,7 @@ var (
 	// name as a previously registered group.
 	ErrDuplicateGroup = errors.New("group with this name already registered")
 	// ErrUpdateGroup is returned when updating a group's enrollment fails.
-	ErrUpdateGroup = errors.New("failed to update group enrollment")
+	ErrUpdateGroup = errors.New("group members not enrolled in the course")
 	// ErrCourseExists is returned when trying to create an association in
 	// the database for a DirectoryId that already exists in the database.
 	ErrCourseExists = errors.New("course already exists on git provider")
@@ -29,7 +29,7 @@ var (
 	// with insufficient access privileges.
 	ErrInsufficientAccess = errors.New("user must be admin to perform this operation")
 	// ErrCreateRepo is returned when trying to create repository with wrong argument.
-	ErrCreateRepo = errors.New("failed to create repository; invalid arguments")
+	ErrCreateRepo = errors.New("invalid arguments for repository creation")
 	// ErrNotEnrolled is returned when the requested user or group do not have
 	// the expected association with the given course
 	ErrNotEnrolled = errors.New("user or group not enrolled in the course")

--- a/database/gormdb_assignment.go
+++ b/database/gormdb_assignment.go
@@ -165,13 +165,13 @@ func updateExpectedTests(tx *gorm.DB, assignment *qf.Assignment) error {
 				// a new assignment, no actions required
 				return nil
 			}
-			return fmt.Errorf("failed to fetch assignment %s from database: %w", assignment.GetName(), err)
+			return fmt.Errorf("fetching assignment %s from database: %w", assignment.GetName(), err)
 		}
 		if len(expectedTests) > 0 {
 			// expected tests changed for this assignment, remove old tests
 			for _, test := range expectedTests {
 				if err := tx.Delete(test).Error; err != nil {
-					return fmt.Errorf("failed to delete expected test %d: %w", test.GetID(), err)
+					return fmt.Errorf("deleting expected test %d: %w", test.GetID(), err)
 				}
 			}
 		}
@@ -190,7 +190,7 @@ func (db *GormDB) updateGradingCriteria(tx *gorm.DB, assignment *qf.Assignment) 
 				// a new assignment, no actions required
 				return nil
 			}
-			return fmt.Errorf("failed to fetch assignment %s from database: %w", assignment.GetName(), err)
+			return fmt.Errorf("fetching assignment %s from database: %w", assignment.GetName(), err)
 		}
 		if len(gradingBenchmarks) > 0 {
 			if cmp.Equal(assignment.GetGradingBenchmarks(), gradingBenchmarks, cmp.Options{
@@ -207,11 +207,11 @@ func (db *GormDB) updateGradingCriteria(tx *gorm.DB, assignment *qf.Assignment) 
 				for _, bm := range gradingBenchmarks {
 					for _, c := range bm.GetCriteria() {
 						if err := tx.Delete(c).Error; err != nil {
-							return fmt.Errorf("failed to delete criterion %d: %w", c.GetID(), err)
+							return fmt.Errorf("deleting criterion %d: %w", c.GetID(), err)
 						}
 					}
 					if err := tx.Delete(bm).Error; err != nil {
-						return fmt.Errorf("failed to delete benchmark %d: %w", bm.GetID(), err)
+						return fmt.Errorf("deleting benchmark %d: %w", bm.GetID(), err)
 					}
 				}
 			}

--- a/database/gormdb_feedback.go
+++ b/database/gormdb_feedback.go
@@ -14,7 +14,7 @@ func (db *GormDB) CreateAssignmentFeedback(feedback *qf.AssignmentFeedback, user
 		// Set the creation timestamp
 		feedback.CreatedAt = timestamppb.Now()
 		if err := tx.Create(feedback).Error; err != nil {
-			return fmt.Errorf("failed to create assignment feedback: %w", err)
+			return fmt.Errorf("creating assignment feedback: %w", err)
 		}
 		// Create a receipt for the feedback
 		receipt := &qf.FeedbackReceipt{
@@ -22,7 +22,7 @@ func (db *GormDB) CreateAssignmentFeedback(feedback *qf.AssignmentFeedback, user
 			UserID:       userID,
 		}
 		if err := tx.Create(receipt).Error; err != nil {
-			return fmt.Errorf("failed to create feedback receipt: %w", err)
+			return fmt.Errorf("creating feedback receipt: %w", err)
 		}
 		return nil
 	})
@@ -35,7 +35,7 @@ func (db *GormDB) GetAssignmentFeedback(query *qf.CourseRequest) (*qf.Assignment
 	if err := db.conn.Model(&qf.AssignmentFeedback{}).Where(&qf.AssignmentFeedback{
 		CourseID: query.GetCourseID(),
 	}).Find(&feedbacks).Error; err != nil {
-		return nil, fmt.Errorf("failed to get assignment feedback: %w", err)
+		return nil, fmt.Errorf("getting assignment feedback: %w", err)
 	}
 	return &qf.AssignmentFeedbacks{Feedbacks: feedbacks}, nil
 }

--- a/database/gormdb_group.go
+++ b/database/gormdb_group.go
@@ -158,7 +158,7 @@ func (db *GormDB) GetGroup(groupID uint64) (*qf.Group, error) {
 		if err == gorm.ErrRecordNotFound {
 			return nil, err
 		}
-		return nil, fmt.Errorf("failed to get group with ID %d: %w", groupID, err)
+		return nil, fmt.Errorf("getting group with ID %d: %w", groupID, err)
 	}
 	if len(userIDs) == 0 {
 		return nil, fmt.Errorf("no users found for group with ID %d", groupID)
@@ -201,7 +201,7 @@ func (db *GormDB) GetGroupsByCourse(courseID uint64, statuses ...qf.Group_GroupS
 func (db *GormDB) setGroupSlipDays(courseID uint64, groups ...*qf.Group) error {
 	course, err := db.GetCourse(courseID)
 	if err != nil {
-		return fmt.Errorf("failed to get course %d: %w", courseID, err)
+		return fmt.Errorf("getting course %d: %w", courseID, err)
 	}
 	for _, group := range groups {
 		group.SetSlipDays(course)

--- a/database/gormdb_submission.go
+++ b/database/gormdb_submission.go
@@ -17,7 +17,7 @@ var (
 	ErrInvalidAssignmentID = errors.New("cannot create submission without an associated assignment")
 	// ErrAllReviewsCreated is returned if all reviews for a submission have already been created.
 	ErrAllReviewsCreated = func(submissionID uint64, assignmentName string, reviewers uint32) error {
-		return fmt.Errorf("failed to create a new review for submission %d to %s: all %d reviews already created", submissionID, assignmentName, reviewers)
+		return fmt.Errorf("all %d reviews already created for submission %d to %s", reviewers, submissionID, assignmentName)
 	}
 	ErrEmptyReviewID = errors.New("cannot update review with empty ID")
 )

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -75,7 +75,7 @@ The [installation process](#installation) will populate the environment variable
 Below is an example production deployment on the `example.com` domain.
 
 ```shell
-# The URL for the installed QuickFeed GitHub app.
+# The URL for the installed QuickFeed GitHub App.
 QUICKFEED_APP_URL=""
 # GitHub App IDs and secrets for deployment
 QUICKFEED_APP_ID=""
@@ -201,10 +201,10 @@ After that it will be possible to receive webhook events on QuickFeed server run
 
 1. Start ngrok: `ngrok http 443` - assuming the server runs on port `:443`.
 2. ngrok will generate a new endpoint URL.
-   Copy the urls an update webhook callback information in your GitHub app to point to this URL.
+   Copy the urls an update webhook callback information in your GitHub App to point to this URL.
    E.g., `https://de08-2a01-799-4df-d900-b5af-5adc-a42a-bcf.eu.ngrok.io/hook/`.
 
-After that any webhook events your GitHub app is subscribed to will send payload to this URL, and ngrok will redirect them to the `/hooks` endpoint of the QuickFeed server running on the given port number.
+After that any webhook events your GitHub App is subscribed to will send payload to this URL, and ngrok will redirect them to the `/hooks` endpoint of the QuickFeed server running on the given port number.
 
 Note that ngrok generates a new URL every time it is restarted and you will need to update webhook callback details unless you want to subscribe to the paid version of ngrok that supports static callback URLs.
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -126,7 +126,7 @@ Application errors can be classified into several groups and handled in differen
 - Some of these can only be fixed by the user who is calling the method by interacting with UI elements (usually course teacher).
 
   **Examples**:
-  - If a GitHub organization cannot be found, one of the possible issues causing this behavior is not having installed the GitHub application on the organization.
+  - If a GitHub organization cannot be found, one of the possible issues causing this behavior is not having installed the GitHub App on the organization.
   As a result, the requested organization cannot be seen by QuickFeed.
   - If a GitHub repository cannot be found, they could have been manually deleted from GitHub.
   Only the current user can remedy the situation, and it is most useful to inform them about the issue in detail and offer a solution.

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -150,6 +150,27 @@ In these cases the error is usually ephemeral in nature, and the action should b
 
 [Connect Error Codes](https://connectrpc.com/docs/protocol#error-codes) are used to allow the client to check whether the error message should be displayed for user, or just logged for developers.
 
+### Error strings
+
+Phrase an error string as the operation that was attempted, not as an announcement that something failed.
+The error itself already conveys the failure, and prefixes such as `failed to`, `could not`, `unable to`, and `error` accumulate as the error is wrapped on its way up the stack.
+
+```go
+// Good:
+return fmt.Errorf("creating SCM client: %w", err)
+// Bad:
+return fmt.Errorf("failed to create SCM client: %w", err)
+```
+
+An unwound chain then reads as prose: `enrolling user: creating SCM client: 401 Unauthorized`.
+
+An error that wraps nothing names the condition instead, since the operation form would describe an attempt rather than what the error means: `no owners for %s`, not `failed to get owners for %s`.
+Preconditions keep the `cannot X without Y` form.
+Do not annotate an error when the annotation only says that something failed; return the error unchanged instead.
+
+Errors that reach the user are the exception, and keep an explicit failure wording, since the message is the only signal the user gets that something went wrong.
+This covers the `connect.NewError` messages returned by the `QuickFeed Service` handlers, and the user errors built with `scm.M`, both of which the frontend renders in an alert.
+
 ### Backend
 
 The backend uses `log/slog` for structured logging.

--- a/internal/cert/gen_certs.go
+++ b/internal/cert/gen_certs.go
@@ -69,7 +69,7 @@ func GenerateSelfSignedCert(opts Options) error {
 
 	serverKeyBytes, err := x509.MarshalPKCS8PrivateKey(serverKey)
 	if err != nil {
-		return fmt.Errorf("unable to marshal server private key: %w", err)
+		return fmt.Errorf("marshaling server private key: %w", err)
 	}
 
 	// save CA certificate (for trust store)
@@ -201,11 +201,11 @@ func setHosts(template *x509.Certificate, hostList string) {
 func makeCertificate(template, parent *x509.Certificate, publicKey, privateKey any) (*x509.Certificate, []byte, error) {
 	derCertBytes, err := x509.CreateCertificate(rand.Reader, template, parent, publicKey, privateKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+		return nil, nil, fmt.Errorf("creating certificate: %w", err)
 	}
 	cert, err := x509.ParseCertificate(derCertBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse certificate: %w", err)
+		return nil, nil, fmt.Errorf("parsing certificate: %w", err)
 	}
 	return cert, derCertBytes, nil
 }
@@ -215,17 +215,17 @@ const defaultFileFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 func savePEM(filename string, block []*pem.Block) error {
 	out, err := os.OpenFile(filename, defaultFileFlags, 0o600)
 	if err != nil {
-		return fmt.Errorf("failed to open %s for writing: %w", filename, err)
+		return fmt.Errorf("opening %s for writing: %w", filename, err)
 	}
 
 	for _, b := range block {
 		if err := pem.Encode(out, b); err != nil {
-			return fmt.Errorf("failed to write data to %s: %w", filename, err)
+			return fmt.Errorf("writing data to %s: %w", filename, err)
 		}
 	}
 
 	if err := out.Close(); err != nil {
-		return fmt.Errorf("error closing %s: %w", filename, err)
+		return fmt.Errorf("closing %s: %w", filename, err)
 	}
 	return nil
 }

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -72,7 +72,7 @@ func checkModulePath(dir string) error {
 	modFile := filepath.Join(dir, "go.mod")
 	data, err := os.ReadFile(modFile)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", modFile, err)
+		return fmt.Errorf("reading %s: %w", modFile, err)
 	}
 	// The module path must match exactly; a prefix match would also accept
 	// nested modules, such as the kit module.

--- a/internal/env/ready.go
+++ b/internal/env/ready.go
@@ -19,7 +19,7 @@ import (
 func EnsureReady(dev bool, envFile string, forceNewSecret bool) error {
 	// Step 1: Ensure auth secret exists (or force regeneration)
 	if generated, err := EnsureAuthSecret(envFile, forceNewSecret); err != nil {
-		return fmt.Errorf("failed to ensure auth secret: %w", err)
+		return fmt.Errorf("ensuring auth secret: %w", err)
 	} else if generated {
 		if forceNewSecret {
 			log.Println("Generated new JWT signing secret (forced rotation)")
@@ -73,13 +73,13 @@ func ensureCertificates() error {
 		CAFile:        CAFile(),
 		Hosts:         Domain(),
 	}); err != nil {
-		return fmt.Errorf("failed to generate self-signed certificates: %w", err)
+		return fmt.Errorf("generating self-signed certificates: %w", err)
 	}
 	log.Printf("Certificates successfully generated at: %s", CertPath())
 
 	log.Print("Adding certificate to local trust store (may require elevated privileges)")
 	if err := cert.AddTrustedCert(CAFile()); err != nil {
-		return fmt.Errorf("failed to install self-signed certificate: %w", err)
+		return fmt.Errorf("installing self-signed certificate: %w", err)
 	}
 	log.Print("Certificate successfully added to trust store")
 

--- a/internal/env/save.go
+++ b/internal/env/save.go
@@ -11,7 +11,7 @@ import (
 //
 // If the env file does not exist, a MissingError returned.
 // QuickFeed requires the env file to load (some) existing environment variables,
-// even when creating a new GitHub app, and overwriting some environment variables.
+// even when creating a new GitHub App, and overwriting some environment variables.
 // If the backup file exists, an ExistsError is returned.
 // This is to avoid that QuickFeed overwrites an existing backup file.
 func Prepared(filename string) error {

--- a/internal/ui/esbuild.go
+++ b/internal/ui/esbuild.go
@@ -85,7 +85,7 @@ func getOptions(outputDir string, dev bool) api.BuildOptions {
 func Build(outputDir string, dev bool) error {
 	result := api.Build(getOptions(outputDir, dev))
 	if len(result.Errors) > 0 {
-		return fmt.Errorf("failed to build UI: %v", result.Errors)
+		return fmt.Errorf("building UI: %v", result.Errors)
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func Build(outputDir string, dev bool) error {
 func Watch() error {
 	ctx, err := api.Context(getOptions("", true))
 	if err != nil {
-		return fmt.Errorf("failed to create build context: %w", err)
+		return fmt.Errorf("creating build context: %w", err)
 	}
 	return ctx.Watch(api.WatchOptions{})
 }

--- a/kit/score/results.go
+++ b/kit/score/results.go
@@ -159,7 +159,7 @@ func ExtractResults(out, secret string, execTime time.Duration, zeroScoreTests [
 		if HasPrefix(line) {
 			sc, err := parse(line, secret)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("failed on line '%s': %w", line, err))
+				errs = append(errs, fmt.Errorf("parsing line '%s': %w", line, err))
 				continue
 			}
 			// only add the score if it's in the expected tests

--- a/main.go
+++ b/main.go
@@ -131,12 +131,12 @@ func initWebServer(dbFile, public string) (http.Handler, func(), error) {
 
 	q.db, err = database.NewGormDB(dbFile, q.logger)
 	if err != nil {
-		return nil, q.cleanup, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, q.cleanup, fmt.Errorf("connecting to database: %w", err)
 	}
 
 	q.runner, err = ci.NewDockerCI()
 	if err != nil {
-		return nil, q.cleanup, fmt.Errorf("failed to set up docker client: %w", err)
+		return nil, q.cleanup, fmt.Errorf("setting up docker client: %w", err)
 	}
 
 	tm, err := auth.NewTokenManager(q.db)
@@ -166,12 +166,12 @@ func (q *quickfeed) cleanup() {
 	var err error
 	if q.runner != nil {
 		if e := q.runner.Close(); e != nil {
-			err = fmt.Errorf("failed to close runner: %w", e)
+			err = fmt.Errorf("closing runner: %w", e)
 		}
 	}
 	if q.db != nil {
 		if e := q.db.Close(); e != nil {
-			err = errors.Join(err, fmt.Errorf("failed to close database: %w", e))
+			err = errors.Join(err, fmt.Errorf("closing database: %w", e))
 		}
 	}
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 	log.Println("QuickFeed shut down gracefully")
 }
 
-// runAppCreation runs the GitHub app creation flow after checking prerequisites.
+// runAppCreation runs the GitHub App creation flow after checking prerequisites.
 func runAppCreation(envFile string, dev bool, srvFn web.ServerType) error {
 	if err := checkDomain(); err != nil {
 		return err
@@ -182,7 +182,7 @@ func (q *quickfeed) cleanup() {
 func checkDomain() error {
 	if env.IsDomainLocal() {
 		msg := `
-WARNING: You are creating a GitHub app on a local or private domain: %q.
+WARNING: You are creating a GitHub App on a local or private domain: %q.
 This is only for development purposes.
 In this mode, QuickFeed will not be able to receive webhook events from GitHub.
 To receive webhook events, you must run QuickFeed on a public domain or use a tunneling service like ngrok.

--- a/scm/github.go
+++ b/scm/github.go
@@ -128,7 +128,7 @@ func (s *GithubSCM) GetOrganization(ctx context.Context, opt *OrganizationOption
 		m := M("%s: permission denied", orgName)
 		membership, _, err := s.client.Organizations.GetOrgMembership(ctx, opt.Username, orgName)
 		if err != nil {
-			return nil, E(op, m, fmt.Errorf("failed to get membership: %w", err))
+			return nil, E(op, m, fmt.Errorf("getting membership: %w", err))
 		}
 		// membership role must be "admin"
 		if membership.GetRole() != OrgOwner {
@@ -185,7 +185,7 @@ func (s *GithubSCM) commitsAhead(ctx context.Context, opt *RepositoryOptions) (i
 	headCommit, resp, err := s.client.Repositories.GetCommit(ctx, opt.Owner, opt.Repo, "main", nil)
 	logger.Debug("got repository head commit", label.Branch, "main", statusLabel, statusCode(resp), label.Error, err)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get head commit for %s/%s: %w", opt.Owner, opt.Repo, err)
+		return 0, fmt.Errorf("getting head commit for %s/%s: %w", opt.Owner, opt.Repo, err)
 	}
 	headSHA := headCommit.GetSHA()
 	if headSHA == "" {
@@ -200,7 +200,7 @@ func (s *GithubSCM) commitsAhead(ctx context.Context, opt *RepositoryOptions) (i
 	// or other transient errors; in all cases we cannot determine the count, so we
 	// return the error and let the caller decide how to handle it.
 	if err != nil {
-		return 0, fmt.Errorf("failed to compare %s/%s with assignments: %w", opt.Owner, opt.Repo, err)
+		return 0, fmt.Errorf("comparing %s/%s with assignments: %w", opt.Owner, opt.Repo, err)
 	}
 	if comparison == nil || comparison.AheadBy == nil {
 		return 0, fmt.Errorf("missing comparison result for %s/%s", opt.Owner, opt.Repo)
@@ -232,7 +232,7 @@ func (s *GithubSCM) CreateCourse(ctx context.Context, opt *CourseOptions) ([]*Re
 		// required to allow forking the assignments repository
 		MembersCanForkPrivateRepos: github.Bool(true),
 	}); err != nil {
-		return nil, E(op, m, fmt.Errorf("failed to update permissions for %s: %w", org.GetScmOrganizationName(), err))
+		return nil, E(op, m, fmt.Errorf("updating permissions for %s: %w", org.GetScmOrganizationName(), err))
 	}
 
 	// Create course repositories
@@ -338,7 +338,7 @@ func (s *GithubSCM) RejectEnrollment(ctx context.Context, opt *RejectEnrollmentO
 	}
 	// tolerate 404 (no such membership) so reject is idempotent
 	if resp, err := s.client.Organizations.RemoveOrgMembership(ctx, opt.User, org.GetScmOrganizationName()); err != nil && !hasStatus(resp, http.StatusNotFound) {
-		return E(op, m, fmt.Errorf("failed to remove user: %w", err))
+		return E(op, m, fmt.Errorf("removing user: %w", err))
 	}
 	return nil
 }
@@ -399,7 +399,7 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 	// find current group members
 	oldUsers, _, err := s.client.Repositories.ListCollaborators(ctx, opt.Organization, opt.GroupName, nil)
 	if err != nil {
-		return E(op, m, fmt.Errorf("failed to get members: %w", err))
+		return E(op, m, fmt.Errorf("getting members: %w", err))
 	}
 
 	// add members that are not already in the group
@@ -415,7 +415,7 @@ func (s *GithubSCM) UpdateGroupMembers(ctx context.Context, opt *GroupOptions) e
 		if !slices.Contains(opt.Users, user) {
 			_, err = s.client.Repositories.RemoveCollaborator(ctx, opt.Organization, opt.GroupName, user)
 			if err != nil {
-				return E(op, m, fmt.Errorf("failed to remove %s: %w", user, err))
+				return E(op, m, fmt.Errorf("removing %s: %w", user, err))
 			}
 		}
 	}
@@ -607,7 +607,7 @@ func (s *GithubSCM) deleteRepository(ctx context.Context, id uint64) error {
 			// is already gone, e.g., from a previously interrupted delete
 			return E(op, m, fmt.Errorf("repository %d: %w", id, ErrNotFound))
 		}
-		return E(op, m, fmt.Errorf("failed to get repository %d: %w", id, err))
+		return E(op, m, fmt.Errorf("getting repository %d: %w", id, err))
 	}
 
 	if deleteResp, err := s.client.Repositories.Delete(ctx, repo.GetOwner().GetLogin(), repo.GetName()); err != nil {
@@ -642,7 +642,7 @@ func (s *GithubSCM) createStudentRepo(ctx context.Context, organization, user st
 
 func (s *GithubSCM) updatePermission(ctx context.Context, user, org string, role *github.Membership) error {
 	if _, _, err := s.client.Organizations.EditOrgMembership(ctx, user, org, role); err != nil {
-		return fmt.Errorf("failed to update to %q: %w", *role.Role, err)
+		return fmt.Errorf("updating to %q: %w", *role.Role, err)
 	}
 	return nil
 }
@@ -650,7 +650,7 @@ func (s *GithubSCM) updatePermission(ctx context.Context, user, org string, role
 // addUser adds user to the repository with the specified access level (pull or push).
 func (s *GithubSCM) addUser(ctx context.Context, org, repo, user string, access *github.RepositoryAddCollaboratorOptions) error {
 	if _, _, err := s.client.Repositories.AddCollaborator(ctx, org, repo, user, access); err != nil {
-		return fmt.Errorf("failed to add with %q access: %w", access.Permission, err)
+		return fmt.Errorf("adding with %q access: %w", access.Permission, err)
 	}
 	return nil
 }

--- a/scm/github_app.go
+++ b/scm/github_app.go
@@ -23,7 +23,7 @@ func newGithubAppClient(ctx context.Context, cfg *Config, organization string) (
 	}
 	installCfg, err := cfg.InstallationConfig(strconv.Itoa(int(inst.GetID())))
 	if err != nil {
-		return nil, fmt.Errorf("error configuring github client for installation: %w", err)
+		return nil, fmt.Errorf("configuring github client for installation: %w", err)
 	}
 	httpClient := installCfg.Client(ctx)
 	return &GithubSCM{
@@ -113,7 +113,7 @@ func (m *appTokenManager) requestNewToken(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("failed to fetch installation access token (response status %s): %s", resp.Status, string(body))
+		return nil, fmt.Errorf("fetching installation access token (response status %s): %s", resp.Status, string(body))
 	}
 	return body, nil
 }
@@ -122,23 +122,23 @@ func (cfg *Config) fetchInstallation(organization string) (*github.Installation,
 	const installationURL = "https://api.github.com/app/installations"
 	resp, err := cfg.Client().Get(installationURL)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching GitHub app installation for organization %s: %w", organization, err)
+		return nil, fmt.Errorf("fetching GitHub app installation for organization %s: %w", organization, err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error reading installation response: %w", err)
+		return nil, fmt.Errorf("reading installation response: %w", err)
 	}
 	var installations []*github.Installation
 	if err := json.Unmarshal(body, &installations); err != nil {
-		return nil, fmt.Errorf("error unmarshalling installation response: %s: %w", body, err)
+		return nil, fmt.Errorf("unmarshaling installation response: %s: %w", body, err)
 	}
 	for _, inst := range installations {
 		if inst.GetAccount().GetLogin() == organization {
 			return inst, nil
 		}
 	}
-	return nil, fmt.Errorf("could not find GitHub app installation for organization %s", organization)
+	return nil, fmt.Errorf("no GitHub app installation for organization %s", organization)
 }
 
 type ExchangeToken struct {
@@ -163,7 +163,7 @@ func (cfg *Config) ExchangeToken(refreshToken string) (*ExchangeToken, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to get access token: %s", resp.Status)
+		return nil, fmt.Errorf("getting access token: %s", resp.Status)
 	}
 	var token ExchangeToken
 	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {

--- a/scm/github_app.go
+++ b/scm/github_app.go
@@ -122,7 +122,7 @@ func (cfg *Config) fetchInstallation(organization string) (*github.Installation,
 	const installationURL = "https://api.github.com/app/installations"
 	resp, err := cfg.Client().Get(installationURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetching GitHub app installation for organization %s: %w", organization, err)
+		return nil, fmt.Errorf("fetching GitHub App installation for organization %s: %w", organization, err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
@@ -138,7 +138,7 @@ func (cfg *Config) fetchInstallation(organization string) (*github.Installation,
 			return inst, nil
 		}
 	}
-	return nil, fmt.Errorf("no GitHub app installation for organization %s", organization)
+	return nil, fmt.Errorf("no GitHub App installation for organization %s", organization)
 }
 
 type ExchangeToken struct {

--- a/scm/github_invite.go
+++ b/scm/github_invite.go
@@ -15,7 +15,7 @@ func (s *GithubSCM) acceptOrgInvitation(ctx context.Context, opt *InvitationOpti
 	userSCM := s.createUserClientFn(opt.AccessToken)
 	state := "active"
 	if _, _, err := userSCM.Organizations.EditOrgMembership(ctx, "", opt.Owner, &github.Membership{State: &state}); err != nil {
-		return fmt.Errorf("failed to accept invitation for %s to organization %s: %w", opt.Login, opt.Owner, err)
+		return fmt.Errorf("accepting invitation for %s to organization %s: %w", opt.Login, opt.Owner, err)
 	}
 	return nil
 }

--- a/scm/githubv4.go
+++ b/scm/githubv4.go
@@ -42,14 +42,14 @@ func (s *GithubSCM) DeleteIssues(ctx context.Context, opt *RepositoryOptions) er
 	// List all open and closed issues (and pull requests)
 	issueList, _, err := s.client.Issues.ListByRepo(ctx, opt.Owner, opt.Repo, &github.IssueListByRepoOptions{State: "all"})
 	if err != nil {
-		return fmt.Errorf("failed to fetch issues for %s: %w", opt.Repo, err)
+		return fmt.Errorf("fetching issues for %s: %w", opt.Repo, err)
 	}
 	for _, issue := range issueList {
 		if issue.IsPullRequest() {
 			continue // ignore pull requests when deleting issues
 		}
 		if err = s.DeleteIssue(ctx, opt, *issue.Number); err != nil {
-			return fmt.Errorf("failed to delete issue %d in %s: %w", *issue.Number, opt.Repo, err)
+			return fmt.Errorf("deleting issue %d in %s: %w", *issue.Number, opt.Repo, err)
 		}
 	}
 	return nil

--- a/scm/manager.go
+++ b/scm/manager.go
@@ -26,7 +26,7 @@ type Manager struct {
 func (m *Manager) ExchangeAndUpdateToken(user *qf.User) (string, error) {
 	exchangeToken, err := m.exchangeTokenFn(user.GetRefreshToken())
 	if err != nil {
-		return "", fmt.Errorf("failed to exchange token for user %s: %w", user.GetLogin(), err)
+		return "", fmt.Errorf("exchanging token for user %s: %w", user.GetLogin(), err)
 	}
 	user.UpdateRefreshToken(exchangeToken.RefreshToken)
 	return exchangeToken.AccessToken, nil
@@ -55,11 +55,11 @@ func NewSCMConfig() (*Config, error) {
 	}
 	createAppKey, err := key.FromFile(env.AppPrivKeyFile())
 	if err != nil {
-		return nil, fmt.Errorf("error reading key from file: %w", err)
+		return nil, fmt.Errorf("reading key from file: %w", err)
 	}
 	appConfig, err := app.NewConfig(appID, createAppKey)
 	if err != nil {
-		return nil, fmt.Errorf("error creating GitHub application client: %w", err)
+		return nil, fmt.Errorf("creating GitHub application client: %w", err)
 	}
 	return &Config{
 		ClientID:     clientID,
@@ -92,7 +92,7 @@ func (s *Manager) GetOrCreateSCM(ctx context.Context, organization string) (SCM,
 	}
 	client, err := newSCMAppClient(ctx, s.Config, organization)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create github application for %s: %w", organization, err)
+		return nil, fmt.Errorf("creating GitHub application for %s: %w", organization, err)
 	}
 	s.mu.Lock()
 	s.scms[organization] = client

--- a/scm/manager.go
+++ b/scm/manager.go
@@ -59,7 +59,7 @@ func NewSCMConfig() (*Config, error) {
 	}
 	appConfig, err := app.NewConfig(appID, createAppKey)
 	if err != nil {
-		return nil, fmt.Errorf("creating GitHub application client: %w", err)
+		return nil, fmt.Errorf("creating GitHub App client: %w", err)
 	}
 	return &Config{
 		ClientID:     clientID,
@@ -92,7 +92,7 @@ func (s *Manager) GetOrCreateSCM(ctx context.Context, organization string) (SCM,
 	}
 	client, err := newSCMAppClient(ctx, s.Config, organization)
 	if err != nil {
-		return nil, fmt.Errorf("creating GitHub application for %s: %w", organization, err)
+		return nil, fmt.Errorf("creating GitHub App client for %s: %w", organization, err)
 	}
 	s.mu.Lock()
 	s.scms[organization] = client

--- a/scm/scm_errors_test.go
+++ b/scm/scm_errors_test.go
@@ -52,7 +52,7 @@ func TestErrorGetOrganization(t *testing.T) {
 		wantUserErrAlreadyExist     = "foo: course repositories (info, assignments, tests): already exist"
 		wantErrAlreadyExist         = "scm.GetOrganization: " + wantUserErrAlreadyExist
 		wantErrPermission           = "scm.GetOrganization: bar: permission denied: meling: not an owner of organization"
-		wantErrPermissionMembership = "scm.GetOrganization: bar: permission denied: failed to get membership: GET http://127.0.0.1/orgs/bar/memberships/jostein: 404  []"
+		wantErrPermissionMembership = "scm.GetOrganization: bar: permission denied: getting membership: GET http://127.0.0.1/orgs/bar/memberships/jostein: 404  []"
 		wantUserErrPermission       = "bar: permission denied"
 		wantUserErrPrefix           = "failed to get organization"
 	)
@@ -253,7 +253,7 @@ func TestErrorCreateCourse(t *testing.T) {
 		{
 			name:        "CompleteRequest/NotMember",
 			opt:         &CourseOptions{OrganizationID: 456, CourseCreator: "lamport"},
-			wantErr:     "scm.GetOrganization: bar: permission denied: failed to get membership: GET http://127.0.0.1/orgs/bar/memberships/lamport: 404  []",
+			wantErr:     "scm.GetOrganization: bar: permission denied: getting membership: GET http://127.0.0.1/orgs/bar/memberships/lamport: 404  []",
 			wantUserErr: "bar: permission denied",
 		},
 		{
@@ -327,7 +327,7 @@ func TestErrorUpdateEnrollment(t *testing.T) {
 		{
 			name:        "CompleteRequest/CreateStudRepo",
 			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "frank", Status: qf.Enrollment_STUDENT, AccessToken: "string"},
-			wantErr:     `scm.UpdateEnrollment: failed to enroll frank as student in bar: failed to add with "pull" access: PUT http://127.0.0.1/repos/bar/assignments/collaborators/frank: 404  []`,
+			wantErr:     `scm.UpdateEnrollment: failed to enroll frank as student in bar: adding with "pull" access: PUT http://127.0.0.1/repos/bar/assignments/collaborators/frank: 404  []`,
 			wantUserErr: "failed to enroll frank as student in bar",
 		},
 		{
@@ -366,7 +366,7 @@ func TestErrorUpdateEnrollment(t *testing.T) {
 		{
 			name:        "CompleteRequest/Student/Fail",
 			opt:         &UpdateEnrollmentOptions{Organization: "bar", User: "meling", Status: qf.Enrollment_STUDENT, AccessToken: "string"},
-			wantErr:     `scm.UpdateEnrollment: failed to enroll meling as student in bar: failed to add with "pull" access: PUT http://127.0.0.1/repos/bar/assignments/collaborators/meling: 404  []`,
+			wantErr:     `scm.UpdateEnrollment: failed to enroll meling as student in bar: adding with "pull" access: PUT http://127.0.0.1/repos/bar/assignments/collaborators/meling: 404  []`,
 			wantUserErr: "failed to enroll meling as student in bar",
 		},
 
@@ -446,7 +446,7 @@ func TestErrorDemoteTeacherToStudent(t *testing.T) {
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &UpdateEnrollmentOptions{Organization: "fuzz", User: "meling", AccessToken: "string"},
-			wantErr:     `scm.DemoteTeacherToStudent: failed to demote teacher meling to student in fuzz: failed to update to "member": PUT http://127.0.0.1/orgs/fuzz/memberships/meling: 404  []`,
+			wantErr:     `scm.DemoteTeacherToStudent: failed to demote teacher meling to student in fuzz: updating to "member": PUT http://127.0.0.1/orgs/fuzz/memberships/meling: 404  []`,
 			wantUserErr: "failed to demote teacher meling to student in fuzz",
 		},
 		// Note: User not found in org will create a new membership with member role (GitHub API behavior)
@@ -549,13 +549,13 @@ func TestErrorUpdateGroupMembers(t *testing.T) {
 		{
 			name:        "CompleteRequest/RepoNotFound",
 			opt:         &GroupOptions{Organization: "foo", GroupName: "a"},
-			wantErr:     "scm.UpdateGroupMembers: failed to update group members: failed to get members: GET http://127.0.0.1/repos/foo/a/collaborators: 404  []",
+			wantErr:     "scm.UpdateGroupMembers: failed to update group members: getting members: GET http://127.0.0.1/repos/foo/a/collaborators: 404  []",
 			wantUserErr: wantUserErr,
 		},
 		{
 			name:        "CompleteRequest/OrgNotFound",
 			opt:         &GroupOptions{Organization: "x", GroupName: "info"},
-			wantErr:     "scm.UpdateGroupMembers: failed to update group members: failed to get members: GET http://127.0.0.1/repos/x/info/collaborators: 404  []",
+			wantErr:     "scm.UpdateGroupMembers: failed to update group members: getting members: GET http://127.0.0.1/repos/x/info/collaborators: 404  []",
 			wantUserErr: wantUserErr,
 		},
 		// TODO: Add more tests to check error handling when updating group members.

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -108,14 +108,14 @@ func OAuth2Callback(logger *slog.Logger, db database.Database, tm *TokenManager,
 		// otherwise frontend will get user object where only name, email and url are set.
 		user, err := fetchUser(logger, db, token, externalUser)
 		if err != nil {
-			authenticationError(logger, w, fmt.Errorf("failed to fetch user %q for remote identity: %w", externalUser.Login, err))
+			authenticationError(logger, w, fmt.Errorf("fetching user %q for remote identity: %w", externalUser.Login, err))
 			return
 		}
 		logger.Debug("fetched user", label.UserID, user.GetID())
 
 		cookie, err := tm.NewAuthCookie(user.GetID())
 		if err != nil {
-			authenticationError(logger, w, fmt.Errorf("failed to create authentication cookie for user %q: %w", externalUser.Login, err))
+			authenticationError(logger, w, fmt.Errorf("creating authentication cookie for user %q: %w", externalUser.Login, err))
 			return
 		}
 		http.SetCookie(w, cookie)
@@ -158,7 +158,7 @@ func extractAccessToken(r *http.Request, authConfig *oauth2.Config, secret strin
 	}
 	token, err := authConfig.Exchange(r.Context(), code)
 	if err != nil {
-		return nil, fmt.Errorf("failed to exchange access token: %w", err)
+		return nil, fmt.Errorf("exchanging access token: %w", err)
 	}
 	return token, nil
 }
@@ -167,13 +167,13 @@ func extractAccessToken(r *http.Request, authConfig *oauth2.Config, secret strin
 func FetchExternalUser(token *oauth2.Token) (user *ExternalUser, err error) {
 	req, err := http.NewRequest("GET", githubUserAPI, http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create user request: %w", err)
+		return nil, fmt.Errorf("creating user request: %w", err)
 	}
 	token.SetAuthHeader(req)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send user request: %w", err)
+		return nil, fmt.Errorf("sending user request: %w", err)
 	}
 	defer func() {
 		closeErr := resp.Body.Close()
@@ -188,11 +188,11 @@ func FetchExternalUser(token *oauth2.Token) (user *ExternalUser, err error) {
 	}
 	responseBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
-		err = fmt.Errorf("failed to read authentication response: %w", readErr)
+		err = fmt.Errorf("reading authentication response: %w", readErr)
 		return
 	}
 	if jsonErr := json.NewDecoder(bytes.NewReader(responseBody)).Decode(&user); jsonErr != nil {
-		err = fmt.Errorf("failed to decode user information: %w", jsonErr)
+		err = fmt.Errorf("decoding user information: %w", jsonErr)
 	}
 	return
 }
@@ -218,14 +218,14 @@ func fetchUser(logger *slog.Logger, db database.Database, token *oauth2.Token, e
 		logger.Debug("found user", label.UserID, user.GetID())
 		user.RefreshToken = token.RefreshToken
 		if err = db.UpdateUser(user); err != nil {
-			return nil, fmt.Errorf("failed to update access token for user %q: %w", externalUser.Login, err)
+			return nil, fmt.Errorf("updating access token for user %q: %w", externalUser.Login, err)
 		}
 		logger.Debug("refresh token updated", label.UserID, user.GetID())
 
 	case gorm.ErrRecordNotFound:
 		// Validate external user information before creating account
 		if err := CheckExternalUser(externalUser); err != nil {
-			return nil, fmt.Errorf("cannot create account for user %q: %w", externalUser.Login, err)
+			return nil, fmt.Errorf("creating account for user %q: %w", externalUser.Login, err)
 		}
 		logger.Debug("creating user")
 		user = &qf.User{
@@ -237,12 +237,12 @@ func fetchUser(logger *slog.Logger, db database.Database, token *oauth2.Token, e
 			RefreshToken: token.RefreshToken,
 		}
 		if err = db.CreateUser(user); err != nil {
-			return nil, fmt.Errorf("failed to create remote identity for user %q: %w", externalUser.Login, err)
+			return nil, fmt.Errorf("creating remote identity for user %q: %w", externalUser.Login, err)
 		}
 		logger.Debug("created user", label.UserID, user.GetID())
 
 	default:
-		return nil, fmt.Errorf("failed to fetch user %q for remote identity: %w", externalUser.Login, err)
+		return nil, fmt.Errorf("fetching user %q for remote identity: %w", externalUser.Login, err)
 	}
 	logger.Debug("reloading user")
 	return db.GetUserByRemoteIdentity(externalUser.ID)

--- a/web/auth/jwt.go
+++ b/web/auth/jwt.go
@@ -53,7 +53,7 @@ func (tm *TokenManager) NewAuthCookie(userID uint64) (*http.Cookie, error) {
 	}
 	signedToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(tm.secret))
 	if err != nil {
-		return nil, fmt.Errorf("failed to sign token: %w", err)
+		return nil, fmt.Errorf("signing token: %w", err)
 	}
 	return &http.Cookie{
 		Name:     CookieName,
@@ -88,7 +88,7 @@ func (tm *TokenManager) GetClaims(cookie string) (*Claims, error) {
 	}
 	claims, ok := token.Claims.(*Claims)
 	if !ok || !token.Valid {
-		return nil, fmt.Errorf("failed to parse token: validation error")
+		return nil, errors.New("invalid token claims")
 	}
 	return claims, nil
 }
@@ -144,7 +144,7 @@ func extractToken(cookieString string) (string, error) {
 			return strings.TrimSpace(cookieValue), nil
 		}
 	}
-	return "", errors.New("failed to extract authentication cookie from request header")
+	return "", errors.New("no authentication cookie in request header")
 }
 
 // Context returns a new context with the claims as value.

--- a/web/auth/jwt_update.go
+++ b/web/auth/jwt_update.go
@@ -13,7 +13,7 @@ func (tm *TokenManager) UpdateCookie(claims *Claims) (*http.Cookie, error) {
 	}
 	updatedCookie, err := tm.NewAuthCookie(claims.UserID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update cookie for user %d: %w", claims.UserID, err)
+		return nil, fmt.Errorf("updating cookie for user %d: %w", claims.UserID, err)
 	}
 	if err := tm.Remove(claims.UserID); err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (tm *TokenManager) updateRequired(claims *Claims) bool {
 func (tm *TokenManager) updateTokenList() error {
 	users, err := tm.db.GetUsers()
 	if err != nil {
-		return fmt.Errorf("failed to update JWT tokens from database: %w", err)
+		return fmt.Errorf("updating JWT token list from database: %w", err)
 	}
 	var tokens []uint64
 	for _, user := range users {

--- a/web/courses.go
+++ b/web/courses.go
@@ -31,7 +31,7 @@ func (s *QuickFeedService) updateEnrollment(ctx context.Context, sc scm.SCM, cur
 
 	// check and update user SCM info before updating enrollment status
 	if err := s.updateUserFromSCM(ctx, sc, enrollment.GetUser()); err != nil {
-		return fmt.Errorf("failed to update SCM info for user %d: %w", enrollment.GetUserID(), err)
+		return fmt.Errorf("updating SCM info for user %d: %w", enrollment.GetUserID(), err)
 	}
 	switch {
 	case (enrollment.IsPending() || enrollment.IsStudent()) && request.IsNone(): // pending or student -> none
@@ -55,7 +55,7 @@ func (s *QuickFeedService) rejectEnrollment(ctx context.Context, sc scm.SCM, enr
 	course, user := enrolled.GetCourse(), enrolled.GetUser()
 	repo, err := s.getRepo(course, user.GetID(), qf.Repository_USER)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("failed to get %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
+		return fmt.Errorf("getting %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 	if repo == nil {
 		qlog.FromContext(ctx).Debug("course repository not found", label.Error, err)
@@ -71,7 +71,7 @@ func (s *QuickFeedService) rejectEnrollment(ctx context.Context, sc scm.SCM, enr
 	}
 	if err := sc.RejectEnrollment(ctx, opt); err != nil {
 		if !errors.Is(err, scm.ErrNotFound) {
-			return fmt.Errorf("failed to remove %s from %q: %w", user.GetLogin(), course.GetCode(), err)
+			return fmt.Errorf("removing %s from %q: %w", user.GetLogin(), course.GetCode(), err)
 		}
 		// repository or membership already removed on GitHub, e.g., by a previously interrupted reject
 		qlog.FromContext(ctx).Debug("user already removed from SCM organization", label.Error, err)
@@ -92,7 +92,7 @@ func (s *QuickFeedService) enrollStudent(ctx context.Context, sc scm.SCM, query 
 	// which could happen if accepting a previously rejected student
 	repo, err := s.getRepo(course, user.GetID(), qf.Repository_USER)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("failed to get %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
+		return fmt.Errorf("getting %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 	// Use enrollment with full updated info to ensure that gorm Select.Updates works correctly.
 	query.Status = qf.Enrollment_STUDENT
@@ -125,7 +125,7 @@ func (s *QuickFeedService) enrollStudent(ctx context.Context, sc scm.SCM, query 
 	}
 	scmRepo, err := sc.UpdateEnrollment(ctx, opt)
 	if err != nil {
-		return fmt.Errorf("failed to update %s repository membership for %q: %w", course.GetCode(), user.GetLogin(), err)
+		return fmt.Errorf("updating %s repository membership for %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 	logger.Debug("student enrollment repository updated")
 
@@ -138,7 +138,7 @@ func (s *QuickFeedService) enrollStudent(ctx context.Context, sc scm.SCM, query 
 		RepoType:          qf.Repository_USER,
 	}
 	if err := s.db.CreateRepository(&userRepo); err != nil {
-		return fmt.Errorf("failed to create %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
+		return fmt.Errorf("creating %s repository for %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 
 	return s.db.UpdateEnrollment(query)
@@ -155,7 +155,7 @@ func (s *QuickFeedService) enrollTeacher(ctx context.Context, sc scm.SCM, query 
 		User:         user.GetLogin(),
 		Status:       qf.Enrollment_TEACHER,
 	}); err != nil {
-		return fmt.Errorf("failed to update %s repository membership for teacher %q: %w", course.GetCode(), user.GetLogin(), err)
+		return fmt.Errorf("updating %s repository membership for teacher %q: %w", course.GetCode(), user.GetLogin(), err)
 	}
 	return s.db.UpdateEnrollment(query)
 }

--- a/web/groups.go
+++ b/web/groups.go
@@ -51,7 +51,7 @@ func (s *QuickFeedService) internalDeleteGroup(ctx context.Context, sc scm.SCM, 
 	ctx, logger := qlog.WithLogger(ctx, label.CourseCode, course.GetCode(), label.Group, group.GetName())
 	repo, err := s.getRepo(course, group.GetID(), qf.Repository_GROUP)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("failed to get %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
+		return fmt.Errorf("getting %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
 	}
 	if repo == nil {
 		logger.Debug("group repository not found", label.Error, err)
@@ -62,7 +62,7 @@ func (s *QuickFeedService) internalDeleteGroup(ctx context.Context, sc scm.SCM, 
 	// when deleting an approved group, remove github repository as well
 	if err := sc.DeleteGroup(ctx, repo.GetScmRepositoryID()); err != nil {
 		if !errors.Is(err, scm.ErrNotFound) {
-			return fmt.Errorf("failed to delete %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
+			return fmt.Errorf("deleting %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
 		}
 		// repository already deleted on GitHub, e.g., by a previously interrupted delete
 		logger.Debug("group repository not found on SCM", label.Error, err)
@@ -98,7 +98,7 @@ func (s *QuickFeedService) internalUpdateGroup(ctx context.Context, sc scm.SCM, 
 	for _, user := range users {
 		// check and update user SCM info before updating group
 		if err := s.updateUserFromSCM(ctx, sc, user); err != nil {
-			return fmt.Errorf("failed to update SCM info for user %d: %w", user.GetID(), err)
+			return fmt.Errorf("updating SCM info for user %d: %w", user.GetID(), err)
 		}
 	}
 
@@ -111,7 +111,7 @@ func (s *QuickFeedService) internalUpdateGroup(ctx context.Context, sc scm.SCM, 
 
 	repo, err := s.getRepo(course, group.GetID(), qf.Repository_GROUP)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("failed to get %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
+		return fmt.Errorf("getting %s repository for group %q: %w", course.GetCode(), group.GetName(), err)
 	}
 	if repo == nil {
 		repo, err := createRepo(ctx, sc, course, newGroup)
@@ -182,7 +182,7 @@ func (s *QuickFeedService) getGroupUsers(request *qf.Group) ([]*qf.User, error) 
 
 	users, err := s.db.GetUsers(userIds...)
 	if err != nil {
-		return nil, errors.New("failed to get users")
+		return nil, fmt.Errorf("getting users: %w", err)
 	}
 	if len(request.GetUsers()) != len(users) || len(users) != len(userIds) {
 		return nil, fmt.Errorf("invariant violation (request.Users=%d, users=%d, userIds=%d)",

--- a/web/hooks/courses_new.go
+++ b/web/hooks/courses_new.go
@@ -31,11 +31,11 @@ func createCourse(ctx context.Context, db database.Database, sc scm.SCM, course 
 			dbRepo.UserID = courseCreator.GetID()
 		}
 		if err := db.CreateRepository(&dbRepo); err != nil {
-			return nil, fmt.Errorf("failed to create database record for repository %s: %w", repo.Repo, err)
+			return nil, fmt.Errorf("creating database record for repository %s: %w", repo.Repo, err)
 		}
 	}
 	if err := db.CreateCourse(course.GetCourseCreatorID(), course); err != nil {
-		return nil, fmt.Errorf("failed to create database record for course %s: %w", course.GetName(), err)
+		return nil, fmt.Errorf("creating database record for course %s: %w", course.GetName(), err)
 	}
 	return course, nil
 }

--- a/web/hooks/pull_request.go
+++ b/web/hooks/pull_request.go
@@ -95,7 +95,7 @@ func (wh GitHubWebHook) getPullRequest(payload *github.PushEvent) (*qf.PullReque
 			// If this happens, QF should not do anything
 			return nil, fmt.Errorf("no pull request found for ref: %s", payload.GetRef())
 		}
-		return nil, fmt.Errorf("failed to get pull request from database: %w", err)
+		return nil, fmt.Errorf("getting pull request from database: %w", err)
 	}
 	return pullRequest, nil
 }

--- a/web/hooks/queries.go
+++ b/web/hooks/queries.go
@@ -9,7 +9,7 @@ import (
 func (wh GitHubWebHook) getRepository(repoID int64) (*qf.Repository, error) {
 	repos, err := wh.db.GetRepositories(&qf.Repository{ScmRepositoryID: uint64(repoID)})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get repository by remote ID %d: %w", repoID, err)
+		return nil, fmt.Errorf("getting repository by remote ID %d: %w", repoID, err)
 	}
 	if len(repos) != 1 {
 		return nil, fmt.Errorf("unknown repository: %d", repoID)
@@ -20,7 +20,7 @@ func (wh GitHubWebHook) getRepository(repoID int64) (*qf.Repository, error) {
 func (wh GitHubWebHook) getRepositoryWithIssues(repoID int64) (*qf.Repository, error) {
 	repos, err := wh.db.GetRepositoriesWithIssues(&qf.Repository{ScmRepositoryID: uint64(repoID)})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get repository by remote ID %d: %w", repoID, err)
+		return nil, fmt.Errorf("getting repository by remote ID %d: %w", repoID, err)
 	}
 	if len(repos) != 1 {
 		return nil, fmt.Errorf("unknown repository: %d", repoID)
@@ -31,7 +31,7 @@ func (wh GitHubWebHook) getRepositoryWithIssues(repoID int64) (*qf.Repository, e
 func (wh GitHubWebHook) getTask(taskID uint64) (*qf.Task, error) {
 	tasks, err := wh.db.GetTasks(&qf.Task{ID: taskID})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get task by ID %d: %w", taskID, err)
+		return nil, fmt.Errorf("getting task by ID %d: %w", taskID, err)
 	}
 	if len(tasks) != 1 {
 		return nil, fmt.Errorf("unknown task: %d", taskID)

--- a/web/interceptor/tokens.go
+++ b/web/interceptor/tokens.go
@@ -40,7 +40,7 @@ var tokenUpdateMethods = map[string]func(context.Context, *auth.TokenManager, us
 			}
 			return defaultTokenUpdater(ctx, tm, group)
 		}
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("cannot update token for %s: request does not contain a group", "DeleteGroup"))
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("updating token for %s: request does not contain a group", "DeleteGroup"))
 	},
 }
 
@@ -73,10 +73,10 @@ func (t *TokenInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		if tokenUpdateFn, ok := tokenUpdateMethods[method]; ok {
 			if msg, ok := request.Any().(userIDs); ok {
 				if err := tokenUpdateFn(ctx, t.tokenManager, msg); err != nil {
-					return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("cannot update token for %s: %w", method, err))
+					return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("updating token for %s: %w", method, err))
 				}
 			} else {
-				return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("cannot update token for %s: message type %T does not implement 'userIDs' interface", method, request))
+				return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("updating token for %s: message type %T does not implement 'userIDs' interface", method, request))
 			}
 		}
 		return next(ctx, request)

--- a/web/interceptor/tokens.go
+++ b/web/interceptor/tokens.go
@@ -40,7 +40,7 @@ var tokenUpdateMethods = map[string]func(context.Context, *auth.TokenManager, us
 			}
 			return defaultTokenUpdater(ctx, tm, group)
 		}
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("updating token for %s: request does not contain a group", "DeleteGroup"))
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("cannot update token for %s: request does not contain a group", "DeleteGroup"))
 	},
 }
 
@@ -73,10 +73,10 @@ func (t *TokenInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		if tokenUpdateFn, ok := tokenUpdateMethods[method]; ok {
 			if msg, ok := request.Any().(userIDs); ok {
 				if err := tokenUpdateFn(ctx, t.tokenManager, msg); err != nil {
-					return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("updating token for %s: %w", method, err))
+					return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("cannot update token for %s: %w", method, err))
 				}
 			} else {
-				return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("updating token for %s: message type %T does not implement 'userIDs' interface", method, request))
+				return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("cannot update token for %s: message type %T does not implement 'userIDs' interface", method, request))
 			}
 		}
 		return next(ctx, request)

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -66,11 +66,11 @@ func (u *UserInterceptor) processHeader(header http.Header) (*auth.Claims, *http
 	cookie := header.Get(auth.Cookie)
 	claims, err := u.tm.GetClaims(cookie)
 	if err != nil {
-		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to extract JWT claims from session cookie: %w", err))
+		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("extracting JWT claims from session cookie: %w", err))
 	}
 	updatedCookie, err := u.tm.UpdateCookie(claims)
 	if err != nil {
-		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))
+		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("updating session cookie: %w", err))
 	}
 	if updatedCookie == nil {
 		return claims, nil, nil

--- a/web/interceptor/user_auth.go
+++ b/web/interceptor/user_auth.go
@@ -66,11 +66,11 @@ func (u *UserInterceptor) processHeader(header http.Header) (*auth.Claims, *http
 	cookie := header.Get(auth.Cookie)
 	claims, err := u.tm.GetClaims(cookie)
 	if err != nil {
-		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("extracting JWT claims from session cookie: %w", err))
+		return nil, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to extract JWT claims from session cookie: %w", err))
 	}
 	updatedCookie, err := u.tm.UpdateCookie(claims)
 	if err != nil {
-		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("updating session cookie: %w", err))
+		return claims, nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to update session cookie: %w", err))
 	}
 	if updatedCookie == nil {
 		return claims, nil, nil

--- a/web/manifest/manifest.go
+++ b/web/manifest/manifest.go
@@ -66,7 +66,7 @@ func (m *Manifest) StartAppCreationFlow(server *web.Server) error {
 	go func() {
 		if err := server.Serve(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
-				m.done <- fmt.Errorf("could not start web server for GitHub App creation flow: %w", err)
+				m.done <- fmt.Errorf("starting web server for GitHub App creation flow: %w", err)
 				return
 			}
 			// server was closed prematurely, e.g., ctrl-C
@@ -286,7 +286,7 @@ func form(w http.ResponseWriter) error {
 	}
 	t := template.Must(template.New("form").Parse(tpl))
 	if err := t.Execute(w, data); err != nil {
-		return fmt.Errorf("failed to execute template: %w", err)
+		return fmt.Errorf("executing template: %w", err)
 	}
 	return nil
 }

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -79,7 +79,7 @@ func (s *QuickFeedService) internalRebuildSubmission(ctx context.Context, reques
 	}
 	submission, err = runData.RecordResults(ctx, s.db, results)
 	if err != nil {
-		return fmt.Errorf("failed to record results for assignment %s for course %s: %w", assignment.GetName(), course.GetName(), err)
+		return fmt.Errorf("recording results for assignment %s for course %s: %w", assignment.GetName(), course.GetName(), err)
 	}
 	// If we fail to get owners, we ignore sending on the stream.
 	if userIDs, err := runData.GetOwners(s.db); err == nil {

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -71,7 +71,7 @@ func CommitsAhead(ctx context.Context, sc scm.SCM, repos []*qf.Repository) error
 		if err != nil {
 			// if we cannot determine whether the repository is ahead,
 			// treat it as ahead so we don't delete a repository that may contain work.
-			return fmt.Errorf("could not determine if repository %s is ahead of assignments: %w", r.Name(), err)
+			return fmt.Errorf("determining if repository %s is ahead of assignments: %w", r.Name(), err)
 		}
 		if ahead > 0 {
 			return fmt.Errorf("repository %s is %d commits ahead", r.Name(), ahead)

--- a/web/server.go
+++ b/web/server.go
@@ -31,7 +31,7 @@ type ServerType func(handler http.Handler) (*Server, error)
 func NewProductionServer(handler http.Handler) (*Server, error) {
 	whitelist, err := env.Whitelist()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get whitelist: %w", err)
+		return nil, fmt.Errorf("getting whitelist: %w", err)
 	}
 	certManager := autocert.Manager{
 		Prompt: autocert.AcceptTOS,
@@ -66,7 +66,7 @@ func NewProductionServer(handler http.Handler) (*Server, error) {
 func NewDevelopmentServer(handler http.Handler) (*Server, error) {
 	certificate, err := tls.LoadX509KeyPair(env.FullchainFile(), env.PrivKeyFile())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load certificates from %q: %w", env.CertPath(), err)
+		return nil, fmt.Errorf("loading certificates from %q: %w", env.CertPath(), err)
 	}
 	log.Println("Existing credentials successfully loaded.")
 


### PR DESCRIPTION
## Summary

Removes the "failed to" / "could not" / "unable to" / "error" prefixes from internal error strings, so wrapped chains read as prose instead of stacking the same prefix at every layer.

Stacked on `meling/slog-context-logging` — review that PR first, or read this one's diff against it.

## Why

The prefix states what the error type already conveys, and it compounds on the way up the stack:

```text
failed to enroll user: failed to create SCM client: 401 Unauthorized
enrolling user: creating SCM client: 401 Unauthorized
```

This is the [Uber Go Style Guide][uber] rule on error wrapping, and it matches the Google Go Style Guide's [advice][google] not to annotate an error solely to indicate failure.

[uber]: https://github.com/uber-go/guide/blob/master/style.md
[google]: https://google.github.io/styleguide/go/best-practices#adding-information-to-errors

## What changed

123 error strings across 40 source files, in three groups.

**Wrapping errors** take the operation form:

```go
// before
return fmt.Errorf("failed to create SCM client: %w", err)
// after
return fmt.Errorf("creating SCM client: %w", err)
```

**Leaf errors** that wrap nothing name the condition, because the operation form would describe an attempt rather than what the error means:

| before | after |
| --- | --- |
| `"failed to update group enrollment"` | `"group members not enrolled in the course"` |
| `"failed to create repository; invalid arguments"` | `"invalid arguments for repository creation"` |
| `"failed to get owners for %s"` | `"no owners for %s"` |
| `"failed to extract authentication cookie from request header"` | `"no authentication cookie in request header"` |
| `"could not find GitHub app installation for organization %s"` | `"no GitHub app installation for organization %s"` |

**Unchanged:** `"cannot X without Y"` preconditions, which already state a condition rather than a failure.

`doc/dev.md` gains an `Error strings` subsection recording the convention, next to the existing guidance on what to show the user versus what to log.

## Deliberately out of scope

**User-facing errors keep their wording.** The ~35 `connect.NewError(...)` messages in `web/quickfeed_service.go` and the `scm.M(...)` messages in `scm/github.go` and `scm/github_issues.go` both reach the browser — `M()` builds a `UserError` that `userSCMError` converts to a connect error, which the frontend renders in an alert. "getting course" is not an acceptable UI string. Uber's guide makes the same carve-out: once an error leaves for another system, a "Failed" prefix belongs in the message.

The result is a chain that is explicit at the boundary and terse inside it:

```text
scm.UpdateEnrollment: failed to enroll frank as student in bar: adding with "pull" access: PUT …: 404
```

**Log messages are untouched.** The pile-up argument is specific to `%w` chains — log messages do not concatenate.

## One change beyond the string

`web/groups.go` discarded the database error (`errors.New("failed to get users")`); it now wraps it. That is the only site where the error value changed, not just its text.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>