### PR TITLE
feat: validate course repository alignment

### DIFF
--- a/.vscode/quickfeed-words.txt
+++ b/.vscode/quickfeed-words.txt
@@ -207,6 +207,7 @@ qfconnect
 qlog
 qtest
 quickfeed
+quickfeedignore
 Radagast
 rankdir
 Repos
@@ -264,6 +265,7 @@ testpackage
 timestamppb
 tmpl
 Typeflag
+unconfigured
 Unexported
 unittests
 unmarshalled

--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -24,15 +24,16 @@ const MaxWait = 15 * time.Minute
 // the frontend.
 //
 // Note that calling this function concurrently is safe, but it may block the
-// caller for an extended period, since it may involve cloning the tests repository,
-// scanning the repository for assignments, building the Docker image, updating the
-// database and synchronizing tasks to issues on the students' group repositories.
+// caller for an extended period, since it may involve cloning the tests and
+// assignments repositories, scanning the repositories for assignments, building
+// the Docker image and updating the database.
 // The ctx is expected to carry a logger scoped with the course and the tests
 // repository, so that the statements below do not repeat those attributes.
 //
-// The returned count reports content problems in the tests repository that did
-// not abort the update, such as a malformed json file for one assignment.
-// Issue details are logged here so webhook updates reach the course log.
+// The returned count reports content problems in the tests repository and
+// alignment problems between the tests and assignments repositories that did not
+// abort the update. Issue details are logged here so webhook updates reach the
+// course log.
 // Callers are responsible for logging returned errors.
 func UpdateFromTestsRepo(ctx context.Context, runner ci.Runner, db database.Database, sc scm.SCM, course *qf.Course) (int, error) {
 	unlock := course.Lock()
@@ -59,10 +60,7 @@ func UpdateFromTestsRepo(ctx context.Context, runner ci.Runner, db database.Data
 		return 0, fmt.Errorf("reading tests repository content: %w", err)
 	}
 	issueCount := len(issues)
-	for _, issue := range issues {
-		logger.Warn("tests repository issue",
-			label.Assignment, issue.Assignment, label.Path, issue.File, "problem", issue.Problem)
-	}
+	logRepositoryIssues(ctx, "tests repository issue", issues)
 
 	if course.UpdateDockerfile(buildContext[ci.Dockerfile]) {
 		// Rebuild the Docker image for the course tagged with the course code
@@ -82,7 +80,23 @@ func UpdateFromTestsRepo(ctx context.Context, runner ci.Runner, db database.Data
 		return issueCount, fmt.Errorf("updating assignments in database: %w", err)
 	}
 	logger.Debug("assignments successfully updated from tests repository")
-	return issueCount, nil
+
+	clonedAssignmentsRepo, err := sc.Clone(ctx, &scm.CloneOptions{
+		Organization: course.GetScmOrganizationName(),
+		Repository:   qf.AssignmentsRepo,
+		DestDir:      course.CloneDir(),
+	})
+	if err != nil {
+		return issueCount, fmt.Errorf("cloning assignments repository: %w", err)
+	}
+	logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
+
+	alignmentIssues, err := courseRepositoryIssues(clonedTestsRepo, clonedAssignmentsRepo, assignments)
+	if err != nil {
+		return issueCount, fmt.Errorf("validating course repositories: %w", err)
+	}
+	logRepositoryIssues(ctx, "course repository issue", alignmentIssues)
+	return issueCount + len(alignmentIssues), nil
 }
 
 // buildDockerImage builds the Docker image for the given course.

--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -14,45 +14,55 @@ import (
 )
 
 // MaxWait is the maximum time allowed for updating a course's assignments
-// and docker image before aborting.
+// and docker image before aborting. It is generous mainly to accommodate the
+// Docker image build, which dominates the duration of a full update; the two
+// clones it also covers are comparatively quick.
 const MaxWait = 15 * time.Minute
 
-// UpdateFromTestsRepo updates the database record for the course assignments.
+// UpdateFromCourseRepositories updates the database record for the course
+// assignments and reports the problems found in the course's repositories.
 //
-// This will be called in response to a push event to the 'tests' repo, which
-// should happen infrequently. It may also be called manually by a teacher from
-// the frontend.
+// This is called in response to a push event to either the 'tests' or the
+// 'assignments' repository, and may also be called manually by a teacher from
+// the frontend. It performs the same full update whichever repository was
+// pushed: db.UpdateAssignments is idempotent, and the Docker image is rebuilt
+// only when the Dockerfile's digest actually changed, which it will not have
+// on an assignments push. An assignments push therefore costs one extra clone
+// and a no-op database pass, and in return the update becomes self-healing: a
+// tests push whose webhook was missed or failed is reconciled by the next
+// assignments push.
 //
 // Note that calling this function concurrently is safe, but it may block the
-// caller for an extended period, since it may involve cloning the tests and
-// assignments repositories, scanning the repositories for assignments, building
-// the Docker image and updating the database.
-// The ctx is expected to carry a logger scoped with the course and the tests
-// repository, so that the statements below do not repeat those attributes.
+// caller for an extended period, since it involves cloning both course
+// repositories, scanning them for assignments, building the Docker image and
+// updating the database.
+//
+// Both repositories are cloned first, so that the checks below work from a
+// snapshot of the two taken at the same time. The tests repository is
+// required: failing to clone or read it aborts the update, since neither the
+// content check nor the database update is possible without it. The
+// assignments repository is only needed for the cross-repository comparison,
+// so failing to clone it, or to compare the two, is logged and skips that
+// comparison alone, leaving the database up to date.
 //
 // The returned count reports content problems in the tests repository and
-// alignment problems between the tests and assignments repositories that did not
-// abort the update. Issue details are logged here so webhook updates reach the
-// course log.
+// alignment problems between the two repositories. Issue details are logged
+// here so that webhook updates reach the course log; the ctx is expected to
+// carry a logger scoped with the course.
 // Callers are responsible for logging returned errors.
-func UpdateFromTestsRepo(ctx context.Context, runner ci.Runner, db database.Database, sc scm.SCM, course *qf.Course) (int, error) {
+func UpdateFromCourseRepositories(ctx context.Context, runner ci.Runner, db database.Database, sc scm.SCM, course *qf.Course) (int, error) {
 	unlock := course.Lock()
 	defer unlock()
 
 	logger := qlog.FromContext(ctx)
-	logger.Debug("updating from tests repository")
+	logger.Debug("updating from course repositories")
 	ctx, cancel := context.WithTimeout(ctx, MaxWait)
 	defer cancel()
 
-	clonedTestsRepo, err := sc.Clone(ctx, &scm.CloneOptions{
-		Organization: course.GetScmOrganizationName(),
-		Repository:   qf.TestsRepo,
-		DestDir:      course.CloneDir(),
-	})
+	clonedTestsRepo, clonedAssignmentsRepo, err := cloneCourseRepositories(ctx, sc, course)
 	if err != nil {
-		return 0, fmt.Errorf("cloning tests repository: %w", err)
+		return 0, err
 	}
-	logger.Debug("cloned tests repository", label.Path, clonedTestsRepo)
 
 	// walk the cloned tests repository and extract the assignments and the course's Dockerfile
 	assignments, buildContext, issues, err := readTestsRepositoryContent(clonedTestsRepo, course.GetID())
@@ -81,22 +91,52 @@ func UpdateFromTestsRepo(ctx context.Context, runner ci.Runner, db database.Data
 	}
 	logger.Debug("assignments successfully updated from tests repository")
 
-	clonedAssignmentsRepo, err := sc.Clone(ctx, &scm.CloneOptions{
+	if clonedAssignmentsRepo == "" {
+		// The assignments repository could not be cloned, and
+		// cloneCourseRepositories has logged why; the update itself is complete.
+		return issueCount, nil
+	}
+	alignmentIssues, err := courseRepositoryIssues(clonedTestsRepo, clonedAssignmentsRepo, assignments)
+	if err != nil {
+		logger.Error("failed to compare course repositories", label.Error, err)
+		return issueCount, nil
+	}
+	logRepositoryIssues(ctx, "course repository issue", alignmentIssues)
+	return issueCount + len(alignmentIssues), nil
+}
+
+// cloneCourseRepositories clones the course's tests and assignments
+// repositories into the course's clone directory, refreshing any local
+// copies are already there.
+//
+// The tests repository is required. Failure to clone it returns an error
+// and the assignments repository is not cloned. The assignments repository
+// is only needed for the comparing the tests and assignments repositories.
+// Failure to clone the assignments repository is logged and reported as an
+// empty assignmentsDir.
+func cloneCourseRepositories(ctx context.Context, sc scm.SCM, course *qf.Course) (testsDir, assignmentsDir string, err error) {
+	logger := qlog.FromContext(ctx)
+	testsDir, err = sc.Clone(ctx, &scm.CloneOptions{
+		Organization: course.GetScmOrganizationName(),
+		Repository:   qf.TestsRepo,
+		DestDir:      course.CloneDir(),
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("cloning tests repository: %w", err)
+	}
+	logger.Debug("cloned tests repository", label.Path, testsDir)
+
+	assignmentsDir, err = sc.Clone(ctx, &scm.CloneOptions{
 		Organization: course.GetScmOrganizationName(),
 		Repository:   qf.AssignmentsRepo,
 		DestDir:      course.CloneDir(),
 	})
 	if err != nil {
-		return issueCount, fmt.Errorf("cloning assignments repository: %w", err)
+		logger.Error("failed to clone assignments repository", label.Error, err)
+		return testsDir, "", nil
 	}
-	logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
-
-	alignmentIssues, err := courseRepositoryIssues(clonedTestsRepo, clonedAssignmentsRepo, assignments)
-	if err != nil {
-		return issueCount, fmt.Errorf("validating course repositories: %w", err)
-	}
-	logRepositoryIssues(ctx, "course repository issue", alignmentIssues)
-	return issueCount + len(alignmentIssues), nil
+	logger.Debug("cloned assignments repository", label.Path, assignmentsDir)
+	return testsDir, assignmentsDir, nil
 }
 
 // buildDockerImage builds the Docker image for the given course.

--- a/assignments/assignments_test.go
+++ b/assignments/assignments_test.go
@@ -51,7 +51,7 @@ func TestFetchAssignments(t *testing.T) {
 		t.Logf("%+v", assignment)
 	}
 
-	// This just to simulate the behavior of UpdateFromTestsRepo to confirm that the Dockerfile is built
+	// This just to simulate the behavior of UpdateFromCourseRepositories to confirm that the Dockerfile is built
 	course.UpdateDockerfile(gotBuildContext[ci.Dockerfile])
 	docker, closeFn := dockerClient(t)
 	defer closeFn()
@@ -60,9 +60,9 @@ func TestFetchAssignments(t *testing.T) {
 	}
 }
 
-// TestUpdateCriteria simulates the behavior of UpdateFromTestsRepo
+// TestUpdateCriteria simulates the behavior of UpdateFromCourseRepositories
 // where we update the criteria for an assignment.
-// Benchmarks and criteria specifically related to a review should not be affected by UpdateFromTestsRepo.
+// Benchmarks and criteria specifically related to a review should not be affected by UpdateFromCourseRepositories.
 // Neither should reviews
 func TestUpdateCriteria(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)

--- a/assignments/repository_validation.go
+++ b/assignments/repository_validation.go
@@ -3,6 +3,7 @@ package assignments
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,25 +17,6 @@ import (
 // ignoreFile is an optional file in the tests repository root listing top-level
 // folders, in either repository, that are not assignments.
 const ignoreFile = ".quickfeedignore"
-
-// ValidateCourseRepositories checks the tests repository's content and verifies
-// that the tests and assignments repositories contain the same assignment folders.
-// Problems are written to the course log and returned as a count; content problems
-// do not make validation fail.
-func ValidateCourseRepositories(ctx context.Context, testsDir, assignmentsDir string, courseID uint64) (int, error) {
-	assignments, _, testsIssues, err := readTestsRepositoryContent(testsDir, courseID)
-	if err != nil {
-		return 0, fmt.Errorf("reading tests repository content: %w", err)
-	}
-	logRepositoryIssues(ctx, "tests repository issue", testsIssues)
-
-	repositoryIssues, err := courseRepositoryIssues(testsDir, assignmentsDir, assignments)
-	if err != nil {
-		return len(testsIssues), err
-	}
-	logRepositoryIssues(ctx, "course repository issue", repositoryIssues)
-	return len(testsIssues) + len(repositoryIssues), nil
-}
 
 // courseRepositoryIssues reports assignment folders that are not aligned across
 // the two course repositories. Every top-level folder in either repository is an
@@ -85,6 +67,7 @@ func assignmentFolderIssues(testsDir, name string, inTests, inAssignments bool, 
 			File:       name,
 			Problem: fmt.Sprintf("assignment folder is missing from %q repository; add it or list the folder in %s",
 				qf.TestsRepo, ignoreFile),
+			Transient: true,
 		}}, nil
 	}
 	files, err := readAssignmentFiles(testsDir, name)
@@ -108,6 +91,7 @@ func assignmentFolderIssues(testsDir, name string, inTests, inAssignments bool, 
 			Assignment: name,
 			File:       name,
 			Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.AssignmentsRepo),
+			Transient:  true,
 		})
 	}
 	// Auto-graded assignments get the more specific missing-tests issue from
