### PR TITLE
frontend: restore ESLint and fix what it reports

### DIFF
--- a/public/eslint.config.js
+++ b/public/eslint.config.js
@@ -23,9 +23,11 @@ export default defineConfig([
     js.configs.recommended,
     tsPlugin.configs["flat/eslint-recommended"],
     reactPlugin.configs.flat.recommended,
-    // react-hooks ships two presets: `recommended` is legacy (eslintrc) and
-    // `recommended-latest` is the flat-config equivalent.
-    reactHooksPlugin.configs["recommended-latest"],
+    // react-hooks ships each preset twice: `configs.recommended` and
+    // `configs["recommended-latest"]` are legacy (eslintrc), whose string
+    // `plugins` array flat config rejects outright; `configs.flat` holds the
+    // flat-config equivalents.
+    reactHooksPlugin.configs.flat["recommended-latest"],
 
     // TypeScript wiring and project-specific overrides.
     {

--- a/public/src/components/CourseCard.tsx
+++ b/public/src/components/CourseCard.tsx
@@ -29,7 +29,7 @@ const CourseCard = ({ course, enrollment, unavailable }: CardProps) => {
     const state = useAppState()
 
     const handleEnroll = useCallback(() => actions.enroll(course.ID), [actions, course.ID])
-    const CourseEnrollmentButton = () => {
+    const courseEnrollmentButton = () => {
         // Always show 'Go to Course' if enrolled or pending, even if unavailable
         if (hasNone(status)) {
             // Show enroll if not unavailable, or if user is admin
@@ -50,7 +50,7 @@ const CourseCard = ({ course, enrollment, unavailable }: CardProps) => {
         return <button className="btn btn-primary course-button" onClick={() => navigate(`/course/${enrollment.courseID}`)}>Go to Course</button>
     }
 
-    const CourseEnrollmentStatus = () => {
+    const courseEnrollmentStatus = () => {
         if (!hasEnrolled(status)) {
             return null
         }
@@ -75,7 +75,7 @@ const CourseCard = ({ course, enrollment, unavailable }: CardProps) => {
                     <h2 className="text-2xl font-bold">{course.code}</h2>
                     <div className="flex items-center gap-2">
                         {unavailable && <Badge color="yellow" text="Unavailable" type="solid" />}
-                        <CourseEnrollmentStatus />
+                        {courseEnrollmentStatus()}
                     </div>
                 </div>
             </div>
@@ -86,7 +86,7 @@ const CourseCard = ({ course, enrollment, unavailable }: CardProps) => {
                 <p className="text-base-content/70">{course.tag} {course.year}</p>
 
                 <div className="card-actions justify-end mt-4">
-                    <CourseEnrollmentButton />
+                    {courseEnrollmentButton()}
                 </div>
             </div>
         </div>

--- a/public/src/components/Lab.tsx
+++ b/public/src/components/Lab.tsx
@@ -28,7 +28,7 @@ const Lab = () => {
         }
     }, [actions, lab, state.isTeacher])
 
-    const InternalLab = () => {
+    const internalLab = () => {
         let submission: Submission | null
         let assignment: Assignment | null
 
@@ -86,7 +86,7 @@ const Lab = () => {
     return (
         <div className={state.isTeacher ? "" : "row"}>
             <div className={state.isTeacher ? "" : "col-md-9"}>
-                <InternalLab />
+                {internalLab()}
             </div>
         </div>
     )

--- a/public/src/components/ManageSubmissionStatus.tsx
+++ b/public/src/components/ManageSubmissionStatus.tsx
@@ -48,7 +48,7 @@ const ManageSubmissionStatus = ({ courseID, reviewers }: { courseID: string, rev
         return ButtonType.OUTLINE
     }
 
-    const StatusButtons = ({ grade }: { grade?: Grade }) => {
+    const statusButtons = (grade?: Grade) => {
         const buttonsInfo = [
             { text: "Approve", color: Color.GREEN, status: Submission_Status.APPROVED },
             { text: "Revision", color: Color.YELLOW, status: Submission_Status.REVISION },
@@ -96,7 +96,7 @@ const ManageSubmissionStatus = ({ courseID, reviewers }: { courseID: string, rev
 
             {!viewIndividualGrades && (
                 <div className="flex gap-3">
-                    <StatusButtons />
+                    {statusButtons()}
                 </div>
             )}
             {viewIndividualGrades && (
@@ -108,7 +108,7 @@ const ManageSubmissionStatus = ({ courseID, reviewers }: { courseID: string, rev
                                     <td className="font-medium">{getUserName(grade.UserID)}</td>
                                     <td>
                                         <div className="flex gap-2 justify-end">
-                                            <StatusButtons grade={grade} />
+                                            {statusButtons(grade)}
                                         </div>
                                     </td>
                                 </tr>

--- a/public/src/components/forms/CourseForm.tsx
+++ b/public/src/components/forms/CourseForm.tsx
@@ -21,26 +21,30 @@ const CourseForm = ({ courseToEdit }: { courseToEdit: Course }) => {
     // Local state containing the course to be created or edited (if any)
     const [course, setCourse] = useState(clone(CourseSchema, courseToEdit))
 
+    // The edited course is replaced rather than mutated: setCourse with the same
+    // object is a no-op, so the form's own state would drift from what a later
+    // render sees.
     const handleChange = useCallback((event: React.FormEvent<HTMLInputElement>) => {
         const { name, value } = event.currentTarget
+        const edited = clone(CourseSchema, course)
         switch (name) {
             case "courseName":
-                course.name = value
+                edited.name = value
                 break
             case "courseTag":
-                course.tag = value
+                edited.tag = value
                 break
             case "courseCode":
-                course.code = value
+                edited.code = value
                 break
             case "courseYear":
-                course.year = Number(value)
+                edited.year = Number(value)
                 break
             case "slipDays":
-                course.slipDays = Number(value)
+                edited.slipDays = Number(value)
                 break
         }
-        setCourse(course)
+        setCourse(edited)
     }, [course])
 
     // Creates a new course if no course is being edited, otherwise updates the existing course

--- a/public/src/components/group/GroupForm.tsx
+++ b/public/src/components/group/GroupForm.tsx
@@ -126,7 +126,7 @@ const GroupForm = () => {
         }
     }
 
-    const EnrollmentTypeButton = () => {
+    const enrollmentTypeButton = () => {
         if (!isTeacher) {
             return (
                 <div className="flex items-center justify-center gap-2 text-lg font-semibold">
@@ -169,7 +169,7 @@ const GroupForm = () => {
                 <div className="card bg-base-200 shadow-xl">
                     <div className="card-body p-0">
                         <div className="bg-base-200 px-4 py-3 rounded-t-2xl">
-                            <EnrollmentTypeButton />
+                            {enrollmentTypeButton()}
                         </div>
                         <div className="px-4 pt-4">
                             <Search placeholder="Search users..." setQuery={setQuery} />

--- a/public/src/components/manual-grading/ReviewInfo.tsx
+++ b/public/src/components/manual-grading/ReviewInfo.tsx
@@ -14,6 +14,16 @@ interface ReviewInfoProps {
     review: Review
 }
 
+const InfoRow = ({ label, value, badge }: { label: string, value: React.ReactNode, badge?: React.ReactNode }) => (
+    <div className="flex items-center justify-between py-3 px-4 hover:bg-base-200 transition-colors">
+        <span className="text-sm font-semibold text-base-content/70 min-w-[140px]">{label}:</span>
+        <div className="flex items-center gap-2 flex-1 justify-end">
+            <span className="font-medium">{value}</span>
+            {badge}
+        </div>
+    </div>
+)
+
 const ReviewInfo = ({ courseID, assignmentName, reviewers, submission, review }: ReviewInfoProps) => {
     const state = useAppState()
 
@@ -24,15 +34,6 @@ const ReviewInfo = ({ courseID, assignmentName, reviewers, submission, review }:
     }
 
     const submissionStatus = submission ? SubmissionStatus[status] : NoSubmission
-    const InfoRow = ({ label, value, badge }: { label: string, value: React.ReactNode, badge?: React.ReactNode }) => (
-        <div className="flex items-center justify-between py-3 px-4 hover:bg-base-200 transition-colors">
-            <span className="text-sm font-semibold text-base-content/70 min-w-[140px]">{label}:</span>
-            <div className="flex items-center gap-2 flex-1 justify-end">
-                <span className="font-medium">{value}</span>
-                {badge}
-            </div>
-        </div>
-    )
 
     return (
         <div className="card bg-base-100 shadow-xl">

--- a/public/src/components/navbar/Breadcrumbs.tsx
+++ b/public/src/components/navbar/Breadcrumbs.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import type { Assignment, Course } from "../../../proto/qf/types_pb"
 import { ScreenSize } from "../../consts"
@@ -12,8 +11,6 @@ const Breadcrumbs = () => {
     const location = useLocation()
     const navigate = useNavigate()
     const { width } = useWindowSize()
-    const [courseName, setCourseName] = useState<string | null>(null)
-    const [assignmentName, setAssignmentName] = useState<string | null>(null)
     const pathnames = location.pathname.split('/').filter(x => x)
 
     const handleDashboard = () => {
@@ -34,17 +31,14 @@ const Breadcrumbs = () => {
         return assignment?.name ?? null
     }
 
-    useEffect(() => {
-        const [prefix, courseId, section, assignmentId] = pathnames
-        if (prefix === 'course' && courseId) {
-            setCourseName(resolveCourseName(state.courses, courseId, width))
-
-            if ((section === 'lab' || section === 'group-lab') && assignmentId) {
-                const courseAssignments = state.assignments?.[courseId] ?? []
-                setAssignmentName(resolveAssignmentName(courseAssignments, assignmentId))
-            }
-        }
-    }, [pathnames, state.courses, state.assignments, width])
+    // Both names follow from the route and the loaded courses, so they are
+    // computed here rather than mirrored into state by an effect: pathnames is a
+    // fresh array on every render, which made that effect run on every render.
+    const [prefix, courseId, section, assignmentId] = pathnames
+    const onCoursePath = prefix === 'course' && Boolean(courseId)
+    const courseName = onCoursePath ? resolveCourseName(state.courses, courseId, width) : null
+    const onLabPath = onCoursePath && (section === 'lab' || section === 'group-lab') && Boolean(assignmentId)
+    const assignmentName = onLabPath ? resolveAssignmentName(state.assignments?.[courseId] ?? [], assignmentId) : null
 
     const segments: { label: string; to: string; last: boolean }[] = []
     pathnames.forEach((value, index) => {

--- a/public/src/components/navbar/ToggleSwitch.tsx
+++ b/public/src/components/navbar/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { useNavigate } from "react-router"
 import { Enrollment_UserStatus } from "../../../proto/qf/types_pb"
 import { hasTeacher } from "../../Helpers"
@@ -8,8 +8,6 @@ const ToggleSwitch = () => {
     const { activeCourse, enrollmentsByCourseID, status } = useAppState()
     const actions = useActions().global
     const navigate = useNavigate()
-    const [enrollmentStatus, setEnrollmentStatus] =
-        React.useState<boolean>(false)
 
     const isTeacher = useCallback((courseID: bigint | undefined): boolean => {
         if (!courseID) {
@@ -18,17 +16,12 @@ const ToggleSwitch = () => {
         return enrollmentsByCourseID[courseID.toString()]?.status === Enrollment_UserStatus.TEACHER
     }, [enrollmentsByCourseID])
 
-    useEffect(() => {
-        if (activeCourse && enrollmentsByCourseID[activeCourse.toString()]) {
-            setEnrollmentStatus(isTeacher(activeCourse))
-        }
-    }, [activeCourse, enrollmentsByCourseID, isTeacher])
+    // changeView updates the enrollment this reads, so the label follows from
+    // the enrollment rather than from a copy an effect keeps in step with it.
+    const enrollmentStatus = isTeacher(activeCourse)
 
     const switchView = () => {
-        actions.changeView().then(() => {
-            setEnrollmentStatus(isTeacher(activeCourse))
-            navigate(`/course/${activeCourse}`)
-        })
+        actions.changeView().then(() => navigate(`/course/${activeCourse}`))
     }
 
     if (!hasTeacher(status[activeCourse.toString()])) {

--- a/public/src/components/profile/Profile.tsx
+++ b/public/src/components/profile/Profile.tsx
@@ -12,8 +12,12 @@ const Profile = () => {
     const state = useAppState()
     const navigate = useNavigate()
     const location = useLocation()
-    // Holds a local state to check whether the user is editing their user information or not
-    const [editing, setEditing] = useState(false)
+    // Holds a local state to check whether the user asked to edit their user
+    // information. Editing is forced while that information is incomplete;
+    // there is nothing useful to show instead, and the signup text belongs
+    // with the form.
+    const [editRequested, setEditing] = useState(false)
+    const editing = editRequested || !state.isValid
 
     // Redirect from "/" to "/profile" when user object is invalid
     useEffect(() => {
@@ -23,13 +27,6 @@ const Profile = () => {
             navigate("/profile")
         }
     }, [state.isLoggedIn, state.isValid, location.pathname, navigate])
-
-    // Default to edit mode if user object does not contain valid information
-    useEffect(() => {
-        if (!state.isValid) {
-            setEditing(true)
-        }
-    }, [state.isValid])
 
     return (
         <div className="min-h-screen">

--- a/public/src/components/profile/ProfileForm.tsx
+++ b/public/src/components/profile/ProfileForm.tsx
@@ -16,26 +16,26 @@ const ProfileForm = ({ children, setEditing }: { children: React.ReactNode, setE
     const [user, setUser] = useState(clone(UserSchema, state.self))
     const [isValid, setIsValid] = useState(state.isValid)
 
-    // Update the user object when user input changes, and update the state.
+    // Update the user object when user input changes, and update the state. The
+    // edited user is replaced rather than mutated: setUser with the same object
+    // is a no-op, so the form's own state would drift from what a later render
+    // sees.
     const handleChange = useCallback((event: React.FormEvent<HTMLInputElement>) => {
         const { name, value } = event.currentTarget
+        const edited = clone(UserSchema, user)
         switch (name) {
             case "name":
-                user.Name = value
+                edited.Name = value
                 break
             case "email":
-                user.Email = value
+                edited.Email = value
                 break
             case "studentid":
-                user.StudentID = value
+                edited.StudentID = value
                 break
         }
-        setUser(user)
-        if (user.Name !== "" && user.Email !== "" && user.StudentID !== "") {
-            setIsValid(true)
-        } else {
-            setIsValid(false)
-        }
+        setUser(edited)
+        setIsValid(edited.Name !== "" && edited.Email !== "" && edited.StudentID !== "")
     }, [user])
 
 

--- a/public/src/components/submissions/SubmissionScores.tsx
+++ b/public/src/components/submissions/SubmissionScores.tsx
@@ -10,7 +10,17 @@ const SubmissionScores = ({ submission }: { submission: Submission }) => {
     const [sortKey, setSortKey] = React.useState<ScoreSort>("name")
     const [sortAscending, setSortAscending] = React.useState<boolean>(true)
 
-    const sortScores = () => {
+    const handleSort = useCallback((event: React.MouseEvent<HTMLTableCellElement>) => {
+        const key = event.currentTarget.dataset.key as ScoreSort
+        if (sortKey === key) {
+            setSortAscending(!sortAscending)
+        } else {
+            setSortKey(key)
+            setSortAscending(true)
+        }
+    }, [sortKey, sortAscending])
+
+    const sortedScores = React.useMemo(() => {
         const sortBy = sortAscending ? 1 : -1
         const scores = submission.Scores.map(score => clone(ScoreSchema, score))
         const totalWeight = scores.reduce((acc, score) => acc + score.Weight, 0)
@@ -28,19 +38,7 @@ const SubmissionScores = ({ submission }: { submission: Submission }) => {
                     return 0
             }
         })
-    }
-
-    const handleSort = useCallback((event: React.MouseEvent<HTMLTableCellElement>) => {
-        const key = event.currentTarget.dataset.key as ScoreSort
-        if (sortKey === key) {
-            setSortAscending(!sortAscending)
-        } else {
-            setSortKey(key)
-            setSortAscending(true)
-        }
-    }, [sortKey, sortAscending])
-
-    const sortedScores = React.useMemo(sortScores, [submission, sortKey, sortAscending])
+    }, [submission, sortKey, sortAscending])
     const totalWeight = sortedScores.reduce((acc, score) => acc + score.Weight, 0)
     return (
         <table className="table table-zebra">

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -110,10 +110,16 @@ const CourseLogs = () => {
     }
 
     useEffect(() => {
+        // set-state-in-effect guards against effects that mirror derived state.
+        // This one starts a request instead, which is what an effect is for, and
+        // reporting that it is in flight is unavoidably a state update. Escaping
+        // the rule would take a data-fetching layer this page does not have.
+        /* eslint-disable react-hooks/set-state-in-effect */
         // A repository belongs to a single course, so the selection cannot carry
         // over to another one.
         setRepository("")
         void fetchLogs("")
+        /* eslint-enable react-hooks/set-state-in-effect */
         // Fetch on mount and whenever the route names another course, since the
         // router keeps this page mounted across that change. The remaining
         // filters are deliberately left out, so that they apply only on Refresh.


### PR DESCRIPTION
`npm run lint` has not been linting anything: it fails while loading its own configuration, with *"A config object has a `plugins` key defined as an array of strings"*. This restores it and fixes everything it then reports.

## The config

eslint-plugin-react-hooks ships every preset twice. The top-level `configs.recommended` and `configs["recommended-latest"]` are the legacy eslintrc shape, whose `plugins` is an array of strings — which flat config rejects outright. The flat equivalents live under `configs.flat`, so `public/eslint.config.js` now uses `reactHooksPlugin.configs.flat["recommended-latest"]`.

With that, ESLint runs and reports 18 errors, all under rules new in react-hooks v7 (the React Compiler set). One commit per rule:

## `react-hooks/static-components` (9)

`CourseCard`, `Lab`, `ManageSubmissionStatus`, `GroupForm`, and `ReviewInfo` each declared a component inside another component's body. That makes a new component *type* on every render, so React unmounts and remounts the whole subtree rather than updating it. All but one are render helpers, not components, and are now called as functions. `InfoRow` is a real component driven only by its props, so it moves to module scope.

## `react-hooks/immutability` (2)

`CourseForm.handleChange` and `ProfileForm.handleChange` mutated the object held in state and then called the setter with that same object. React compares by identity, so the update was dropped — the form's copy and the value a later render reads could disagree. Only the uncontrolled `defaultValue` inputs kept that from being visible. Both now clone, edit the clone, and set that.

## `react-hooks/use-memo` (1)

`SubmissionScores` passed a named function to `useMemo`, so the memo was keyed on a dependency list that never mentioned the function it called. The sort is inlined; `submission`, `sortKey`, and `sortAscending` are now the complete list.

## `react-hooks/set-state-in-effect` (4)

Three are derived state mirrored into `useState` by an effect, which only buys a second render after every change: `Breadcrumbs`' course and assignment names (whose effect additionally ran on *every* render, since `pathnames` is a fresh array each time), `ToggleSwitch`'s teacher/student label, and `Profile`'s edit mode, which is really "forced whenever the user object is incomplete". All three are computed during render now, and three `useState`/`useEffect` pairs go away.

The fourth is `CourseLogs`' fetch effect, which is what an effect is actually for; reporting that a request is in flight is unavoidably a state update, and escaping the rule would take a data-fetching layer this page does not have. It carries a scoped disable and the reason.

## Verification

`npx eslint .` clean, `npx vitest run` 95 passed, `npx tsc --noEmit` clean apart from the pre-existing `src/__tests__/TestHelpers.ts` error. No CI workflow runs the frontend lint today, so this was only reachable locally and through DeepSource.
