### PR TITLE
logging: add the course-scoped log sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ public/dist/bundle.js*
 public/dist/bundle.js.map
 quickfeed
 backups
+logs
 scratchpad
 proto-include
 bin
@@ -15,6 +16,8 @@ bin
 cyclone.sh
 start.sh
 update.sh
+update-and-rotate.sh
+backup.sh
 quickfeed-env.sh
 .env*
 !.env-template
@@ -41,6 +44,4 @@ TODO*
 dat320-original.xlsx
 dat320-approve-list.xlsx
 patch/go.pb.go
-oldbackups/*
-backup.sh
 go.work.sum

--- a/internal/env/path.go
+++ b/internal/env/path.go
@@ -106,3 +106,8 @@ func DatabasePath() string {
 func TestdataPath() string {
 	return Root("testdata", "courses")
 }
+
+// CourseLogDir returns the path to the directory holding per-course teacher logs.
+func CourseLogDir() string {
+	return Root("logs", "courses")
+}

--- a/internal/qlog/course.go
+++ b/internal/qlog/course.go
@@ -1,0 +1,49 @@
+package qlog
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+// Course is the subset of qf.Course that WithCourse and WithCourseLog need.
+// Declaring it here, rather than importing qf, keeps qlog free of a
+// dependency on the database model package.
+type Course interface {
+	GetID() uint64
+	GetCode() string
+	GetScmOrganizationName() string
+}
+
+// CourseAttrs returns the attributes WithCourse attaches, for the rare caller
+// that already holds an enriched logger it only wants to extend, rather than
+// a context to enrich.
+func CourseAttrs(course Course) []any {
+	return []any{
+		label.CourseID, course.GetID(),
+		label.CourseCode, course.GetCode(),
+		label.CourseLog, course.GetScmOrganizationName(),
+	}
+}
+
+// WithCourse returns a context and logger scoped to course, in addition to
+// attrs. Records logged through the returned logger are copied to the
+// course's teacher-visible log, so course must come from the database, never
+// from request data: nothing else can mark a scope for a course's log.
+func WithCourse(ctx context.Context, course Course, attrs ...any) (context.Context, *slog.Logger) {
+	return WithLogger(ctx, append(CourseAttrs(course), attrs...)...)
+}
+
+// WithCourseLog is WithCourse without CourseID, for the handful of RPC call
+// paths where the logging interceptors already attached CourseID to the
+// request logger from the caller's claims; see enrichRequestLogger. It still
+// attaches CourseCode, which is not part of that RPC scope, and the course
+// log marker.
+func WithCourseLog(ctx context.Context, course Course, attrs ...any) (context.Context, *slog.Logger) {
+	scoped := append([]any{
+		label.CourseCode, course.GetCode(),
+		label.CourseLog, course.GetScmOrganizationName(),
+	}, attrs...)
+	return WithLogger(ctx, scoped...)
+}

--- a/internal/qlog/course_test.go
+++ b/internal/qlog/course_test.go
@@ -1,0 +1,98 @@
+package qlog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+// fakeCourse implements Course without depending on qf.Course.
+type fakeCourse struct {
+	id   uint64
+	code string
+	org  string
+}
+
+func (c fakeCourse) GetID() uint64                  { return c.id }
+func (c fakeCourse) GetCode() string                { return c.code }
+func (c fakeCourse) GetScmOrganizationName() string { return c.org }
+
+func TestCourseAttrs(t *testing.T) {
+	course := fakeCourse{id: 7, code: "DAT320", org: "dat320-2026"}
+	want := []any{
+		label.CourseID, uint64(7),
+		label.CourseCode, "DAT320",
+		label.CourseLog, "dat320-2026",
+	}
+	got := CourseAttrs(course)
+	if len(got) != len(want) {
+		t.Fatalf("CourseAttrs() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("CourseAttrs()[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWithCourse(t *testing.T) {
+	var output bytes.Buffer
+	logger := New(&output)
+	course := fakeCourse{id: 42, code: "DAT520", org: "dat520-2026"}
+
+	ctx, scoped := WithCourse(NewContext(context.Background(), logger), course, label.Repository, "student")
+	if FromContext(ctx) != scoped {
+		t.Fatalf("FromContext(ctx) did not return the logger WithCourse attached to ctx")
+	}
+	scoped.Info("scoped record")
+
+	got := output.String()
+	for _, want := range []string{"course_id=42", "course_code=DAT520", "course_log=dat520-2026", "repository=student"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log output %q does not contain %q", got, want)
+		}
+	}
+}
+
+// TestWithCourseLogOmitsCourseID guards the variant used where the RPC
+// interceptors already attached course_id from the caller's claims: it must
+// not repeat it, only add CourseCode and the log marker.
+func TestWithCourseLogOmitsCourseID(t *testing.T) {
+	var output bytes.Buffer
+	logger := New(&output)
+	course := fakeCourse{id: 42, code: "DAT520", org: "dat520-2026"}
+
+	ambient := logger.With(label.CourseID, uint64(42)) // simulates enrichRequestLogger
+	_, scoped := WithCourseLog(NewContext(context.Background(), ambient), course)
+	scoped.Info("scoped record")
+
+	got := output.String()
+	if n := strings.Count(got, "course_id="); n != 1 {
+		t.Errorf("log output %q has course_id %d times, want exactly once", got, n)
+	}
+	for _, want := range []string{"course_code=DAT520", "course_log=dat520-2026"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestWithSink(t *testing.T) {
+	var primary, secondary bytes.Buffer
+	logger := New(&primary)
+	sink := slog.NewJSONHandler(&secondary, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	combined := WithSink(logger, sink)
+	combined.Info("fanned out")
+
+	if !strings.Contains(primary.String(), "fanned out") {
+		t.Errorf("primary output %q does not contain the record", primary.String())
+	}
+	if !strings.Contains(secondary.String(), "fanned out") {
+		t.Errorf("secondary output %q does not contain the record", secondary.String())
+	}
+}

--- a/internal/qlog/courselog/handler.go
+++ b/internal/qlog/courselog/handler.go
@@ -1,0 +1,123 @@
+package courselog
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/quickfeed/quickfeed/internal/env"
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+// maxFieldBytes is the largest message or string attribute value kept in a
+// course log record; anything longer is cut down to size and the record is
+// marked label.Truncated.
+const maxFieldBytes = 64 * 1024
+
+// handler is a slog.Handler that copies records carrying label.CourseLog to a
+// Store, and drops every other record. Attach it alongside the operator's
+// handler with slog.NewMultiHandler; see qlog.WithSink.
+//
+// A handler is immutable: WithAttrs and WithGroup return a new value, as
+// slog.Handler requires. Until a scope's WithAttrs call carries
+// label.CourseLog, its attributes are held pending; the call that carries it
+// selects the course's file and replays the pending attributes into it.
+type handler struct {
+	store *Store
+
+	// inner is nil until label.CourseLog has been observed in this scope.
+	inner   slog.Handler
+	pending []slog.Attr
+}
+
+// NewHandler returns a Handler that writes through store.
+func NewHandler(store *Store) slog.Handler {
+	return &handler{store: store}
+}
+
+func (h *handler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= slog.LevelDebug
+}
+
+func (h *handler) Handle(ctx context.Context, r slog.Record) error {
+	if h.inner == nil {
+		// No scope up to this record has attached label.CourseLog.
+		return nil
+	}
+	return h.inner.Handle(ctx, truncate(r))
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	if h.inner != nil {
+		return &handler{store: h.store, inner: h.inner.WithAttrs(attrs)}
+	}
+	org, rest, found := extractCourseLog(attrs)
+	pending := make([]slog.Attr, 0, len(h.pending)+len(rest))
+	pending = append(pending, h.pending...)
+	pending = append(pending, rest...)
+	if !found {
+		return &handler{store: h.store, pending: pending}
+	}
+	inner := slog.NewJSONHandler(h.store.Writer(org), &slog.HandlerOptions{
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: qlog.RelativeSource(env.Root()),
+	})
+	return &handler{store: h.store, inner: inner.WithAttrs(pending)}
+}
+
+func (h *handler) WithGroup(name string) slog.Handler {
+	if h.inner != nil {
+		return &handler{store: h.store, inner: h.inner.WithGroup(name)}
+	}
+	// No call site scopes a course logger with a group before attaching
+	// label.CourseLog, so there is nothing meaningful to carry forward here.
+	return h
+}
+
+// extractCourseLog reports whether attrs carries label.CourseLog, returning
+// its string value and the remaining attributes with it removed. The marker
+// itself is not written to the course log: it is a routing detail internal
+// to the sink, not a field a teacher needs to see.
+func extractCourseLog(attrs []slog.Attr) (org string, rest []slog.Attr, found bool) {
+	rest = make([]slog.Attr, 0, len(attrs))
+	for _, a := range attrs {
+		if !found && a.Key == label.CourseLog {
+			org = a.Value.String()
+			found = true
+			continue
+		}
+		rest = append(rest, a)
+	}
+	return org, rest, found
+}
+
+// truncate returns a copy of r with its message, and any string attribute
+// value, longer than maxFieldBytes cut down to size. The record is marked
+// label.Truncated when anything was cut.
+func truncate(r slog.Record) slog.Record {
+	msg := r.Message
+	truncated := false
+	if len(msg) > maxFieldBytes {
+		msg = msg[:maxFieldBytes]
+		truncated = true
+	}
+	out := slog.NewRecord(r.Time, r.Level, msg, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Value.Kind() == slog.KindString {
+			if s := a.Value.String(); len(s) > maxFieldBytes {
+				a = slog.String(a.Key, s[:maxFieldBytes])
+				truncated = true
+			}
+		}
+		out.AddAttrs(a)
+		return true
+	})
+	if truncated {
+		out.AddAttrs(slog.Bool(label.Truncated, true))
+	}
+	return out
+}

--- a/internal/qlog/courselog/handler.go
+++ b/internal/qlog/courselog/handler.go
@@ -36,7 +36,7 @@ func NewHandler(store *Store) slog.Handler {
 }
 
 func (h *handler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= slog.LevelDebug
+	return h.inner != nil && level >= slog.LevelDebug
 }
 
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {

--- a/internal/qlog/courselog/handler_test.go
+++ b/internal/qlog/courselog/handler_test.go
@@ -1,0 +1,104 @@
+package courselog
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+func TestHandlerDropsRecordsWithoutMarker(t *testing.T) {
+	store, _ := newTestStore(t)
+	logger := slog.New(NewHandler(store))
+	logger.Info("no course scope")
+	logger.With(label.CourseID, uint64(1)).Info("course id but no marker")
+
+	entries, err := os.ReadDir(store.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("store directory has entries %v, want none: unmarked records must be dropped", entries)
+	}
+}
+
+func TestHandlerRoutesMarkedRecords(t *testing.T) {
+	store, _ := newTestStore(t)
+	logger := slog.New(NewHandler(store))
+	scoped := logger.With(label.CourseID, uint64(42), label.CourseCode, "DAT520", label.CourseLog, "dat520-2026")
+	scoped.Info("hello", "extra", "value")
+
+	entry := readSingleEntry(t, store, "dat520-2026")
+	if entry["msg"] != "hello" {
+		t.Errorf("msg = %v, want %q", entry["msg"], "hello")
+	}
+	if entry["extra"] != "value" {
+		t.Errorf("extra = %v, want %q", entry["extra"], "value")
+	}
+	if entry[label.CourseID] != float64(42) {
+		t.Errorf("course_id = %v, want 42", entry[label.CourseID])
+	}
+	if entry[label.CourseCode] != "DAT520" {
+		t.Errorf("course_code = %v, want DAT520", entry[label.CourseCode])
+	}
+	if _, ok := entry[label.CourseLog]; ok {
+		t.Errorf("course log entry carries the internal %q marker, want it stripped", label.CourseLog)
+	}
+}
+
+// TestHandlerPendingAttrsReplayedOnceMarkerAppears guards that an attribute
+// attached before the course marker, such as rpc_method on every request, is
+// not lost once a later scope in the same chain marks it for the course log.
+func TestHandlerPendingAttrsReplayedOnceMarkerAppears(t *testing.T) {
+	store, _ := newTestStore(t)
+	logger := slog.New(NewHandler(store))
+	scoped := logger.With("rpc_method", "/qf.QuickFeedService/UpdateAssignments").
+		With(label.CourseID, uint64(1), label.CourseCode, "DAT520", label.CourseLog, "dat520-2026")
+	scoped.Info("scoped record")
+
+	entry := readSingleEntry(t, store, "dat520-2026")
+	if entry["rpc_method"] != "/qf.QuickFeedService/UpdateAssignments" {
+		t.Errorf("rpc_method = %v, want the attribute attached before the marker", entry["rpc_method"])
+	}
+}
+
+func TestHandlerTruncatesOversizedFields(t *testing.T) {
+	store, _ := newTestStore(t)
+	logger := slog.New(NewHandler(store)).With(label.CourseID, uint64(1), label.CourseCode, "DAT520", label.CourseLog, "dat520-2026")
+	big := strings.Repeat("x", maxFieldBytes+1)
+	logger.Info("test output", "output", big)
+
+	entry := readSingleEntry(t, store, "dat520-2026")
+	output, ok := entry["output"].(string)
+	if !ok {
+		t.Fatalf("output = %v (%T), want string", entry["output"], entry["output"])
+	}
+	if len(output) != maxFieldBytes {
+		t.Errorf("len(output) = %d, want %d", len(output), maxFieldBytes)
+	}
+	if entry[label.Truncated] != true {
+		t.Errorf("truncated = %v, want true", entry[label.Truncated])
+	}
+}
+
+// readSingleEntry reads and decodes the single JSONL record expected in
+// org's log file for the current UTC date.
+func readSingleEntry(t *testing.T, store *Store, org string) map[string]any {
+	t.Helper()
+	date := time.Now().UTC().Format(dateLayout)
+	data, err := os.ReadFile(filepath.Join(store.dir, org, date+".jsonl"))
+	if err != nil {
+		t.Fatalf("reading course log: %v", err)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+		t.Fatalf("unmarshal course log line %q: %v", data, err)
+	}
+	return entry
+}

--- a/internal/qlog/courselog/store.go
+++ b/internal/qlog/courselog/store.go
@@ -1,0 +1,243 @@
+// Package courselog stores structured log records scoped to a course, so
+// teachers can review webhook processing, CI and Docker output, and course
+// operations without operator access to the shared process log.
+//
+// Store holds one newline-delimited JSON file per course per UTC day, under
+// <dir>/<organization>/<date>.jsonl. A single Store instance serves every
+// course for the lifetime of the process: courses are registered lazily, on
+// their first write, so a course created after the server started requires
+// no restart before it starts logging.
+package courselog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+// retention is how long a course's date files are kept before being removed.
+const retention = 14 * 24 * time.Hour
+
+const dateLayout = "2006-01-02"
+
+// cleanupInterval is how often the retention sweep runs after startup.
+const cleanupInterval = 24 * time.Hour
+
+// Store manages the on-disk course log files under a single root directory.
+// One Store instance serves every course for the lifetime of the process;
+// courses are registered lazily, on their first write, so a course created
+// after the process started requires no restart.
+type Store struct {
+	dir      string
+	operator *slog.Logger
+	now      func() time.Time // overridden in tests to exercise date rollover without waiting for it
+
+	mu      sync.Mutex // guards courses; each course's own file is guarded by its courseFile
+	courses map[string]*courseFile
+
+	stop    chan struct{}
+	stopped chan struct{}
+}
+
+// courseFile holds the currently open file for one course and the UTC date
+// it covers. Access is serialized by mu, so a course's records are written in
+// order even under concurrent logging.
+type courseFile struct {
+	mu   sync.Mutex
+	file *os.File
+	date string
+}
+
+// NewStore creates dir if it does not already exist, removes any date files
+// already past retention, and starts a daily cleanup loop. Call Close to stop
+// the loop and release open file handles.
+func NewStore(dir string, operator *slog.Logger) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("creating course log directory: %w", err)
+	}
+	s := &Store{
+		dir:      dir,
+		operator: operator,
+		now:      time.Now,
+		courses:  make(map[string]*courseFile),
+		stop:     make(chan struct{}),
+		stopped:  make(chan struct{}),
+	}
+	s.cleanupExpired()
+	go s.cleanupLoop()
+	return s, nil
+}
+
+func (s *Store) cleanupLoop() {
+	defer close(s.stopped)
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.cleanupExpired()
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+// Close stops the retention loop and closes every open course file.
+func (s *Store) Close() error {
+	close(s.stop)
+	<-s.stopped
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var errs []error
+	for _, cf := range s.courses {
+		cf.mu.Lock()
+		if cf.file != nil {
+			if err := cf.file.Close(); err != nil {
+				errs = append(errs, err)
+			}
+			cf.file = nil
+		}
+		cf.mu.Unlock()
+	}
+	return errors.Join(errs...)
+}
+
+// Writer returns an io.Writer that appends to org's current date file,
+// creating the course's directory and file on first use. org is sanitized
+// before use as a path element, so it cannot escape the store's directory.
+func (s *Store) Writer(org string) io.Writer {
+	return &courseWriter{store: s, org: sanitize(org)}
+}
+
+type courseWriter struct {
+	store *Store
+	org   string
+}
+
+func (w *courseWriter) Write(p []byte) (int, error) {
+	return w.store.write(w.org, p)
+}
+
+func (s *Store) write(org string, p []byte) (int, error) {
+	cf := s.courseFileFor(org)
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+
+	today := s.now().UTC().Format(dateLayout)
+	if cf.file == nil || cf.date != today {
+		if cf.file != nil {
+			_ = cf.file.Close()
+		}
+		f, err := s.openFile(org, today)
+		if err != nil {
+			s.reportError(org, "opening course log file", err)
+			return 0, err
+		}
+		cf.file = f
+		cf.date = today
+	}
+	n, err := cf.file.Write(p)
+	if err != nil {
+		s.reportError(org, "writing course log record", err)
+	}
+	return n, err
+}
+
+// courseFileFor returns org's file state, registering the course on its
+// first appearance. This is the only place a course is added to the store:
+// no course needs to be known when the Store is constructed, and none needs
+// a restart to start logging after it is created.
+func (s *Store) courseFileFor(org string) *courseFile {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cf, ok := s.courses[org]
+	if !ok {
+		cf = &courseFile{}
+		s.courses[org] = cf
+	}
+	return cf
+}
+
+func (s *Store) openFile(org, date string) (*os.File, error) {
+	dir := filepath.Join(s.dir, org)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, date+".jsonl")
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}
+
+func (s *Store) reportError(org, action string, err error) {
+	s.operator.Error("course log store: "+action, label.Organization, org, label.Error, err)
+}
+
+// cleanupExpired removes date files older than the retention window, across
+// every course directory.
+func (s *Store) cleanupExpired() {
+	cutoff := s.now().UTC().Add(-retention)
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		s.operator.Error("course log store: listing course directories", label.Error, err)
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			s.cleanupCourseDir(entry.Name(), cutoff)
+		}
+	}
+}
+
+func (s *Store) cleanupCourseDir(org string, cutoff time.Time) {
+	dir := filepath.Join(s.dir, org)
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		s.reportError(org, "listing course log files", err)
+		return
+	}
+	for _, f := range files {
+		date, ok := strings.CutSuffix(f.Name(), ".jsonl")
+		if !ok {
+			continue
+		}
+		t, err := time.Parse(dateLayout, date)
+		if err != nil {
+			// Not a date file this store wrote; leave it alone.
+			continue
+		}
+		if t.Before(cutoff) {
+			if err := os.Remove(filepath.Join(dir, f.Name())); err != nil {
+				s.reportError(org, "removing expired course log file", err)
+			}
+		}
+	}
+}
+
+// sanitize restricts org to characters safe as a single path element,
+// replacing anything else with '_', so a course's SCM organization name can
+// never escape the course log directory.
+func sanitize(org string) string {
+	var b strings.Builder
+	for _, r := range org {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	switch sanitized := b.String(); sanitized {
+	case "", ".", "..":
+		return "_"
+	default:
+		return sanitized
+	}
+}

--- a/internal/qlog/courselog/store_test.go
+++ b/internal/qlog/courselog/store_test.go
@@ -1,0 +1,245 @@
+package courselog
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestStore returns a Store rooted at a temporary directory, along with
+// the buffer its operator logger writes to, and registers its cleanup.
+func newTestStore(t *testing.T) (*Store, *bytes.Buffer) {
+	t.Helper()
+	var operatorOutput bytes.Buffer
+	operator := slog.New(slog.NewTextHandler(&operatorOutput, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	store, err := NewStore(t.TempDir(), operator)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return store, &operatorOutput
+}
+
+func TestStoreCreatesDirectoryAndFileLazily(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Writer("dat520-2026").Write([]byte("line1\n")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	date := time.Now().UTC().Format(dateLayout)
+	path := filepath.Join(store.dir, "dat520-2026", date+".jsonl")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", path, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %v, want 0600", perm)
+	}
+	dirInfo, err := os.Stat(filepath.Join(store.dir, "dat520-2026"))
+	if err != nil {
+		t.Fatalf("Stat(course dir) error = %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o750 {
+		t.Errorf("directory mode = %v, want 0750", perm)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "line1\n" {
+		t.Errorf("file content = %q, want %q", got, "line1\n")
+	}
+}
+
+// TestStoreRegistersCourseCreatedAfterConstruction guards the property that
+// makes a course log usable without a server restart: a course the Store has
+// never seen still gets a directory and file on its very first write.
+func TestStoreRegistersCourseCreatedAfterConstruction(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Writer("brand-new-2026").Write([]byte("hello\n")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(store.dir, "brand-new-2026")); err != nil {
+		t.Errorf("course directory not created for a course unknown at startup: %v", err)
+	}
+}
+
+func TestStorePerCourseIsolation(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Writer("course-a").Write([]byte("a\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Writer("course-b").Write([]byte("b\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	date := time.Now().UTC().Format(dateLayout)
+	gotA, err := os.ReadFile(filepath.Join(store.dir, "course-a", date+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := os.ReadFile(filepath.Join(store.dir, "course-b", date+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotA) != "a\n" || string(gotB) != "b\n" {
+		t.Errorf("course-a = %q, course-b = %q, want isolated per-course contents", gotA, gotB)
+	}
+}
+
+func TestStoreConcurrentWrites(t *testing.T) {
+	store, _ := newTestStore(t)
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			if _, err := fmt.Fprintf(store.Writer("dat520-2026"), "line-%d\n", i); err != nil {
+				t.Errorf("Write() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	date := time.Now().UTC().Format(dateLayout)
+	got, err := os.ReadFile(filepath.Join(store.dir, "dat520-2026", date+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(got), "\n"), "\n")
+	if len(lines) != n {
+		t.Errorf("got %d lines, want %d; concurrent writes may have interleaved or been lost", len(lines), n)
+	}
+}
+
+func TestStoreDateRollover(t *testing.T) {
+	store, _ := newTestStore(t)
+	day1 := time.Date(2026, 1, 1, 23, 59, 0, 0, time.UTC)
+	store.now = func() time.Time { return day1 }
+	if _, err := store.Writer("dat520-2026").Write([]byte("day1\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	day2 := day1.Add(2 * time.Minute) // crosses into 2026-01-02 UTC
+	store.now = func() time.Time { return day2 }
+	if _, err := store.Writer("dat520-2026").Write([]byte("day2\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	file1, err := os.ReadFile(filepath.Join(store.dir, "dat520-2026", "2026-01-01.jsonl"))
+	if err != nil {
+		t.Fatalf("day-1 file: %v", err)
+	}
+	file2, err := os.ReadFile(filepath.Join(store.dir, "dat520-2026", "2026-01-02.jsonl"))
+	if err != nil {
+		t.Fatalf("day-2 file: %v", err)
+	}
+	if string(file1) != "day1\n" || string(file2) != "day2\n" {
+		t.Errorf("file1 = %q, file2 = %q, want separate contents per UTC day", file1, file2)
+	}
+}
+
+func TestStoreRetentionCleanup(t *testing.T) {
+	store, _ := newTestStore(t)
+	courseDir := filepath.Join(store.dir, "dat520-2026")
+	if err := os.MkdirAll(courseDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	expired := filepath.Join(courseDir, "2000-01-01.jsonl")
+	if err := os.WriteFile(expired, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recent := filepath.Join(courseDir, time.Now().UTC().Format(dateLayout)+".jsonl")
+	if err := os.WriteFile(recent, []byte("new\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	notADateFile := filepath.Join(courseDir, "not-a-date.jsonl")
+	if err := os.WriteFile(notADateFile, []byte("keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store.cleanupExpired()
+
+	if _, err := os.Stat(expired); !os.IsNotExist(err) {
+		t.Errorf("Stat(expired) error = %v, want the expired file removed", err)
+	}
+	if _, err := os.Stat(recent); err != nil {
+		t.Errorf("recent file was removed: %v", err)
+	}
+	if _, err := os.Stat(notADateFile); err != nil {
+		t.Errorf("non-date file was removed: %v", err)
+	}
+}
+
+func TestStoreCloseReleasesHandles(t *testing.T) {
+	var operatorOutput bytes.Buffer
+	operator := slog.New(slog.NewTextHandler(&operatorOutput, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	store, err := NewStore(t.TempDir(), operator)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if _, err := store.Writer("dat520-2026").Write([]byte("line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if cf := store.courses["dat520-2026"]; cf.file != nil {
+		t.Errorf("file handle not released after Close()")
+	}
+}
+
+// TestStoreErrorsReachOperatorWithoutRecursion guards that a write failure is
+// reported through the plain operator logger, not one carrying the course
+// marker, which would otherwise recurse back into the handler that calls it.
+func TestStoreErrorsReachOperatorWithoutRecursion(t *testing.T) {
+	store, operatorOutput := newTestStore(t)
+	const org = "dat520-2026"
+	// A regular file where the course's directory should go makes MkdirAll
+	// fail regardless of the test's privileges, unlike a permission check.
+	blocked := filepath.Join(store.dir, org)
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Writer(org).Write([]byte("line\n")); err == nil {
+		t.Fatal("Write() error = nil, want failure creating the course directory")
+	}
+
+	got := operatorOutput.String()
+	if !strings.Contains(got, "course log store") {
+		t.Errorf("operator log = %q, does not report the store failure", got)
+	}
+	if !strings.Contains(got, org) {
+		t.Errorf("operator log = %q, does not identify the course", got)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"dat520-2026", "dat520-2026"},
+		{"", "_"},
+		{".", "_"},
+		{"..", "_"},
+		{"../../etc", ".._.._etc"},
+		{"a/b", "a_b"},
+	}
+	for _, test := range tests {
+		if got := sanitize(test.in); got != test.want {
+			t.Errorf("sanitize(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}

--- a/internal/qlog/label/label.go
+++ b/internal/qlog/label/label.go
@@ -9,6 +9,11 @@
 // since slog records every attribute it is given, including duplicate keys.
 // When a handler acts on some other user than the caller, use TargetUser and
 // TargetUserID to keep the two apart.
+//
+// CourseLog opts a logger scope into the course-scoped log sink; set it only
+// through qlog.WithCourse, from a database-loaded course, never from request
+// data, since anything reaching a scope carrying it becomes visible to that
+// course's teachers.
 package label
 
 const (
@@ -19,6 +24,7 @@ const (
 	Commit         = "commit"
 	CourseCode     = "course_code"
 	CourseID       = "course_id"
+	CourseLog      = "course_log" // Marks a scope whose records are copied to the named course's log; value is the course's SCM organization name.
 	Duration       = "duration"
 	Error          = "error"
 	Group          = "group"
@@ -34,6 +40,7 @@ const (
 	SubmissionID   = "submission_id"
 	TargetUser     = "target_user"    // SCM login of the user acted upon.
 	TargetUserID   = "target_user_id" // QuickFeed database ID of the user acted upon.
+	Truncated      = "truncated"      // Set on a course log record whose message or an attribute was cut down to size.
 	User           = "user"           // SCM login or another human-readable user identifier.
 	UserID         = "user_id"        // QuickFeed database user ID.
 )

--- a/internal/qlog/logger.go
+++ b/internal/qlog/logger.go
@@ -14,39 +14,55 @@ type contextKey struct{}
 
 // New returns a structured logger that writes debug and higher-level records to w.
 func New(w io.Writer) *slog.Logger {
-	root := env.Root()
 	handler := slog.NewTextHandler(w, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
-			if attr.Key != slog.SourceKey {
-				return attr
-			}
-			source, ok := attr.Value.Any().(*slog.Source)
-			if !ok {
-				return attr
-			}
-			// Keep the recorded path for records that do not originate below
-			// root, such as those from the standard library or the module
-			// cache, or when the paths recorded by the compiler differ from
-			// root; a relative path would then be a walk-up, not a shorthand.
-			path, err := filepath.Rel(root, source.File)
-			if err != nil || strings.HasPrefix(path, "..") {
-				return attr
-			}
-			return slog.Any(slog.SourceKey, &slog.Source{
-				Function: source.Function,
-				File:     path,
-				Line:     source.Line,
-			})
-		},
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: RelativeSource(env.Root()),
 	})
 	return slog.New(handler)
+}
+
+// RelativeSource returns a ReplaceAttr function that rewrites the slog source
+// attribute's file path to be relative to root, so it stays readable outside
+// the machine that produced it. Handlers that write structured records to
+// storage, such as the course log sink, reuse this so their "source" field
+// matches the process logger's.
+func RelativeSource(root string) func(groups []string, attr slog.Attr) slog.Attr {
+	return func(_ []string, attr slog.Attr) slog.Attr {
+		if attr.Key != slog.SourceKey {
+			return attr
+		}
+		source, ok := attr.Value.Any().(*slog.Source)
+		if !ok {
+			return attr
+		}
+		// Keep the recorded path for records that do not originate below
+		// root, such as those from the standard library or the module
+		// cache, or when the paths recorded by the compiler differ from
+		// root; a relative path would then be a walk-up, not a shorthand.
+		path, err := filepath.Rel(root, source.File)
+		if err != nil || strings.HasPrefix(path, "..") {
+			return attr
+		}
+		return slog.Any(slog.SourceKey, &slog.Source{
+			Function: source.Function,
+			File:     path,
+			Line:     source.Line,
+		})
+	}
 }
 
 // SetDefault installs logger as the process-wide fallback logger.
 func SetDefault(logger *slog.Logger) {
 	slog.SetDefault(logger)
+}
+
+// WithSink returns a logger that writes every record to logger's handler and,
+// in addition, to sink. Use it to fan records carrying an opt-in scope, such
+// as the one WithCourse attaches, out to a secondary handler without
+// affecting where records land by default.
+func WithSink(logger *slog.Logger, sink slog.Handler) *slog.Logger {
+	return slog.New(slog.NewMultiHandler(logger.Handler(), sink))
 }
 
 // NewContext returns a context carrying logger.

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/quickfeed/quickfeed/doc"
 	"github.com/quickfeed/quickfeed/internal/env"
 	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qlog/courselog"
 	"github.com/quickfeed/quickfeed/scm"
 	"github.com/quickfeed/quickfeed/web"
 	"github.com/quickfeed/quickfeed/web/auth"
@@ -126,7 +127,12 @@ func initWebServer(dbFile, public string) (http.Handler, func(), error) {
 	q := &quickfeed{}
 	var err error
 
-	q.logger = qlog.New(os.Stderr)
+	operator := qlog.New(os.Stderr)
+	q.courseLogs, err = courselog.NewStore(env.CourseLogDir(), operator)
+	if err != nil {
+		return nil, q.cleanup, fmt.Errorf("setting up course log store: %w", err)
+	}
+	q.logger = qlog.WithSink(operator, courselog.NewHandler(q.courseLogs))
 	qlog.SetDefault(q.logger)
 
 	q.db, err = database.NewGormDB(dbFile, q.logger)
@@ -157,9 +163,10 @@ func initWebServer(dbFile, public string) (http.Handler, func(), error) {
 }
 
 type quickfeed struct {
-	logger *slog.Logger
-	db     *database.GormDB
-	runner *ci.Docker
+	logger     *slog.Logger
+	db         *database.GormDB
+	runner     *ci.Docker
+	courseLogs *courselog.Store
 }
 
 func (q *quickfeed) cleanup() {
@@ -172,6 +179,11 @@ func (q *quickfeed) cleanup() {
 	if q.db != nil {
 		if e := q.db.Close(); e != nil {
 			err = errors.Join(err, fmt.Errorf("closing database: %w", e))
+		}
+	}
+	if q.courseLogs != nil {
+		if e := q.courseLogs.Close(); e != nil {
+			err = errors.Join(err, fmt.Errorf("closing course log store: %w", e))
 		}
 	}
 	if err != nil {

--- a/web/course_log_sink_test.go
+++ b/web/course_log_sink_test.go
@@ -1,0 +1,51 @@
+package web_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qlog/courselog"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
+	"github.com/quickfeed/quickfeed/web"
+)
+
+// TestCourseLogSinkNotOptedIn guards that an ordinary authenticated,
+// authorized RPC that never calls qlog.WithCourse writes nothing to the
+// course log store: the course_id the interceptors attach on their own must
+// not, by itself, opt a scope into a course's log.
+func TestCourseLogSinkNotOptedIn(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	store, err := courselog.NewStore(dir, qtest.Logger(t))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	}()
+	sinkLogger := qlog.WithSink(qtest.Logger(t), courselog.NewHandler(store))
+
+	client := web.NewMockClient(t, db, scm.WithMockOrgs(), web.WithInterceptors(), web.WithLogger(sinkLogger))
+	teacher := qtest.CreateFakeUser(t, db)
+	course := qtest.MockCourses[0]
+	qtest.CreateCourse(t, db, teacher, course)
+
+	if _, err := client.GetAssignments(client.Context(t, teacher), &qf.CourseRequest{CourseID: course.GetID()}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("course log directory has entries %v, want none: GetAssignments does not opt into the course log", entries)
+	}
+}

--- a/web/hooks/installation.go
+++ b/web/hooks/installation.go
@@ -37,9 +37,11 @@ func (wh GitHubWebHook) handleInstallationCreated(ctx context.Context, event *gi
 		Year:                defaultYear(now),
 	}
 
+	// Scope the logger with the course's organization and user, since
+	// the course does not exist yet; we use qlog.WithCourse below to
+	// add the course code and ID.
 	ctx, logger = qlog.WithLogger(
 		ctx,
-		label.CourseCode, course.GetCode(),
 		label.Organization, orgName,
 		label.User, courseCreator.GetLogin(),
 	)

--- a/web/hooks/installation.go
+++ b/web/hooks/installation.go
@@ -54,7 +54,9 @@ func (wh GitHubWebHook) handleInstallationCreated(ctx context.Context, event *gi
 		logger.Error("failed to create course", label.Error, err)
 		return
 	}
-	logger.Info("created course", label.CourseID, c.GetID())
+	// The course now exists, so its records can be copied to its log.
+	_, logger = qlog.WithCourse(ctx, c)
+	logger.Info("created course")
 
 	if err := wh.tm.Add(courseCreator.GetID()); err != nil {
 		logger.Error("failed to schedule token refresh", label.Error, err)

--- a/web/hooks/pull_request.go
+++ b/web/hooks/pull_request.go
@@ -133,7 +133,7 @@ func (wh GitHubWebHook) handlePullRequestReview(ctx context.Context, payload *gi
 		logger.Error("failed to get course", label.Error, err)
 		return
 	}
-	logger = logger.With(label.CourseID, course.GetID(), label.CourseCode, course.GetCode())
+	logger = logger.With(qlog.CourseAttrs(course)...)
 	user, err := wh.db.GetUserByRemoteIdentity(uint64(payload.GetSender().GetID()))
 	if err != nil {
 		logger.Error("failed to get review user", label.Error, err)
@@ -171,17 +171,17 @@ func (wh GitHubWebHook) handlePullRequestOpened(ctx context.Context, payload *gi
 		logger.Error("failed to get pull request repository", label.Error, err)
 		return
 	}
-	ctx, logger = qlog.WithLogger(ctx, label.RepositoryType, repo.GetRepoType().String())
-	if !repo.IsGroupRepo() {
-		logger.Debug("ignoring pull request for non-group repository")
-		return
-	}
 	// Add course scope to the logger only if the event is known to be relevant;
 	// a missing course should not abort the handler.
 	if course, err := wh.db.GetCourseByOrganizationID(repo.GetScmOrganizationID()); err == nil {
-		ctx, logger = qlog.WithLogger(ctx, label.CourseID, course.GetID(), label.CourseCode, course.GetCode())
+		ctx, logger = qlog.WithCourse(ctx, course, label.RepositoryType, repo.GetRepoType().String())
 	} else {
+		ctx, logger = qlog.WithLogger(ctx, label.RepositoryType, repo.GetRepoType().String())
 		logger.Debug("pull request course not found", label.Error, err)
+	}
+	if !repo.IsGroupRepo() {
+		logger.Debug("ignoring pull request for non-group repository")
+		return
 	}
 	issue, err := findIssue(payload.GetPullRequest().GetBody(), repo.GetIssues())
 	if err != nil {
@@ -207,9 +207,10 @@ func (wh GitHubWebHook) handlePullRequestClosed(ctx context.Context, payload *gi
 	// Add repository and course scope to logger; a repository or course unknown to QuickFeed
 	// need not abort the handler, since the pull request lookup below reports that case.
 	if repo, err := wh.getRepository(payload.GetRepo().GetID()); err == nil {
-		logger = logger.With(label.RepositoryType, repo.GetRepoType().String())
 		if course, err := wh.db.GetCourseByOrganizationID(repo.GetScmOrganizationID()); err == nil {
-			logger = logger.With(label.CourseID, course.GetID(), label.CourseCode, course.GetCode())
+			logger = logger.With(append(qlog.CourseAttrs(course), label.RepositoryType, repo.GetRepoType().String())...)
+		} else {
+			logger = logger.With(label.RepositoryType, repo.GetRepoType().String())
 		}
 	}
 

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -45,11 +45,7 @@ func (wh GitHubWebHook) handlePush(ctx context.Context, payload *github.PushEven
 		logger.Error("failed to get course from database", label.Error, err)
 		return
 	}
-	ctx, logger = qlog.WithLogger(ctx,
-		label.CourseID, course.GetID(),
-		label.CourseCode, course.GetCode(),
-		label.Organization, course.GetScmOrganizationName(),
-	)
+	ctx, logger = qlog.WithCourse(ctx, course)
 	logger.Debug("resolved push course")
 
 	if repo.IsStudentRepo() {

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -494,8 +494,10 @@ func (s *QuickFeedService) UpdateAssignments(ctx context.Context, in *qf.CourseR
 		qlog.FromContext(ctx).Error("failed to get course", label.Error, err)
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("course not found"))
 	}
-	// Scope the logger to the course
-	ctx, logger := qlog.WithLogger(ctx, label.CourseCode, course.GetCode(), label.Organization, course.GetScmOrganizationName())
+	// Scope the remainder of the method to the course; UpdateFromTestsRepo and
+	// the clone below add only their own repository scope on top of this.
+	// The course ID comes from the request logger; see enrichRequestLogger.
+	ctx, logger := qlog.WithCourseLog(ctx, course)
 	scmClient, err := s.getSCM(ctx, course.GetScmOrganizationName())
 	if err != nil {
 		logger.Error("failed to create SCM client", label.Error, err)

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -49,8 +49,8 @@ func (s *QuickFeedService) internalRebuildSubmission(ctx context.Context, reques
 	}
 	// Scope the rebuild; RunTests and RecordResults log under the same context.
 	// The course ID comes from the request logger; see enrichRequestLogger.
-	ctx, logger := qlog.WithLogger(ctx,
-		label.CourseCode, course.GetCode(),
+	ctx, logger := qlog.WithCourseLog(ctx,
+		course,
 		label.Repository, repo.Name(),
 		label.RepositoryType, repo.GetRepoType().String(),
 		label.Assignment, assignment.GetName(),
@@ -95,7 +95,20 @@ func (s *QuickFeedService) internalRebuildAllSubmissions(ctx context.Context, re
 	if err != nil {
 		return err
 	}
-	logger := qlog.FromContext(ctx).With(label.AssignmentID, request.GetAssignmentID())
+	assignment, err := s.db.GetAssignment(&qf.Assignment{ID: request.GetAssignmentID()})
+	if err != nil {
+		return err
+	}
+	course, err := s.db.GetCourse(assignment.GetCourseID())
+	if err != nil {
+		return err
+	}
+	// logger is scoped to the course so this batch's own summary and failure
+	// records land in the course log too, but ctx is left unscoped: each
+	// rebuild below derives and attaches this same course scope for itself
+	// (see internalRebuildSubmission), and attaching it here as well would
+	// duplicate it in every one of their records.
+	_, logger := qlog.WithCourseLog(ctx, course, label.AssignmentID, request.GetAssignmentID())
 	logger.Debug("rebuilding all submissions")
 	start := time.Now()
 


### PR DESCRIPTION
Adds a `slog` handler that copies course-scoped log records, such as webhook processing, CI and Docker output, teacher-triggered rebuilds and assignment syncs, to per-course files teachers can read, without exposing the shared operator log. This is the storage layer only: no new API surface yet.

## What's new

**`internal/qlog`** — `WithCourse`/`WithCourseLog` scope a logger to a course, attaching `course_id`, `course_code`, and an opt-in `course_log` marker (the course's SCM organization name) that a later handler keys a course's log file on. `WithCourseLog` is the same minus `course_id`, for the RPC call paths where the interceptors already attached it from the caller's claims. `CourseAttrs` returns the same attributes for callers extending an existing logger rather than a context. `WithSink` fans a logger out to a second handler with `slog.NewMultiHandler`. `RelativeSource` is `New`'s source-path rewriter, pulled out for reuse.

**`internal/qlog/courselog`** — `Store` keeps one newline-delimited JSON file per course per UTC day under `<dir>/<organization>/<date>.jsonl` (directories `0750`, files `0600`). It's a single process-wide instance: a course's directory and file are created lazily on its first write, so a course created after the server started needs no restart. Retention is 14 days, swept at startup, at daily rollover, and by a ticker `Close` stops. Store failures go to a plain operator logger that never carries the marker, so reporting a failure can't recurse.

`Handler` copies a record only once a scope's `WithAttrs` call has carried the marker; attributes attached earlier (e.g. `rpc_method`) are held pending and replayed once it appears. Everything else is dropped. A message or attribute over 64 KiB is cut down to size and marked `truncated`.

**Wired in** — `main.go` builds the store at `$QUICKFEED/logs/courses` and fans the process logger through it; the store closes alongside the database and runner.

**Opted in** — `web/hooks/push.go`, `pull_request.go`, `installation.go` (after the course is persisted); `web/rebuild.go`'s single-submission and rebuild-all paths; `web/quickfeed_service.go`'s `UpdateAssignments`. `ci/run_tests.go`, `assignments/`, `courses_new.go`, and `sync.go` needed no changes — they always run under a `ctx` one of the above already scoped.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>