### PR TITLE
Fix: ci use portable bash name instead of hardcoded /bin/bash

### DIFF
--- a/ci/local_unix.go
+++ b/ci/local_unix.go
@@ -15,7 +15,7 @@ type Local struct{}
 // completed or an error occurs, e.g., the context times out.
 func (*Local) Run(_ context.Context, job *Job) (string, error) {
 	// TODO: Execute tests in something like: os.CreateTemp(os.TempDir(), "local-ci")
-	cmd := exec.Command("/bin/bash", "-c", strings.Join(job.Commands, "\n"))
+	cmd := exec.Command("bash", "-c", strings.Join(job.Commands, "\n"))
 	cmd.Env = job.Env
 	b, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
## Description

On NixOS (and potentially other non-FHS Linux systems), `/bin/bash` does not exist — bash lives in the Nix store.
The hardcoded path caused `TestRebuildSubmissions` to fail with:

```
fork/exec /bin/bash: no such file or directory
```

Replace the hardcoded path with just `"bash"`.
`exec.Command` already calls `exec.LookPath` internally when the name contains no path separators, resolving bash from `$PATH` portably across Linux, macOS, and NixOS.

## Testing

- `go test ./ci/... -run TestLocal` — passes
- `go test ./web/... -run TestRebuildSubmissions` — previously failing, now passes
- `make test` — all tests pass

## Breaking Changes

None that I'm aware
