### PR TITLE
Drop obsolete SCORE_INIT two-phase pattern from run.sh templates

### DIFF
--- a/ci/testdata/run.sh
+++ b/ci/testdata/run.sh
@@ -1,22 +1,6 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Initializing Tests for %s ***\n" "$CURRENT"
-
-# Move to folder with assignment handout code for the current assignment to test.
-cd "$ASSIGNMENTS/$CURRENT"
-# Remove assignment handout tests, if any, to avoid interference, but keep quickfeed tests.
-find . \( -name '*_test.go' -and -not -name '*_ag_test.go' \) -exec rm -rf {} \;
-
-# Copy tests into the base assignments folder for initializing test scores
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
-
-# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
-go get -t github.com/quickfeed/quickfeed/kit/score
-go mod tidy
-# Initialize test scores
-SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
-
 printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.

--- a/doc/templates/go-course/scripts/run.sh
+++ b/doc/templates/go-course/scripts/run.sh
@@ -1,22 +1,6 @@
 #image/qf101
 
 start=$SECONDS
-printf "*** Initializing Tests for %s ***\n" "$CURRENT"
-
-# Move to folder with assignment handout code for the current assignment to test.
-cd "$ASSIGNMENTS/$CURRENT"
-# Remove assignment handout tests, if any, to avoid interference, but keep quickfeed tests.
-find . \( -name '*_test.go' -and -not -name '*_ag_test.go' \) -exec rm -rf {} \;
-
-# Copy tests into the base assignments folder for initializing test scores
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
-
-# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
-go get -t github.com/quickfeed/quickfeed/kit/score
-go mod tidy
-# Initialize test scores
-SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
-
 printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.

--- a/kit/score/doc.go
+++ b/kit/score/doc.go
@@ -49,7 +49,11 @@
 //
 //	func TestMain(m *testing.M) {
 //	    score.PrintTestInfo()
-//	    os.Exit(m.Run())
+//	    exitCode := m.Run()
+//	    if err := score.Validate(); err != nil {
+//	        fmt.Println(err)
+//	    }
+//	    os.Exit(exitCode)
 //	}
 //
 // To implement a test with scoring, you may use score.Max() to obtain a score object

--- a/testdata/courses/qf104-2022/tests/lab1/sequence/main_test.go
+++ b/testdata/courses/qf104-2022/tests/lab1/sequence/main_test.go
@@ -12,9 +12,6 @@ var scores = score.NewRegistry()
 
 func TestMain(m *testing.M) {
 	scores.PrintTestInfo()
-	if os.Getenv("SCORE_INIT") != "" {
-		os.Exit(0)
-	}
 	exitCode := m.Run()
 	if err := scores.Validate(); err != nil {
 		fmt.Println(err)

--- a/testdata/courses/qf104-2022/tests/lab2/sequence/main_test.go
+++ b/testdata/courses/qf104-2022/tests/lab2/sequence/main_test.go
@@ -12,9 +12,6 @@ var scores = score.NewRegistry()
 
 func TestMain(m *testing.M) {
 	scores.PrintTestInfo()
-	if os.Getenv("SCORE_INIT") != "" {
-		os.Exit(0)
-	}
 	exitCode := m.Run()
 	if err := scores.Validate(); err != nil {
 		fmt.Println(err)

--- a/testdata/courses/qf104-2022/tests/lab2/sequence/run.sh
+++ b/testdata/courses/qf104-2022/tests/lab2/sequence/run.sh
@@ -1,22 +1,6 @@
 #image/qf104
 
 start=$SECONDS
-printf "*** Initializing Tests for %s ***\n" "$CURRENT"
-
-# Move to folder with assignment handout code for the current assignment to test.
-cd "$ASSIGNMENTS/$CURRENT"
-# Remove assignment handout tests, if any, to avoid interference, but keep quickfeed tests.
-find . \( -name '*_test.go' -and -not -name '*_ag_test.go' \) -exec rm -rf {} \;
-
-# Copy tests into the base assignments folder for initializing test scores
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
-
-# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
-go get -t github.com/quickfeed/quickfeed/kit/score
-go mod tidy
-# Initialize test scores
-SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
-
 printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.

--- a/testdata/courses/qf104-2022/tests/scripts/run.sh
+++ b/testdata/courses/qf104-2022/tests/scripts/run.sh
@@ -1,22 +1,6 @@
 #image/qf104
 
 start=$SECONDS
-printf "*** Initializing Tests for %s ***\n" "$CURRENT"
-
-# Move to folder with assignment handout code for the current assignment to test.
-cd "$ASSIGNMENTS/$CURRENT"
-# Remove assignment handout tests, if any, to avoid interference, but keep quickfeed tests.
-find . \( -name '*_test.go' -and -not -name '*_ag_test.go' \) -exec rm -rf {} \;
-
-# Copy tests into the base assignments folder for initializing test scores
-cp -r "$TESTS"/* "$ASSIGNMENTS"/
-
-# $TESTS does not contain go.mod and go.sum: make sure to get the kit/score package
-go get -t github.com/quickfeed/quickfeed/kit/score
-go mod tidy
-# Initialize test scores
-SCORE_INIT=1 go test -v ./... 2>&1 | grep TestName
-
 printf "*** Preparing Test Execution for %s ***\n" "$CURRENT"
 
 # Move to folder with submitted code for the current assignment to test.


### PR DESCRIPTION
## Summary

`score.(*registry).PrintTestInfo()` has printed its JSON test-registration lines unconditionally since `a557aefec` (Nov 2022); `SCORE_INIT` now only controls whether the program exits immediately afterward. Since every course's `TestMain` calls `PrintTestInfo()` before `m.Run()`, an ordinary `go test` run against the submission already emits the zero-score baseline for every registered test before the real tests overwrite it with actual scores. The separate skeleton pass against `$ASSIGNMENTS` (guarded by `SCORE_INIT=1 ... | grep TestName`) adds nothing the real pass doesn't already produce.

This mirrors what courses running in production have already done: single-phase `run.sh` with no `SCORE_INIT`, and generated `TestMain` with no `SCORE_INIT` check.

## Changes

- `doc/templates/go-course/scripts/run.sh` — the course template teachers copy from
- `ci/testdata/run.sh`
- `testdata/courses/qf104-2022/tests/scripts/run.sh` and `.../lab2/sequence/run.sh`
- `testdata/courses/qf104-2022/tests/lab1/sequence/main_test.go` and `.../lab2/sequence/main_test.go` — drop the `if os.Getenv("SCORE_INIT") != "" { os.Exit(0) }` guard
- `kit/score/doc.go` — align the `TestMain` doc example with the actual generated pattern by adding the `scores.Validate()` call after `m.Run()`

The Dockerfile template comparison mentioned in the issue (Alpine vs Debian base, golangci-lint pinning) is left out of scope, as the issue notes it isn't required.

## Testing

- `go build ./...`
- `go test ./ci/... ./assignments/... ./kit/score/... ./web/...` — all pass

Fixes https://github.com/quickfeed/quickfeed/issues/1604