### PR TITLE
scm: retry org invitation accept when GitHub job is still scheduled

### DIFF
--- a/scm/github.go
+++ b/scm/github.go
@@ -283,6 +283,8 @@ func (s *GithubSCM) UpdateEnrollment(ctx context.Context, opt *UpdateEnrollmentO
 		// Step 2: Accept the org invitation so user becomes an org member.
 		// Once they are an org member, adding them as collaborator to org-owned
 		// repos grants access immediately without requiring further invitations.
+		// GitHub creates the invitation asynchronously; acceptOrgInvitation
+		// retries if the accept call returns "job scheduled on GitHub side".
 		if err := s.acceptOrgInvitation(ctx, &InvitationOptions{
 			Login:       opt.User,
 			Owner:       org.GetScmOrganizationName(),

--- a/scm/github_invite.go
+++ b/scm/github_invite.go
@@ -2,20 +2,61 @@ package scm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/go-github/v62/github"
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+)
+
+// GitHub creates organization invitations asynchronously. The first attempt to
+// accept one often returns github.AcceptedError ("job scheduled on GitHub side").
+// These defaults match waitForRepository: a few seconds is typical; the cap
+// covers slower GitHub jobs without hanging the RPC indefinitely.
+// Tests may shorten these.
+var (
+	waitForInviteMaxAttempts  = 10
+	waitForInviteInitialDelay = 1 * time.Second
+	waitForInviteMaxDelay     = 5 * time.Second
 )
 
 // acceptOrgInvitation accepts an organization membership invitation on behalf of the user.
+// GitHub may return github.AcceptedError until the invitation job has finished;
+// this retries with exponential backoff until the invitation is ready.
 func (s *GithubSCM) acceptOrgInvitation(ctx context.Context, opt *InvitationOptions) error {
 	if !opt.valid() {
 		return fmt.Errorf("invalid options: %+v", opt)
 	}
 	userSCM := s.createUserClientFn(opt.AccessToken)
 	state := "active"
-	if _, _, err := userSCM.Organizations.EditOrgMembership(ctx, "", opt.Owner, &github.Membership{State: &state}); err != nil {
-		return fmt.Errorf("accepting invitation for %s to organization %s: %w", opt.Login, opt.Owner, err)
+	logger := qlog.FromContext(ctx).With(label.TargetUser, opt.Login, label.Organization, opt.Owner)
+	delay := waitForInviteInitialDelay
+	var err error
+	for attempt := range waitForInviteMaxAttempts {
+		_, _, err = userSCM.Organizations.EditOrgMembership(ctx, "", opt.Owner, &github.Membership{State: &state})
+		if err == nil {
+			if attempt > 0 {
+				logger.Debug("organization invitation accepted", "attempts", attempt+1)
+			}
+			return nil
+		}
+		if !isGitHubAccepted(err) {
+			return fmt.Errorf("accepting invitation for %s to organization %s: %w", opt.Login, opt.Owner, err)
+		}
+		logger.Debug("organization invitation not ready", "attempt", attempt+1, "max_attempts", waitForInviteMaxAttempts, "delay", delay)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("accepting invitation for %s to organization %s: %w", opt.Login, opt.Owner, ctx.Err())
+		case <-time.After(delay):
+		}
+		delay = min(delay*2, waitForInviteMaxDelay)
 	}
-	return nil
+	return fmt.Errorf("accepting invitation for %s to organization %s: invitation not ready after %d attempts: %w", opt.Login, opt.Owner, waitForInviteMaxAttempts, err)
+}
+
+func isGitHubAccepted(err error) bool {
+	var accepted *github.AcceptedError
+	return errors.As(err, &accepted)
 }

--- a/scm/github_invite_test.go
+++ b/scm/github_invite_test.go
@@ -1,0 +1,133 @@
+package scm
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/go-github/v62/github"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+)
+
+func restoreInviteWait(t *testing.T) {
+	t.Helper()
+	attempts, initial, maxDelay := waitForInviteMaxAttempts, waitForInviteInitialDelay, waitForInviteMaxDelay
+	t.Cleanup(func() {
+		waitForInviteMaxAttempts = attempts
+		waitForInviteInitialDelay = initial
+		waitForInviteMaxDelay = maxDelay
+	})
+}
+
+func TestAcceptOrgInvitationRetriesAccepted(t *testing.T) {
+	restoreInviteWait(t)
+	waitForInviteMaxAttempts = 5
+	waitForInviteInitialDelay = time.Millisecond
+	waitForInviteMaxDelay = time.Millisecond
+
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling, State: new("pending")},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo), WithMembers(members...), WithInvitationNotReady(2))
+
+	if err := s.acceptOrgInvitation(context.Background(), &InvitationOptions{
+		Login:       "meling",
+		Owner:       "foo",
+		AccessToken: "dummy",
+	}); err != nil {
+		t.Fatalf("acceptOrgInvitation() after retries: %v", err)
+	}
+}
+
+func TestAcceptOrgInvitationGivesUp(t *testing.T) {
+	restoreInviteWait(t)
+	waitForInviteMaxAttempts = 3
+	waitForInviteInitialDelay = time.Millisecond
+	waitForInviteMaxDelay = time.Millisecond
+
+	members := []github.Membership{
+		{Organization: &ghOrgFoo, User: &meling, State: new("pending")},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo), WithMembers(members...), WithInvitationNotReady(10))
+
+	err := s.acceptOrgInvitation(context.Background(), &InvitationOptions{
+		Login:       "meling",
+		Owner:       "foo",
+		AccessToken: "dummy",
+	})
+	if err == nil {
+		t.Fatal("acceptOrgInvitation() succeeded, want error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "invitation not ready after 3 attempts") {
+		t.Errorf("acceptOrgInvitation() error = %v, want exhausted-retries message", err)
+	}
+	if !isGitHubAccepted(err) {
+		t.Errorf("acceptOrgInvitation() error should unwrap to AcceptedError, got %v", err)
+	}
+}
+
+func TestAcceptOrgInvitationDoesNotRetryOtherErrors(t *testing.T) {
+	restoreInviteWait(t)
+	waitForInviteMaxAttempts = 5
+	waitForInviteInitialDelay = 50 * time.Millisecond
+	waitForInviteMaxDelay = 50 * time.Millisecond
+
+	// Org exists but has no membership, so PATCH returns 404, not 202.
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgFoo))
+
+	start := time.Now()
+	err := s.acceptOrgInvitation(context.Background(), &InvitationOptions{
+		Login:       "meling",
+		Owner:       "foo",
+		AccessToken: "dummy",
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("acceptOrgInvitation() succeeded, want not-found error")
+	}
+	if isGitHubAccepted(err) {
+		t.Errorf("acceptOrgInvitation() wrapped AcceptedError, want a hard error: %v", err)
+	}
+	if elapsed >= 50*time.Millisecond {
+		t.Errorf("acceptOrgInvitation() retried a non-accepted error; took %v", elapsed)
+	}
+}
+
+func TestAcceptOrgInvitationInvalidOptions(t *testing.T) {
+	s := NewMockedGithubSCMClient(qtest.Logger(t))
+	if err := s.acceptOrgInvitation(context.Background(), &InvitationOptions{}); err == nil {
+		t.Fatal("acceptOrgInvitation() succeeded, want invalid options error")
+	}
+}
+
+func TestUpdateEnrollmentRetriesInvitation(t *testing.T) {
+	restoreInviteWait(t)
+	waitForInviteMaxAttempts = 5
+	waitForInviteInitialDelay = time.Millisecond
+	waitForInviteMaxDelay = time.Millisecond
+
+	g := map[string]map[string][]github.User{
+		"bar": {
+			"assignments": {},
+			"frank-labs":  {},
+		},
+	}
+	s := NewMockedGithubSCMClient(qtest.Logger(t), WithOrgs(ghOrgBar), WithRepos(repos...), WithGroups(g), WithInvitationNotReady(2))
+	got, err := s.UpdateEnrollment(context.Background(), &UpdateEnrollmentOptions{
+		Organization: "bar",
+		User:         "frank",
+		Status:       qf.Enrollment_STUDENT,
+		AccessToken:  "dummy",
+	})
+	if err != nil {
+		t.Fatalf("UpdateEnrollment() after invitation retries: %v", err)
+	}
+	want := &Repository{Owner: "bar", Repo: "frank-labs"}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Repository{}, "ID")); diff != "" {
+		t.Errorf("UpdateEnrollment() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/scm/github_mock.go
+++ b/scm/github_mock.go
@@ -312,6 +312,13 @@ func NewMockedGithubSCMClient(logger *slog.Logger, opts ...MockOption) *MockedGi
 			membership := mustRead[github.Membership](r.Body)
 			logger.Debug("mock SCM request", routeLabel, replaceArgs(patchUserMembershipsOrgsByOrg, org), "membership", membership)
 
+			// Simulate GitHub's asynchronous invitation job.
+			if s.invitationNotReadyFor > 0 {
+				s.invitationNotReadyFor--
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+
 			// Find the pending membership and activate it
 			found := s.matchOrgFunc(org, func(o github.Organization) {
 				for i, m := range s.members {

--- a/scm/github_mock_opts.go
+++ b/scm/github_mock_opts.go
@@ -10,16 +10,17 @@ import (
 )
 
 type mockOptions struct {
-	orgs       []github.Organization
-	repos      []github.Repository
-	members    []github.Membership
-	groups     map[string]map[string][]github.User                   // map: owner -> repo -> collaborators
-	issues     map[string]map[string][]github.Issue                  // map: owner -> repo -> issues
-	comments   map[string]map[string]map[int64][]github.IssueComment // map: owner -> repo -> issue ID -> comments
-	reviewers  map[string]map[string]map[int]github.ReviewersRequest // map: owner -> repo -> pull requests ID -> reviewers
-	appConfigs map[string]github.AppConfig                           // map: code -> app config
-	aheadBy    map[string]int                                        // map: "owner/repo" -> commits ahead of the upstream assignments repo
-	userID     int64                                                 // counter for generating unique user IDs
+	orgs                  []github.Organization
+	repos                 []github.Repository
+	members               []github.Membership
+	groups                map[string]map[string][]github.User                   // map: owner -> repo -> collaborators
+	issues                map[string]map[string][]github.Issue                  // map: owner -> repo -> issues
+	comments              map[string]map[string]map[int64][]github.IssueComment // map: owner -> repo -> issue ID -> comments
+	reviewers             map[string]map[string]map[int]github.ReviewersRequest // map: owner -> repo -> pull requests ID -> reviewers
+	appConfigs            map[string]github.AppConfig                           // map: code -> app config
+	aheadBy               map[string]int                                        // map: "owner/repo" -> commits ahead of the upstream assignments repo
+	userID                int64                                                 // counter for generating unique user IDs
+	invitationNotReadyFor int                                                   // remaining 202 responses before PATCH /user/memberships/orgs/{org} succeeds
 }
 
 // repoKey is the key used to track per-repository mock state keyed by owner and repository name.
@@ -185,6 +186,14 @@ func WithCommitsAhead(owner, repo string, n int) MockOption {
 func WithMembers(members ...github.Membership) MockOption {
 	return func(opts *mockOptions) {
 		opts.members = append(opts.members, members...)
+	}
+}
+
+// WithInvitationNotReady makes the next n attempts to accept an organization
+// invitation return HTTP 202, matching GitHub's asynchronous invitation job.
+func WithInvitationNotReady(n int) MockOption {
+	return func(opts *mockOptions) {
+		opts.invitationNotReadyFor = n
 	}
 }
 


### PR DESCRIPTION
UpdateEnrollment invites the student to the course org and immediately
accepts that invitation. GitHub creates the invitation asynchronously,
so the accept call often returns AcceptedError on the first attempt and
the teacher has to click Accept again. Retry the accept with the same
backoff used for async forks.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>