@@ -232,10 +216,19 @@ func regularFile(path string) (bool, error) {
 	return false, fmt.Errorf("checking %q: %w", path, err)
 }
 
+// logRepositoryIssues writes issues to the course log. Most issues are warnings,
+// but transient issues are logged at info level because they only reflect the
+// temporary mismatch between the two pushes needed to add an assignment.
+// The frontend issue count reports the state after the latest push.
 func logRepositoryIssues(ctx context.Context, message string, issues []RepoIssue) {
 	logger := qlog.FromContext(ctx)
 	for _, issue := range issues {
-		logger.Warn(
+		level := slog.LevelWarn
+		if issue.Transient {
+			level = slog.LevelInfo
+		}
+		logger.Log(
+			ctx, level,
 			message,
 			label.Assignment, issue.Assignment,
 			label.Path, issue.File,

--- a/assignments/repository_validation.go
+++ b/assignments/repository_validation.go
@@ -13,6 +13,10 @@ import (
 	"github.com/quickfeed/quickfeed/qf"
 )
 
+// ignoreFile is an optional file in the tests repository root listing top-level
+// folders, in either repository, that are not assignments.
+const ignoreFile = ".quickfeedignore"
+
 // ValidateCourseRepositories checks the tests repository's content and verifies
 // that the tests and assignments repositories contain the same assignment folders.
 // Problems are written to the course log and returned as a count; content problems
@@ -32,26 +36,22 @@ func ValidateCourseRepositories(ctx context.Context, testsDir, assignmentsDir st
 	return len(testsIssues) + len(repositoryIssues), nil
 }
 
+// courseRepositoryIssues reports assignment folders that are not aligned across
+// the two course repositories. Every top-level folder in either repository is an
+// assignment candidate, except repository metadata, the reserved scripts folder,
+// and the folders listed in the tests repository's ignore file.
 func courseRepositoryIssues(testsDir, assignmentsDir string, parsedAssignments []*qf.Assignment) ([]RepoIssue, error) {
-	testsFolders, err := topLevelFolders(testsDir)
-	if err != nil {
-		return nil, fmt.Errorf("reading tests repository folders: %w", err)
-	}
-	assignmentsFolders, err := topLevelFolders(assignmentsDir)
-	if err != nil {
-		return nil, fmt.Errorf("reading assignments repository folders: %w", err)
-	}
-
-	configuredTestsFolders, err := configuredAssignmentFolders(testsDir, testsFolders)
+	ignored, issues, err := readIgnoreFile(testsDir)
 	if err != nil {
 		return nil, err
 	}
-	// A folder without configuration is still an assignment folder when its
-	// counterpart in the assignments repository establishes that name.
-	for name := range assignmentsFolders {
-		if testsFolders[name] {
-			configuredTestsFolders[name] = true
-		}
+	testsFolders, err := topLevelFolders(testsDir, ignored)
+	if err != nil {
+		return nil, fmt.Errorf("reading tests repository folders: %w", err)
+	}
+	assignmentsFolders, err := topLevelFolders(assignmentsDir, ignored)
+	if err != nil {
+		return nil, fmt.Errorf("reading assignments repository folders: %w", err)
 	}
 
 	parsed := make(map[string]*qf.Assignment, len(parsedAssignments))
@@ -59,66 +59,61 @@ func courseRepositoryIssues(testsDir, assignmentsDir string, parsedAssignments [
 		parsed[assignment.GetName()] = assignment
 	}
 
-	names := unionNames(configuredTestsFolders, assignmentsFolders)
-	var issues []RepoIssue
-	for _, name := range names {
-		inTests := configuredTestsFolders[name]
-		inAssignments := assignmentsFolders[name]
-		switch {
-		case !inTests:
-			issues = append(issues, RepoIssue{
-				Assignment: name,
-				File:       name,
-				Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.TestsRepo),
-			})
-			continue
-		case !inAssignments:
-			issues = append(issues, RepoIssue{
-				Assignment: name,
-				File:       name,
-				Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.AssignmentsRepo),
-			})
-		}
-
-		structureIssues, err := assignmentStructureIssues(testsDir, name, parsed[name])
+	for _, name := range unionNames(testsFolders, assignmentsFolders) {
+		folderIssues, err := assignmentFolderIssues(testsDir, name, testsFolders[name], assignmentsFolders[name], parsed[name])
 		if err != nil {
 			return nil, err
 		}
-		issues = append(issues, structureIssues...)
+		issues = append(issues, folderIssues...)
 	}
 	return issues, nil
 }
 
-func assignmentStructureIssues(testsDir, name string, assignment *qf.Assignment) ([]RepoIssue, error) {
-	assignmentPath := filepath.Join(name, assignmentFile)
-	hasAssignment, err := regularFile(filepath.Join(testsDir, assignmentPath))
+// assignmentFolderIssues reports the problems found for a single candidate
+// assignment folder.
+//
+// A folder holding no assignment configuration at all is reported once, and
+// nothing further is checked for it: QuickFeed cannot tell an assignment whose
+// assignment.json was forgotten from shared course code that belongs in the
+// tests repository. That single issue names both remedies, so an unconfigured
+// folder costs one line whichever it turns out to be. The remaining checks
+// apply to folders that are known to be assignments.
+func assignmentFolderIssues(testsDir, name string, inTests, inAssignments bool, assignment *qf.Assignment) ([]RepoIssue, error) {
+	if !inTests {
+		return []RepoIssue{{
+			Assignment: name,
+			File:       name,
+			Problem: fmt.Sprintf("assignment folder is missing from %q repository; add it or list the folder in %s",
+				qf.TestsRepo, ignoreFile),
+		}}, nil
+	}
+	files, err := readAssignmentFiles(testsDir, name)
 	if err != nil {
 		return nil, err
 	}
-	hasTests, err := regularFile(filepath.Join(testsDir, name, testsFile))
-	if err != nil {
-		return nil, err
-	}
-	hasCriteria, err := regularFile(filepath.Join(testsDir, name, criteriaFile))
-	if err != nil {
-		return nil, err
+	if !files.configured() {
+		// readTestsRepositoryContent cannot discover this folder, since its
+		// file-oriented walk only sees the configuration files that are absent here.
+		return []RepoIssue{{
+			Assignment: name,
+			File:       name,
+			Problem: fmt.Sprintf("no assignment configuration found; add %q if this is an assignment, or list the folder in %s",
+				filepath.Join(name, assignmentFile), ignoreFile),
+		}}, nil
 	}
 
 	var issues []RepoIssue
-	// When tests.json or criteria.json exists, readTestsRepositoryContent already
-	// reports the missing assignment file. Add it here only for otherwise empty
-	// or unrecognized folders that its file-oriented walk cannot discover.
-	if !hasAssignment && !hasTests && !hasCriteria {
+	if !inAssignments {
 		issues = append(issues, RepoIssue{
 			Assignment: name,
-			File:       assignmentPath,
-			Problem:    fmt.Sprintf("missing %q", assignmentPath),
+			File:       name,
+			Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.AssignmentsRepo),
 		})
 	}
 	// Auto-graded assignments get the more specific missing-tests issue from
-	// missingTestsIssues. This check covers empty, broken, and manually graded
+	// missingTestsIssues. This check covers broken and manually graded
 	// assignment folders for which neither scoring configuration exists.
-	if !hasTests && !hasCriteria && (assignment == nil || assignment.GradedManually()) {
+	if !files.tests && !files.criteria && (assignment == nil || assignment.GradedManually()) {
 		issues = append(issues, RepoIssue{
 			Assignment: name,
 			File:       name,
@@ -128,42 +123,88 @@ func assignmentStructureIssues(testsDir, name string, assignment *qf.Assignment)
 	return issues, nil
 }
 
-// topLevelFolders returns all possible assignment directories. Dot directories
-// and the reserved scripts directory are repository metadata, not assignments.
-func topLevelFolders(dir string) (map[string]bool, error) {
+// assignmentFiles records which configuration files an assignment folder in the
+// tests repository contains.
+type assignmentFiles struct {
+	assignment bool
+	tests      bool
+	criteria   bool
+}
+
+// configured reports whether the folder holds any assignment configuration, and
+// is therefore intended as an assignment rather than shared course code.
+func (f assignmentFiles) configured() bool {
+	return f.assignment || f.tests || f.criteria
+}
+
+func readAssignmentFiles(testsDir, name string) (assignmentFiles, error) {
+	var files assignmentFiles
+	for _, entry := range []struct {
+		filename string
+		found    *bool
+	}{
+		{assignmentFile, &files.assignment},
+		{testsFile, &files.tests},
+		{criteriaFile, &files.criteria},
+	} {
+		exists, err := regularFile(filepath.Join(testsDir, name, entry.filename))
+		if err != nil {
+			return files, err
+		}
+		*entry.found = exists
+	}
+	return files, nil
+}
+
+// topLevelFolders returns the assignment candidates in dir. Dot directories and
+// the reserved scripts directory are repository metadata, not assignments, and
+// so are the folders named by the course's ignore file.
+func topLevelFolders(dir string, ignored map[string]bool) (map[string]bool, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
 	folders := make(map[string]bool)
 	for _, entry := range entries {
-		if !entry.IsDir() || entry.Name() == scriptsDir || strings.HasPrefix(entry.Name(), ".") {
+		name := entry.Name()
+		if !entry.IsDir() || name == scriptsDir || ignored[name] || strings.HasPrefix(name, ".") {
 			continue
 		}
-		folders[entry.Name()] = true
+		folders[name] = true
 	}
 	return folders, nil
 }
 
-// configuredAssignmentFolders keeps only tests-side directories containing at
-// least one assignment configuration file. Other top-level directories may hold
-// shared packages and are not assignments unless the assignments repository has
-// a folder with the same name.
-func configuredAssignmentFolders(dir string, folders map[string]bool) (map[string]bool, error) {
-	configured := make(map[string]bool)
-	for name := range folders {
-		for _, filename := range []string{assignmentFile, testsFile, criteriaFile} {
-			exists, err := regularFile(filepath.Join(dir, name, filename))
-			if err != nil {
-				return nil, err
-			}
-			if exists {
-				configured[name] = true
-				break
-			}
+// readIgnoreFile reads the optional ignore file from the tests repository root.
+// Each line names one top-level folder, in either repository, that is not an
+// assignment; blank lines and lines starting with '#' are skipped. Only exact
+// folder names are supported; path and glob entries are reported and ignored,
+// so that a misunderstood entry does not silently hide an assignment folder.
+func readIgnoreFile(testsDir string) (map[string]bool, []RepoIssue, error) {
+	contents, err := os.ReadFile(filepath.Join(testsDir, ignoreFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
 		}
+		return nil, nil, fmt.Errorf("reading %q: %w", ignoreFile, err)
 	}
-	return configured, nil
+	ignored := make(map[string]bool)
+	var issues []RepoIssue
+	for line := range strings.Lines(string(contents)) {
+		entry := strings.TrimSpace(line)
+		if entry == "" || strings.HasPrefix(entry, "#") {
+			continue
+		}
+		if strings.ContainsAny(entry, `/\*?[`) {
+			issues = append(issues, RepoIssue{
+				File:    ignoreFile,
+				Problem: fmt.Sprintf("invalid entry %q: only top-level folder names are supported", entry),
+			})
+			continue
+		}
+		ignored[entry] = true
+	}
+	return ignored, issues, nil
 }
 
 func unionNames(left, right map[string]bool) []string {
@@ -194,7 +235,8 @@ func regularFile(path string) (bool, error) {
 func logRepositoryIssues(ctx context.Context, message string, issues []RepoIssue) {
 	logger := qlog.FromContext(ctx)
 	for _, issue := range issues {
-		logger.Warn(message,
+		logger.Warn(
+			message,
 			label.Assignment, issue.Assignment,
 			label.Path, issue.File,
 			"problem", issue.Problem,

--- a/assignments/repository_validation.go
+++ b/assignments/repository_validation.go
@@ -1,0 +1,203 @@
+package assignments
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qlog/label"
+	"github.com/quickfeed/quickfeed/qf"
+)
+
+// ValidateCourseRepositories checks the tests repository's content and verifies
+// that the tests and assignments repositories contain the same assignment folders.
+// Problems are written to the course log and returned as a count; content problems
+// do not make validation fail.
+func ValidateCourseRepositories(ctx context.Context, testsDir, assignmentsDir string, courseID uint64) (int, error) {
+	assignments, _, testsIssues, err := readTestsRepositoryContent(testsDir, courseID)
+	if err != nil {
+		return 0, fmt.Errorf("reading tests repository content: %w", err)
+	}
+	logRepositoryIssues(ctx, "tests repository issue", testsIssues)
+
+	repositoryIssues, err := courseRepositoryIssues(testsDir, assignmentsDir, assignments)
+	if err != nil {
+		return len(testsIssues), err
+	}
+	logRepositoryIssues(ctx, "course repository issue", repositoryIssues)
+	return len(testsIssues) + len(repositoryIssues), nil
+}
+
+func courseRepositoryIssues(testsDir, assignmentsDir string, parsedAssignments []*qf.Assignment) ([]RepoIssue, error) {
+	testsFolders, err := topLevelFolders(testsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading tests repository folders: %w", err)
+	}
+	assignmentsFolders, err := topLevelFolders(assignmentsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading assignments repository folders: %w", err)
+	}
+
+	configuredTestsFolders, err := configuredAssignmentFolders(testsDir, testsFolders)
+	if err != nil {
+		return nil, err
+	}
+	// A folder without configuration is still an assignment folder when its
+	// counterpart in the assignments repository establishes that name.
+	for name := range assignmentsFolders {
+		if testsFolders[name] {
+			configuredTestsFolders[name] = true
+		}
+	}
+
+	parsed := make(map[string]*qf.Assignment, len(parsedAssignments))
+	for _, assignment := range parsedAssignments {
+		parsed[assignment.GetName()] = assignment
+	}
+
+	names := unionNames(configuredTestsFolders, assignmentsFolders)
+	var issues []RepoIssue
+	for _, name := range names {
+		inTests := configuredTestsFolders[name]
+		inAssignments := assignmentsFolders[name]
+		switch {
+		case !inTests:
+			issues = append(issues, RepoIssue{
+				Assignment: name,
+				File:       name,
+				Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.TestsRepo),
+			})
+			continue
+		case !inAssignments:
+			issues = append(issues, RepoIssue{
+				Assignment: name,
+				File:       name,
+				Problem:    fmt.Sprintf("assignment folder is missing from %q repository", qf.AssignmentsRepo),
+			})
+		}
+
+		structureIssues, err := assignmentStructureIssues(testsDir, name, parsed[name])
+		if err != nil {
+			return nil, err
+		}
+		issues = append(issues, structureIssues...)
+	}
+	return issues, nil
+}
+
+func assignmentStructureIssues(testsDir, name string, assignment *qf.Assignment) ([]RepoIssue, error) {
+	assignmentPath := filepath.Join(name, assignmentFile)
+	hasAssignment, err := regularFile(filepath.Join(testsDir, assignmentPath))
+	if err != nil {
+		return nil, err
+	}
+	hasTests, err := regularFile(filepath.Join(testsDir, name, testsFile))
+	if err != nil {
+		return nil, err
+	}
+	hasCriteria, err := regularFile(filepath.Join(testsDir, name, criteriaFile))
+	if err != nil {
+		return nil, err
+	}
+
+	var issues []RepoIssue
+	// When tests.json or criteria.json exists, readTestsRepositoryContent already
+	// reports the missing assignment file. Add it here only for otherwise empty
+	// or unrecognized folders that its file-oriented walk cannot discover.
+	if !hasAssignment && !hasTests && !hasCriteria {
+		issues = append(issues, RepoIssue{
+			Assignment: name,
+			File:       assignmentPath,
+			Problem:    fmt.Sprintf("missing %q", assignmentPath),
+		})
+	}
+	// Auto-graded assignments get the more specific missing-tests issue from
+	// missingTestsIssues. This check covers empty, broken, and manually graded
+	// assignment folders for which neither scoring configuration exists.
+	if !hasTests && !hasCriteria && (assignment == nil || assignment.GradedManually()) {
+		issues = append(issues, RepoIssue{
+			Assignment: name,
+			File:       name,
+			Problem:    fmt.Sprintf("missing %s or %s", testsFile, criteriaFile),
+		})
+	}
+	return issues, nil
+}
+
+// topLevelFolders returns all possible assignment directories. Dot directories
+// and the reserved scripts directory are repository metadata, not assignments.
+func topLevelFolders(dir string) (map[string]bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	folders := make(map[string]bool)
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == scriptsDir || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		folders[entry.Name()] = true
+	}
+	return folders, nil
+}
+
+// configuredAssignmentFolders keeps only tests-side directories containing at
+// least one assignment configuration file. Other top-level directories may hold
+// shared packages and are not assignments unless the assignments repository has
+// a folder with the same name.
+func configuredAssignmentFolders(dir string, folders map[string]bool) (map[string]bool, error) {
+	configured := make(map[string]bool)
+	for name := range folders {
+		for _, filename := range []string{assignmentFile, testsFile, criteriaFile} {
+			exists, err := regularFile(filepath.Join(dir, name, filename))
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				configured[name] = true
+				break
+			}
+		}
+	}
+	return configured, nil
+}
+
+func unionNames(left, right map[string]bool) []string {
+	names := make([]string, 0, len(left)+len(right))
+	for name := range left {
+		names = append(names, name)
+	}
+	for name := range right {
+		if !left[name] {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func regularFile(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.Mode().IsRegular(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking %q: %w", path, err)
+}
+
+func logRepositoryIssues(ctx context.Context, message string, issues []RepoIssue) {
+	logger := qlog.FromContext(ctx)
+	for _, issue := range issues {
+		logger.Warn(message,
+			label.Assignment, issue.Assignment,
+			label.Path, issue.File,
+			"problem", issue.Problem,
+		)
+	}
+}

--- a/assignments/repository_validation_test.go
+++ b/assignments/repository_validation_test.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/quickfeed/quickfeed/ci"
+	"github.com/quickfeed/quickfeed/database"
 	"github.com/quickfeed/quickfeed/internal/qlog"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
@@ -58,8 +61,8 @@ func TestCourseRepositoryIssues(t *testing.T) {
 	}
 	want := []RepoIssue{
 		{Assignment: "internal", File: "internal", Problem: `no assignment configuration found; add "internal/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
-		{Assignment: "lab2", File: "lab2", Problem: `assignment folder is missing from "assignments" repository`},
-		{Assignment: "lab3", File: "lab3", Problem: `assignment folder is missing from "tests" repository; add it or list the folder in .quickfeedignore`},
+		{Assignment: "lab2", File: "lab2", Problem: `assignment folder is missing from "assignments" repository`, Transient: true},
+		{Assignment: "lab3", File: "lab3", Problem: `assignment folder is missing from "tests" repository; add it or list the folder in .quickfeedignore`, Transient: true},
 		{Assignment: "lab4", File: "lab4", Problem: `no assignment configuration found; add "lab4/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
 		{Assignment: "lab5", File: "lab5", Problem: "missing tests.json or criteria.json"},
 		{Assignment: "lab6", File: "lab6", Problem: `no assignment configuration found; add "lab6/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
@@ -121,40 +124,6 @@ func TestCourseRepositoryIssuesInvalidIgnoreEntry(t *testing.T) {
 	}
 }
 
-func TestValidateCourseRepositoriesCountsAllIssues(t *testing.T) {
-	testsDir := t.TempDir()
-	assignmentsDir := t.TempDir()
-	writeFile(t, testsDir, "lab1", assignmentFile, j1)
-	makeRepoDir(t, assignmentsDir, "lab1")
-
-	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
-	got, err := ValidateCourseRepositories(ctx, testsDir, assignmentsDir, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// The tests repository content check reports the missing tests.json. The
-	// cross-repository check finds no additional problem for the aligned folders.
-	if got != 1 {
-		t.Errorf("ValidateCourseRepositories() = %d, want 1", got)
-	}
-}
-
-func TestValidateCourseRepositoriesDoesNotDuplicateMissingAssignment(t *testing.T) {
-	testsDir := t.TempDir()
-	assignmentsDir := t.TempDir()
-	writeFile(t, testsDir, "lab1", testsFile, testJson)
-	makeRepoDir(t, assignmentsDir, "lab1")
-
-	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
-	got, err := ValidateCourseRepositories(ctx, testsDir, assignmentsDir, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != 1 {
-		t.Errorf("ValidateCourseRepositories() = %d, want one missing-assignment issue", got)
-	}
-}
-
 func TestCourseRepositoryIssuesMissingRoot(t *testing.T) {
 	_, err := courseRepositoryIssues(filepath.Join(t.TempDir(), "missing"), t.TempDir(), nil)
 	if err == nil {
@@ -162,65 +131,171 @@ func TestCourseRepositoryIssuesMissingRoot(t *testing.T) {
 	}
 }
 
-func TestUpdateFromTestsRepoReportsAlignmentIssues(t *testing.T) {
+// newCourse returns a course backed by a fresh test database, ready to be
+// updated from a pair of local directories standing in for the two course
+// repositories.
+func newCourse(t *testing.T) (database.Database, *qf.Course) {
+	t.Helper()
 	db, cleanup := qtest.TestDB(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	admin := qtest.CreateFakeUser(t, db)
 	course := &qf.Course{}
 	qtest.CreateCourse(t, db, admin, course)
+	return db, course
+}
 
-	testsDir := t.TempDir()
-	assignmentsDir := t.TempDir()
-	writeFile(t, testsDir, "lab1", assignmentFile, j1)
-	writeFile(t, testsDir, "lab1", testsFile, testJson)
-	scmClient := &cloneOnlySCM{directories: map[string]string{
-		qf.TestsRepo:       testsDir,
-		qf.AssignmentsRepo: assignmentsDir,
-	}}
+// TestUpdateFromCourseRepositoriesIssueCount checks that the returned count
+// covers both the tests repository's content problems and the alignment of the
+// two repositories, without reporting the same folder twice.
+func TestUpdateFromCourseRepositoriesIssueCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		writeRepo       func(t *testing.T, testsDir, assignmentsDir string)
+		wantCount       int
+		wantAssignments []string
+	}{
+		{
+			// The content check reports the missing tests.json; the aligned
+			// folders add nothing to it.
+			name: "MissingTestsFile",
+			writeRepo: func(t *testing.T, testsDir, assignmentsDir string) {
+				writeFile(t, testsDir, "lab1", assignmentFile, j1)
+				makeRepoDir(t, assignmentsDir, "lab1")
+			},
+			wantCount:       1,
+			wantAssignments: []string{"lab1"},
+		},
+		{
+			// A folder configured by tests.json alone is missing its
+			// assignment.json; it must be reported once, not once per check.
+			name: "MissingAssignmentFile",
+			writeRepo: func(t *testing.T, testsDir, assignmentsDir string) {
+				writeFile(t, testsDir, "lab1", testsFile, testJson)
+				makeRepoDir(t, assignmentsDir, "lab1")
+			},
+			// The folder holds no parsable assignment, so nothing is stored.
+			wantCount: 1,
+		},
+		{
+			// An assignment folder that has not reached the assignments
+			// repository yet: one alignment issue, no content issue.
+			name: "MissingFromAssignmentsRepository",
+			writeRepo: func(t *testing.T, testsDir, _ string) {
+				writeFile(t, testsDir, "lab1", assignmentFile, j1)
+				writeFile(t, testsDir, "lab1", testsFile, testJson)
+			},
+			wantCount:       1,
+			wantAssignments: []string{"lab1"},
+		},
+		{
+			name: "AlignedRepositories",
+			writeRepo: func(t *testing.T, testsDir, assignmentsDir string) {
+				writeFile(t, testsDir, "lab1", assignmentFile, j1)
+				writeFile(t, testsDir, "lab1", testsFile, testJson)
+				makeRepoDir(t, assignmentsDir, "lab1")
+			},
+			wantCount:       0,
+			wantAssignments: []string{"lab1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, course := newCourse(t)
+			testsDir, assignmentsDir := t.TempDir(), t.TempDir()
+			tt.writeRepo(t, testsDir, assignmentsDir)
+			scmClient := &cloneOnlySCM{directories: map[string]string{
+				qf.TestsRepo:       testsDir,
+				qf.AssignmentsRepo: assignmentsDir,
+			}}
 
-	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
-	got, err := UpdateFromTestsRepo(ctx, &ci.Local{}, db, scmClient, course)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != 1 {
-		t.Errorf("UpdateFromTestsRepo() issue count = %d, want 1", got)
-	}
-	stored, err := db.GetAssignmentsByCourse(course.GetID())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(stored) != 1 || stored[0].GetName() != "lab1" {
-		t.Errorf("stored assignments = %+v, want lab1", stored)
+			ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+			got, err := UpdateFromCourseRepositories(ctx, &ci.Local{}, db, scmClient, course)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.wantCount {
+				t.Errorf("UpdateFromCourseRepositories() issue count = %d, want %d", got, tt.wantCount)
+			}
+			assertStoredAssignments(t, db, course, tt.wantAssignments)
+		})
 	}
 }
 
-func TestUpdateFromTestsRepoPersistsBeforeAlignmentFailure(t *testing.T) {
-	db, cleanup := qtest.TestDB(t)
-	defer cleanup()
-	admin := qtest.CreateFakeUser(t, db)
-	course := &qf.Course{}
-	qtest.CreateCourse(t, db, admin, course)
-
+// TestUpdateFromCourseRepositoriesAssignmentsCloneFailure checks the failure
+// policy for the assignments repository: the update itself still completes, and
+// only the cross-repository comparison is skipped.
+func TestUpdateFromCourseRepositoriesAssignmentsCloneFailure(t *testing.T) {
+	db, course := newCourse(t)
 	testsDir := t.TempDir()
 	writeFile(t, testsDir, "lab1", assignmentFile, j1)
-	writeFile(t, testsDir, "lab1", testsFile, testJson)
 	scmClient := &cloneOnlySCM{
 		directories: map[string]string{qf.TestsRepo: testsDir},
 		errors:      map[string]error{qf.AssignmentsRepo: errors.New("clone failed")},
 	}
 
 	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
-	_, err := UpdateFromTestsRepo(ctx, &ci.Local{}, db, scmClient, course)
-	if err == nil {
-		t.Fatal("UpdateFromTestsRepo() error = nil, want assignments clone error")
+	got, err := UpdateFromCourseRepositories(ctx, &ci.Local{}, db, scmClient, course)
+	if err != nil {
+		t.Fatalf("UpdateFromCourseRepositories() error = %v, want nil despite the assignments clone failure", err)
 	}
-	stored, dbErr := db.GetAssignmentsByCourse(course.GetID())
-	if dbErr != nil {
-		t.Fatal(dbErr)
+	// The missing tests.json is still reported; the alignment issue that the
+	// empty assignments repository would have produced is not.
+	if got != 1 {
+		t.Errorf("UpdateFromCourseRepositories() issue count = %d, want 1", got)
 	}
-	if len(stored) != 1 || stored[0].GetName() != "lab1" {
-		t.Errorf("stored assignments = %+v, want lab1 despite validation failure", stored)
+	assertStoredAssignments(t, db, course, []string{"lab1"})
+}
+
+// TestUpdateFromCourseRepositoriesTestsCloneFailure checks that a failure to
+// clone the tests repository aborts the update: nothing can be done without it.
+func TestUpdateFromCourseRepositoriesTestsCloneFailure(t *testing.T) {
+	db, course := newCourse(t)
+	scmClient := &cloneOnlySCM{errors: map[string]error{qf.TestsRepo: errors.New("clone failed")}}
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	if _, err := UpdateFromCourseRepositories(ctx, &ci.Local{}, db, scmClient, course); err == nil {
+		t.Fatal("UpdateFromCourseRepositories() error = nil, want tests clone error")
+	}
+	if calls := scmClient.calls; !slices.Equal(calls, []string{qf.TestsRepo}) {
+		t.Errorf("Clone() calls = %v, want only %q", calls, qf.TestsRepo)
+	}
+}
+
+// TestUpdateFromCourseRepositoriesClonesBothRepositories checks that the update
+// refreshes both local clones, whichever repository the push came from.
+func TestUpdateFromCourseRepositoriesClonesBothRepositories(t *testing.T) {
+	db, course := newCourse(t)
+	testsDir, assignmentsDir := t.TempDir(), t.TempDir()
+	writeFile(t, testsDir, "lab1", assignmentFile, j1)
+	writeFile(t, testsDir, "lab1", testsFile, testJson)
+	makeRepoDir(t, assignmentsDir, "lab1")
+	scmClient := &cloneOnlySCM{directories: map[string]string{
+		qf.TestsRepo:       testsDir,
+		qf.AssignmentsRepo: assignmentsDir,
+	}}
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	if _, err := UpdateFromCourseRepositories(ctx, &ci.Local{}, db, scmClient, course); err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []string{qf.TestsRepo, qf.AssignmentsRepo}
+	if diff := cmp.Diff(wantCalls, scmClient.calls); diff != "" {
+		t.Errorf("Clone() calls mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func assertStoredAssignments(t *testing.T, db database.Database, course *qf.Course, want []string) {
+	t.Helper()
+	stored, err := db.GetAssignmentsByCourse(course.GetID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(stored))
+	for _, assignment := range stored {
+		got = append(got, assignment.GetName())
+	}
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("stored assignments mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -228,9 +303,11 @@ type cloneOnlySCM struct {
 	scm.SCM
 	directories map[string]string
 	errors      map[string]error
+	calls       []string // repositories passed to Clone, in order
 }
 
 func (s *cloneOnlySCM) Clone(_ context.Context, options *scm.CloneOptions) (string, error) {
+	s.calls = append(s.calls, options.Repository)
 	if err := s.errors[options.Repository]; err != nil {
 		return "", err
 	}

--- a/assignments/repository_validation_test.go
+++ b/assignments/repository_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -34,8 +35,15 @@ func TestCourseRepositoryIssues(t *testing.T) {
 	writeRepoFile(t, testsDir, "lab5", assignmentFile)
 	makeRepoDir(t, assignmentsDir, "lab5")
 
-	// Shared packages and repository metadata are not assignment folders.
+	// Test code pushed without assignment.json and without the counterpart
+	// folder in the assignments repository; QuickFeed cannot tell this apart
+	// from shared course code, so it reports the folder once.
+	writeRepoFile(t, testsDir, "lab6", "lab6_test.go")
+
+	// A shared package is reported the same way until it is listed in the
+	// ignore file; see TestCourseRepositoryIssuesIgnoreFile.
 	writeRepoFile(t, testsDir, "internal/pkg", testsFile)
+	// Repository metadata is never an assignment folder.
 	makeRepoDir(t, testsDir, scriptsDir)
 	makeRepoDir(t, testsDir, ".github")
 
@@ -49,11 +57,64 @@ func TestCourseRepositoryIssues(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []RepoIssue{
+		{Assignment: "internal", File: "internal", Problem: `no assignment configuration found; add "internal/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
 		{Assignment: "lab2", File: "lab2", Problem: `assignment folder is missing from "assignments" repository`},
-		{Assignment: "lab3", File: "lab3", Problem: `assignment folder is missing from "tests" repository`},
-		{Assignment: "lab4", File: "lab4/assignment.json", Problem: `missing "lab4/assignment.json"`},
-		{Assignment: "lab4", File: "lab4", Problem: "missing tests.json or criteria.json"},
+		{Assignment: "lab3", File: "lab3", Problem: `assignment folder is missing from "tests" repository; add it or list the folder in .quickfeedignore`},
+		{Assignment: "lab4", File: "lab4", Problem: `no assignment configuration found; add "lab4/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
 		{Assignment: "lab5", File: "lab5", Problem: "missing tests.json or criteria.json"},
+		{Assignment: "lab6", File: "lab6", Problem: `no assignment configuration found; add "lab6/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("courseRepositoryIssues() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCourseRepositoryIssuesIgnoreFile(t *testing.T) {
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+
+	writeRepoFile(t, testsDir, "lab1", assignmentFile)
+	writeRepoFile(t, testsDir, "lab1", testsFile)
+	makeRepoDir(t, assignmentsDir, "lab1")
+
+	// Shared course code in the tests repository, and handout material that
+	// students receive but that has no tests; neither is an assignment.
+	writeRepoFile(t, testsDir, "internal", "helper.go")
+	makeRepoDir(t, assignmentsDir, "internal")
+	makeRepoDir(t, assignmentsDir, "resources")
+
+	writeIgnoreFile(
+		t, testsDir,
+		"# folders that are not assignments",
+		"internal",
+		"",
+		"resources",
+	)
+
+	got, err := courseRepositoryIssues(testsDir, assignmentsDir, []*qf.Assignment{{Name: "lab1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("courseRepositoryIssues() = %+v, want no issues", got)
+	}
+}
+
+func TestCourseRepositoryIssuesInvalidIgnoreEntry(t *testing.T) {
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+
+	writeRepoFile(t, testsDir, "internal", "helper.go")
+	writeIgnoreFile(t, testsDir, "internal/*")
+
+	got, err := courseRepositoryIssues(testsDir, assignmentsDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []RepoIssue{
+		{File: ".quickfeedignore", Problem: `invalid entry "internal/*": only top-level folder names are supported`},
+		// The invalid entry does not hide the folder it was meant to exclude.
+		{Assignment: "internal", File: "internal", Problem: `no assignment configuration found; add "internal/assignment.json" if this is an assignment, or list the folder in .quickfeedignore`},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("courseRepositoryIssues() mismatch (-want +got):\n%s", diff)
@@ -179,6 +240,14 @@ func (s *cloneOnlySCM) Clone(_ context.Context, options *scm.CloneOptions) (stri
 func makeRepoDir(t *testing.T, root string, elements ...string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(append([]string{root}, elements...)...), 0o750); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeIgnoreFile(t *testing.T, root string, lines ...string) {
+	t.Helper()
+	contents := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(root, ignoreFile), []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/assignments/repository_validation_test.go
+++ b/assignments/repository_validation_test.go
@@ -1,0 +1,195 @@
+package assignments
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/quickfeed/quickfeed/ci"
+	"github.com/quickfeed/quickfeed/internal/qlog"
+	"github.com/quickfeed/quickfeed/internal/qtest"
+	"github.com/quickfeed/quickfeed/qf"
+	"github.com/quickfeed/quickfeed/scm"
+)
+
+func TestCourseRepositoryIssues(t *testing.T) {
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+
+	writeRepoFile(t, testsDir, "lab1", assignmentFile)
+	writeRepoFile(t, testsDir, "lab1", testsFile)
+	makeRepoDir(t, assignmentsDir, "lab1")
+
+	writeRepoFile(t, testsDir, "lab2", assignmentFile)
+	writeRepoFile(t, testsDir, "lab2", criteriaFile)
+
+	makeRepoDir(t, assignmentsDir, "lab3")
+
+	makeRepoDir(t, testsDir, "lab4")
+	makeRepoDir(t, assignmentsDir, "lab4")
+
+	writeRepoFile(t, testsDir, "lab5", assignmentFile)
+	makeRepoDir(t, assignmentsDir, "lab5")
+
+	// Shared packages and repository metadata are not assignment folders.
+	writeRepoFile(t, testsDir, "internal/pkg", testsFile)
+	makeRepoDir(t, testsDir, scriptsDir)
+	makeRepoDir(t, testsDir, ".github")
+
+	parsed := []*qf.Assignment{
+		{Name: "lab1"},
+		{Name: "lab2", Reviewers: 1},
+		{Name: "lab5", Reviewers: 1},
+	}
+	got, err := courseRepositoryIssues(testsDir, assignmentsDir, parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []RepoIssue{
+		{Assignment: "lab2", File: "lab2", Problem: `assignment folder is missing from "assignments" repository`},
+		{Assignment: "lab3", File: "lab3", Problem: `assignment folder is missing from "tests" repository`},
+		{Assignment: "lab4", File: "lab4/assignment.json", Problem: `missing "lab4/assignment.json"`},
+		{Assignment: "lab4", File: "lab4", Problem: "missing tests.json or criteria.json"},
+		{Assignment: "lab5", File: "lab5", Problem: "missing tests.json or criteria.json"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("courseRepositoryIssues() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidateCourseRepositoriesCountsAllIssues(t *testing.T) {
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+	writeFile(t, testsDir, "lab1", assignmentFile, j1)
+	makeRepoDir(t, assignmentsDir, "lab1")
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	got, err := ValidateCourseRepositories(ctx, testsDir, assignmentsDir, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The tests repository content check reports the missing tests.json. The
+	// cross-repository check finds no additional problem for the aligned folders.
+	if got != 1 {
+		t.Errorf("ValidateCourseRepositories() = %d, want 1", got)
+	}
+}
+
+func TestValidateCourseRepositoriesDoesNotDuplicateMissingAssignment(t *testing.T) {
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+	writeFile(t, testsDir, "lab1", testsFile, testJson)
+	makeRepoDir(t, assignmentsDir, "lab1")
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	got, err := ValidateCourseRepositories(ctx, testsDir, assignmentsDir, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("ValidateCourseRepositories() = %d, want one missing-assignment issue", got)
+	}
+}
+
+func TestCourseRepositoryIssuesMissingRoot(t *testing.T) {
+	_, err := courseRepositoryIssues(filepath.Join(t.TempDir(), "missing"), t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("courseRepositoryIssues() error = nil, want missing repository error")
+	}
+}
+
+func TestUpdateFromTestsRepoReportsAlignmentIssues(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	admin := qtest.CreateFakeUser(t, db)
+	course := &qf.Course{}
+	qtest.CreateCourse(t, db, admin, course)
+
+	testsDir := t.TempDir()
+	assignmentsDir := t.TempDir()
+	writeFile(t, testsDir, "lab1", assignmentFile, j1)
+	writeFile(t, testsDir, "lab1", testsFile, testJson)
+	scmClient := &cloneOnlySCM{directories: map[string]string{
+		qf.TestsRepo:       testsDir,
+		qf.AssignmentsRepo: assignmentsDir,
+	}}
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	got, err := UpdateFromTestsRepo(ctx, &ci.Local{}, db, scmClient, course)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("UpdateFromTestsRepo() issue count = %d, want 1", got)
+	}
+	stored, err := db.GetAssignmentsByCourse(course.GetID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored) != 1 || stored[0].GetName() != "lab1" {
+		t.Errorf("stored assignments = %+v, want lab1", stored)
+	}
+}
+
+func TestUpdateFromTestsRepoPersistsBeforeAlignmentFailure(t *testing.T) {
+	db, cleanup := qtest.TestDB(t)
+	defer cleanup()
+	admin := qtest.CreateFakeUser(t, db)
+	course := &qf.Course{}
+	qtest.CreateCourse(t, db, admin, course)
+
+	testsDir := t.TempDir()
+	writeFile(t, testsDir, "lab1", assignmentFile, j1)
+	writeFile(t, testsDir, "lab1", testsFile, testJson)
+	scmClient := &cloneOnlySCM{
+		directories: map[string]string{qf.TestsRepo: testsDir},
+		errors:      map[string]error{qf.AssignmentsRepo: errors.New("clone failed")},
+	}
+
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	_, err := UpdateFromTestsRepo(ctx, &ci.Local{}, db, scmClient, course)
+	if err == nil {
+		t.Fatal("UpdateFromTestsRepo() error = nil, want assignments clone error")
+	}
+	stored, dbErr := db.GetAssignmentsByCourse(course.GetID())
+	if dbErr != nil {
+		t.Fatal(dbErr)
+	}
+	if len(stored) != 1 || stored[0].GetName() != "lab1" {
+		t.Errorf("stored assignments = %+v, want lab1 despite validation failure", stored)
+	}
+}
+
+type cloneOnlySCM struct {
+	scm.SCM
+	directories map[string]string
+	errors      map[string]error
+}
+
+func (s *cloneOnlySCM) Clone(_ context.Context, options *scm.CloneOptions) (string, error) {
+	if err := s.errors[options.Repository]; err != nil {
+		return "", err
+	}
+	return s.directories[options.Repository], nil
+}
+
+func makeRepoDir(t *testing.T, root string, elements ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(append([]string{root}, elements...)...), 0o750); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRepoFile(t *testing.T, root string, elements ...string) {
+	t.Helper()
+	path := filepath.Join(append([]string{root}, elements...)...)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/assignments/walk_tests_repo.go
+++ b/assignments/walk_tests_repo.go
@@ -22,14 +22,18 @@ const (
 	scriptsDir     = "scripts"
 )
 
-// RepoIssue describes a content problem detected in the tests repository,
-// such as a malformed json file or a missing assignment.json. Issues are
-// reported to the teaching staff via the course log; they do not abort the
-// assignment update.
+// RepoIssue describes a problem detected in the course repositories, such as
+// a malformed json file, a missing assignment.json, or an assignment folder
+// present in only one of the two repositories. Issues are reported to the
+// teaching staff via the course log; they do not abort the assignment update.
 type RepoIssue struct {
 	Assignment string // assignment folder name; empty for repository-level issues
 	File       string // repository-relative path, e.g., "lab1/tests.json"
 	Problem    string
+	// Transient marks an issue that depends on both course repositories and
+	// that resolves itself once the teaching staff has pushed to both. Such
+	// issues are reported less prominently; see logRepositoryIssues.
+	Transient bool
 }
 
 // filesForBuildContext specifies files for the Docker build context.

--- a/assignments/walk_tests_repo_test.go
+++ b/assignments/walk_tests_repo_test.go
@@ -227,7 +227,7 @@ func TestReadTestsRepositoryContentBadContent(t *testing.T) {
 			if !slices.ContainsFunc(issues, func(issue RepoIssue) bool {
 				return strings.Contains(issue.Problem, tc.wantProblem)
 			}) {
-				t.Errorf("issues %q do not mention %q", issues, tc.wantProblem)
+				t.Errorf("issues %+v do not mention %q", issues, tc.wantProblem)
 			}
 		})
 	}

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -49,7 +49,7 @@ func setupRunData(t *testing.T, runner ci.Runner) *ci.RunData {
 	}
 	course.UpdateDockerfile(dockerfile)
 
-	// Emulate running UpdateFromTestsRepo to ensure the docker image is built before running tests.
+	// Emulate running UpdateFromCourseRepositories to ensure the docker image is built before running tests.
 	t.Logf("Building %s's Dockerfile:\n%v", course.GetCode(), course.GetDockerfile())
 	out, err := runner.Run(context.Background(), &ci.Job{
 		Name:  course.JobName(),

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -160,6 +160,9 @@ To facilitate automated testing and scoring of student submitted solutions, a te
 This is the purpose of the `tests` repository.
 
 The file system layout of the `tests` repository must match that of the `assignments` repository, as shown below.
+Every top-level assignment folder must occur in both repositories.
+Each assignment folder in the `tests` repository must contain `assignment.json` and at least one of `tests.json` or `criteria.json`.
+QuickFeed checks these requirements whenever either repository is updated and reports problems in the course log.
 The `assignment.json` files contains the [assignment information](#assignment-information).
 In addition, each assignment folder should also contain test code for the corresponding assignment.
 If the assignment has tests that should be run by QuickFeed, the the tests should be listed in the `tests.json` file.

--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -70,7 +70,7 @@ QuickFeed uses the following repository structure.
 These will be created automatically when a course is created.
 
 | Repository name | Description                                                                    | Access                        |
-|-----------------|--------------------------------------------------------------------------------|-------------------------------|
+| --------------- | ------------------------------------------------------------------------------ | ----------------------------- |
 | info            | Holds information about the course.                                            | Public                        |
 | assignments     | Contains a separate folder for each assignment.                                | Students, Teachers, QuickFeed |
 | username-labs   | Created for each student username in QuickFeed                                 | Student, Teachers, QuickFeed  |
@@ -163,6 +163,7 @@ The file system layout of the `tests` repository must match that of the `assignm
 Every top-level assignment folder must occur in both repositories.
 Each assignment folder in the `tests` repository must contain `assignment.json` and at least one of `tests.json` or `criteria.json`.
 QuickFeed checks these requirements whenever either repository is updated and reports problems in the course log.
+See [Folders That Are Not Assignments](#folders-that-are-not-assignments) for top-level folders that are exempt.
 The `assignment.json` files contains the [assignment information](#assignment-information).
 In addition, each assignment folder should also contain test code for the corresponding assignment.
 If the assignment has tests that should be run by QuickFeed, the the tests should be listed in the `tests.json` file.
@@ -175,6 +176,7 @@ Otherwise, the [test runner](#test-runners) for each assignment specifies which 
 
 ```text
 tests┐
+     ├── .quickfeedignore
      ├── lab1
      │   ├── assignment.json
      │   ├── tests.json
@@ -188,10 +190,30 @@ tests┐
      ├── lab4
      │   ├── assignment.json
      │   └── criteria.json
+     ├── internal
+     │   └── grading.go
      └── scripts
          ├── Dockerfile
          └── run.sh
 ```
+
+#### Folders That Are Not Assignments
+
+QuickFeed treats every top-level folder in either repository as an assignment folder, so that a folder missing its `assignment.json` is reported rather than silently skipped.
+The `scripts` folder and folders whose name begins with a dot are the only built-in exceptions.
+
+Courses that keep shared code, handout material, or tooling in a top-level folder should list those folders in an optional `.quickfeedignore` file in the root of the `tests` repository.
+Each line names one top-level folder, in either repository; blank lines and lines starting with `#` are skipped.
+Only exact folder names are supported; entries containing path separators or glob characters are reported as invalid and have no effect.
+
+```text
+# folders that are not assignments
+internal
+resources
+```
+
+Listing a folder is optional.
+An unlisted folder is reported once per update with a message naming both remedies; adding it to `.quickfeedignore` silences the message.
 
 ### Assignment Information
 
@@ -217,7 +239,7 @@ QuickFeed only use the fields in the table below.
 The `title` and `effort` are used by other tooling to create a README.md file for an assignment.
 
 | Field              | Description                                                                                    |
-|--------------------|------------------------------------------------------------------------------------------------|
+| ------------------ | ---------------------------------------------------------------------------------------------- |
 | `order`            | Assignment's sequence number; used to order the assignments in the frontend.                   |
 | `deadline`         | Submission deadline for the assignment.                                                        |
 | `isgrouplab`       | Assignment is considered a group assignment if true; otherwise it is an individual assignment. |

--- a/qf/course.go
+++ b/qf/course.go
@@ -44,7 +44,7 @@ var (
 // Lock locks the course to prevent concurrent updates to the course.
 // It returns a corresponding unlock function which must be called when the update is done.
 // Specifically, this method is used to prevent concurrent database updates
-// derived from the test repository. See [assignments.UpdateFromTestsRepo].
+// derived from the course repositories. See [assignments.UpdateFromCourseRepositories].
 func (course *Course) Lock() func() {
 	mapMutex.Lock()
 	if _, ok := courseMutexMap[course.GetID()]; !ok {

--- a/web/assignments_test.go
+++ b/web/assignments_test.go
@@ -36,8 +36,8 @@ func TestUpdateAssignments(t *testing.T) {
 		},
 		{
 			// The mock's tests repository is empty, so the clone inside
-			// UpdateFromTestsRepo fails; previously this failure was silently
-			// ignored and the RPC continued to the assignments repository.
+			// UpdateFromCourseRepositories fails; previously this failure was
+			// silently ignored and the RPC continued to the assignments repository.
 			name: "Valid course ID but failed to clone tests repository",
 			request: &qf.CourseRequest{
 				CourseID: course.GetID(),

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -83,7 +83,7 @@ func TestGetCourseWithoutDockerfileDigest(t *testing.T) {
 		t.Errorf("UpdateDockerfile(%q) = %t, want %t", dockerfile, got, want)
 	}
 	// Update the course's DockerfileDigest in the database
-	// To simulate the behavior in assignments.UpdateFromTestsRepo()
+	// To simulate the behavior in assignments.UpdateFromCourseRepositories()
 	if err := db.UpdateCourse(course); err != nil {
 		t.Error(err)
 	}

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -60,14 +60,18 @@ func (wh GitHubWebHook) handlePush(ctx context.Context, payload *github.PushEven
 	case repo.IsTestsRepo():
 		// The push event is for the tests repository, so update the course
 		// assignments in the database.
-		if _, err := assignments.UpdateFromTestsRepo(ctx, wh.runner, wh.db, scmClient, course); err != nil {
-			logger.Error("failed to update assignments from tests repository", label.Error, err)
+		if _, err := assignments.UpdateFromCourseRepositories(ctx, wh.runner, wh.db, scmClient, course); err != nil {
+			logger.Error("failed to update from course repositories", label.Error, err)
 		}
 
 	case repo.IsAssignmentsRepo():
-		if err := validateAssignmentsPush(ctx, scmClient, course); err != nil {
-			logger.Error("failed to clone repository", label.Error, err)
-			return
+		// A push to the assignments repository runs the same update, which
+		// reconciles the database with the tests repository and reports the
+		// alignment of the two. A failure must not prevent the sync below:
+		// syncStudentRepos works against the SCM's fork API, not the local
+		// clones, and is unaffected by whatever failed here.
+		if _, err := assignments.UpdateFromCourseRepositories(ctx, wh.runner, wh.db, scmClient, course); err != nil {
+			logger.Error("failed to update from course repositories", label.Error, err)
 		}
 		if isDefaultBranch(payload) {
 			// Sync all student repositories (forks) with the updated assignments repo
@@ -88,40 +92,6 @@ func (wh GitHubWebHook) handlePush(ctx context.Context, payload *github.PushEven
 	default:
 		logger.Debug("nothing to do for push event")
 	}
-}
-
-// validateAssignmentsPush updates both local course repositories and checks
-// their content and assignment-folder alignment. A tests repository failure is
-// logged but does not prevent syncing the assignments repository to students.
-func validateAssignmentsPush(ctx context.Context, scmClient scm.SCM, course *qf.Course) error {
-	unlock := course.Lock()
-	defer unlock()
-
-	logger := qlog.FromContext(ctx)
-	clonedAssignmentsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
-		Organization: course.GetScmOrganizationName(),
-		Repository:   qf.AssignmentsRepo,
-		DestDir:      course.CloneDir(),
-	})
-	if err != nil {
-		return err
-	}
-	logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
-
-	clonedTestsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
-		Organization: course.GetScmOrganizationName(),
-		Repository:   qf.TestsRepo,
-		DestDir:      course.CloneDir(),
-	})
-	if err != nil {
-		logger.Error("failed to clone tests repository for validation", label.Error, err)
-		return nil
-	}
-	logger.Debug("cloned tests repository for validation", label.Path, clonedTestsRepo)
-	if _, err := assignments.ValidateCourseRepositories(ctx, clonedTestsRepo, clonedAssignmentsRepo, course.GetID()); err != nil {
-		logger.Error("failed to validate course repositories", label.Error, err)
-	}
-	return nil
 }
 
 // ignorePush returns true if the push event should be ignored.

--- a/web/hooks/push.go
+++ b/web/hooks/push.go
@@ -65,17 +65,10 @@ func (wh GitHubWebHook) handlePush(ctx context.Context, payload *github.PushEven
 		}
 
 	case repo.IsAssignmentsRepo():
-		// the push event is for the 'assignments' repo; we need to update the local working copy
-		clonedAssignmentsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
-			Organization: course.GetScmOrganizationName(),
-			Repository:   qf.AssignmentsRepo,
-			DestDir:      course.CloneDir(),
-		})
-		if err != nil {
+		if err := validateAssignmentsPush(ctx, scmClient, course); err != nil {
 			logger.Error("failed to clone repository", label.Error, err)
 			return
 		}
-		logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
 		if isDefaultBranch(payload) {
 			// Sync all student repositories (forks) with the updated assignments repo
 			wh.syncStudentRepos(ctx, scmClient, course, payload.GetRepo().GetDefaultBranch())
@@ -95,6 +88,40 @@ func (wh GitHubWebHook) handlePush(ctx context.Context, payload *github.PushEven
 	default:
 		logger.Debug("nothing to do for push event")
 	}
+}
+
+// validateAssignmentsPush updates both local course repositories and checks
+// their content and assignment-folder alignment. A tests repository failure is
+// logged but does not prevent syncing the assignments repository to students.
+func validateAssignmentsPush(ctx context.Context, scmClient scm.SCM, course *qf.Course) error {
+	unlock := course.Lock()
+	defer unlock()
+
+	logger := qlog.FromContext(ctx)
+	clonedAssignmentsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
+		Organization: course.GetScmOrganizationName(),
+		Repository:   qf.AssignmentsRepo,
+		DestDir:      course.CloneDir(),
+	})
+	if err != nil {
+		return err
+	}
+	logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
+
+	clonedTestsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
+		Organization: course.GetScmOrganizationName(),
+		Repository:   qf.TestsRepo,
+		DestDir:      course.CloneDir(),
+	})
+	if err != nil {
+		logger.Error("failed to clone tests repository for validation", label.Error, err)
+		return nil
+	}
+	logger.Debug("cloned tests repository for validation", label.Path, clonedTestsRepo)
+	if _, err := assignments.ValidateCourseRepositories(ctx, clonedTestsRepo, clonedAssignmentsRepo, course.GetID()); err != nil {
+		logger.Error("failed to validate course repositories", label.Error, err)
+	}
+	return nil
 }
 
 // ignorePush returns true if the push event should be ignored.

--- a/web/hooks/push_test.go
+++ b/web/hooks/push_test.go
@@ -2,15 +2,12 @@ package hooks
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v62/github"
 	"github.com/quickfeed/quickfeed/ci"
-	"github.com/quickfeed/quickfeed/internal/qlog"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
@@ -18,44 +15,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func TestValidateAssignmentsPushRefreshesBothRepositories(t *testing.T) {
-	testsDir := filepath.Join(t.TempDir(), qf.TestsRepo)
-	assignmentsDir := filepath.Join(t.TempDir(), qf.AssignmentsRepo)
-	for _, dir := range []string{filepath.Join(testsDir, "lab1"), filepath.Join(assignmentsDir, "lab1")} {
-		if err := os.MkdirAll(dir, 0o750); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(testsDir, "lab1", "assignment.json"), []byte("{}"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	scmClient := &cloningSCM{directories: map[string]string{
-		qf.TestsRepo:       testsDir,
-		qf.AssignmentsRepo: assignmentsDir,
-	}}
-	course := &qf.Course{ID: 42, ScmOrganizationName: "course-2026"}
-	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
-	if err := validateAssignmentsPush(ctx, scmClient, course); err != nil {
-		t.Fatal(err)
-	}
-	wantCalls := []string{qf.AssignmentsRepo, qf.TestsRepo}
-	if diff := cmp.Diff(wantCalls, scmClient.calls); diff != "" {
-		t.Errorf("Clone() calls mismatch (-want +got):\n%s", diff)
-	}
-}
-
-type cloningSCM struct {
-	scm.SCM
-	directories map[string]string
-	calls       []string
-}
-
-func (s *cloningSCM) Clone(_ context.Context, options *scm.CloneOptions) (string, error) {
-	s.calls = append(s.calls, options.Repository)
-	return s.directories[options.Repository], nil
-}
 
 func TestExtractAssignments(t *testing.T) {
 	course := qtest.MockCourses[0]

--- a/web/hooks/push_test.go
+++ b/web/hooks/push_test.go
@@ -2,12 +2,15 @@ package hooks
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v62/github"
 	"github.com/quickfeed/quickfeed/ci"
+	"github.com/quickfeed/quickfeed/internal/qlog"
 	"github.com/quickfeed/quickfeed/internal/qtest"
 	"github.com/quickfeed/quickfeed/qf"
 	"github.com/quickfeed/quickfeed/scm"
@@ -15,6 +18,44 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestValidateAssignmentsPushRefreshesBothRepositories(t *testing.T) {
+	testsDir := filepath.Join(t.TempDir(), qf.TestsRepo)
+	assignmentsDir := filepath.Join(t.TempDir(), qf.AssignmentsRepo)
+	for _, dir := range []string{filepath.Join(testsDir, "lab1"), filepath.Join(assignmentsDir, "lab1")} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(testsDir, "lab1", "assignment.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	scmClient := &cloningSCM{directories: map[string]string{
+		qf.TestsRepo:       testsDir,
+		qf.AssignmentsRepo: assignmentsDir,
+	}}
+	course := &qf.Course{ID: 42, ScmOrganizationName: "course-2026"}
+	ctx := qlog.NewContext(t.Context(), qtest.Logger(t))
+	if err := validateAssignmentsPush(ctx, scmClient, course); err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []string{qf.AssignmentsRepo, qf.TestsRepo}
+	if diff := cmp.Diff(wantCalls, scmClient.calls); diff != "" {
+		t.Errorf("Clone() calls mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type cloningSCM struct {
+	scm.SCM
+	directories map[string]string
+	calls       []string
+}
+
+func (s *cloningSCM) Clone(_ context.Context, options *scm.CloneOptions) (string, error) {
+	s.calls = append(s.calls, options.Repository)
+	return s.directories[options.Repository], nil
+}
 
 func TestExtractAssignments(t *testing.T) {
 	course := qtest.MockCourses[0]

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -490,17 +490,17 @@ func (s *QuickFeedService) GetAssignments(ctx context.Context, in *qf.CourseRequ
 }
 
 // UpdateAssignments updates the course's assignments record in the database
-// by fetching assignment information from the course's test repository.
-// The response reports the number of content issues found; details are written
-// to the course log so that the teaching staff can fix them.
+// by fetching assignment information from the course's tests repository, and
+// comparing it with the assignments repository. The response reports the
+// number of issues found; details are written to the course log so that the
+// teaching staff can fix them.
 func (s *QuickFeedService) UpdateAssignments(ctx context.Context, in *qf.CourseRequest) (*qf.RepositoryIssues, error) {
 	course, err := s.db.GetCourse(in.GetCourseID())
 	if err != nil {
 		qlog.FromContext(ctx).Error("failed to get course", label.Error, err)
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("course not found"))
 	}
-	// Scope the remainder of the method to the course; the update below uses a
-	// tests-repository scope on top of this.
+	// Scope the remainder of the method to the course.
 	// The course ID comes from the request logger; see enrichRequestLogger.
 	ctx, logger := qlog.WithCourseLog(ctx, course)
 	scmClient, err := s.getSCM(ctx, course.GetScmOrganizationName())
@@ -508,10 +508,9 @@ func (s *QuickFeedService) UpdateAssignments(ctx context.Context, in *qf.CourseR
 		logger.Error("failed to create SCM client", label.Error, err)
 		return nil, scmConnectErr
 	}
-	testsCtx := qlog.With(ctx, label.Repository, qf.TestsRepo, label.RepositoryType, qf.Repository_TESTS.String())
-	issueCount, err := assignments.UpdateFromTestsRepo(testsCtx, s.runner, s.db, scmClient, course)
+	issueCount, err := assignments.UpdateFromCourseRepositories(ctx, s.runner, s.db, scmClient, course)
 	if err != nil {
-		qlog.FromContext(testsCtx).Error("failed to update assignments from tests repository", label.Error, err)
+		logger.Error("failed to update from course repositories", label.Error, err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to update assignments from tests repository"))
 	}
 	return &qf.RepositoryIssues{Count: uint32(issueCount)}, nil

--- a/web/quickfeed_service.go
+++ b/web/quickfeed_service.go
@@ -499,8 +499,8 @@ func (s *QuickFeedService) UpdateAssignments(ctx context.Context, in *qf.CourseR
 		qlog.FromContext(ctx).Error("failed to get course", label.Error, err)
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("course not found"))
 	}
-	// Scope the remainder of the method to the course; UpdateFromTestsRepo and
-	// the clone below add only their own repository scope on top of this.
+	// Scope the remainder of the method to the course; the update below uses a
+	// tests-repository scope on top of this.
 	// The course ID comes from the request logger; see enrichRequestLogger.
 	ctx, logger := qlog.WithCourseLog(ctx, course)
 	scmClient, err := s.getSCM(ctx, course.GetScmOrganizationName())
@@ -508,28 +508,12 @@ func (s *QuickFeedService) UpdateAssignments(ctx context.Context, in *qf.CourseR
 		logger.Error("failed to create SCM client", label.Error, err)
 		return nil, scmConnectErr
 	}
-	// Scope the logger with the tests repository separately, so that it does not
-	// carry over to the assignments repository scope below.
 	testsCtx := qlog.With(ctx, label.Repository, qf.TestsRepo, label.RepositoryType, qf.Repository_TESTS.String())
 	issueCount, err := assignments.UpdateFromTestsRepo(testsCtx, s.runner, s.db, scmClient, course)
 	if err != nil {
 		qlog.FromContext(testsCtx).Error("failed to update assignments from tests repository", label.Error, err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to update assignments from tests repository"))
 	}
-
-	// Scope the remaining log calls with the assignments repository
-	ctx, logger = qlog.WithLogger(ctx, label.Repository, qf.AssignmentsRepo, label.RepositoryType, qf.Repository_ASSIGNMENTS.String())
-	clonedAssignmentsRepo, err := scmClient.Clone(ctx, &scm.CloneOptions{
-		Organization: course.GetScmOrganizationName(),
-		Repository:   qf.AssignmentsRepo,
-		DestDir:      course.CloneDir(),
-	})
-	if err != nil {
-		logger.Error("failed to clone assignments repository", label.Error, err)
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("failed to clone assignments repository"))
-	}
-	logger.Debug("cloned assignments repository", label.Path, clonedAssignmentsRepo)
-
 	return &qf.RepositoryIssues{Count: uint32(issueCount)}, nil
 }
 


### PR DESCRIPTION
Compare assignment folders in tests and assignments whenever either repository changes. Report missing folders and configuration through the course log without preventing assignment metadata updates. Fixes #1595




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>