### PR TITLE
fix(frontend): polish teacher course log view

### DIFF
--- a/doc/teacher.md
+++ b/doc/teacher.md
@@ -101,13 +101,13 @@ This approach prevents accidentally revealing commit history from old course ins
 
 ### Course Logs
 
-The "Course Logs" tile, on the course's teacher page, shows what QuickFeed has done on your course's behalf: incoming webhook events, CI and Docker output from building and testing submissions, and rebuilds or assignment syncs you trigger yourself. It does not include the operator-only server log, and it never includes a student's own successful test output, which stays on that student's submission page.
+The "Course Logs" tile, on the course's teacher page, shows what QuickFeed has done on your course's behalf: incoming webhook events, CI and Docker output from building and testing submissions, and rebuilds or assignment syncs you trigger yourself.
+It does not include the operator-only server log, and it never includes a student's own successful test output, which stays on that student's submission page.
 
-By default, the page shows the last 24 hours, ending whenever you last clicked Refresh; leave To alone and each Refresh brings the view up to the present. Use the From/To fields to look further back, up to 14 days: QuickFeed only keeps that much history, so an interval reaching further back is narrowed automatically rather than rejected. A From that falls after To is rejected, since no entry can lie in such an interval. The Repository and Minimum level selectors narrow the result further; the repository list always reflects every repository active in the selected interval, so switching one filter never removes an option from the other, and a repository you have selected stays listed even once it falls quiet. Changing any of these takes effect the next time you click Refresh; the free-text box below it, by contrast, filters what is already on screen immediately, with no additional request. Copy and Download act on whatever is currently on screen, filters included.
+QuickFeed keeps 14 days of history.
 
-Each entry shows its time, level, repository, and message, followed by the structured details QuickFeed recorded with it, such as the assignment, the commit, and the CI or Docker output. A very long result is cut off at its newest entries; the page says so when that happens, and narrowing the interval or the filters brings the rest into reach.
-
-A course's logs begin accumulating once it starts running on a QuickFeed deployment that has this feature; nothing is recorded retroactively for activity from before that.
+The interval, repository, and level filters take effect when you click Refresh.
+The free-text box and the Columns row instead act on what is already on screen; Copy and Download include attributes you have hidden.
 
 ## Teaching Assistants
 

--- a/public/src/__tests__/courseLogFormatting.test.ts
+++ b/public/src/__tests__/courseLogFormatting.test.ts
@@ -1,0 +1,56 @@
+import { create } from "@bufbuild/protobuf"
+import { timestampFromDate } from "@bufbuild/protobuf/wkt"
+import { CourseLogEntry_Level, CourseLogEntrySchema } from "../../proto/qf/requests_pb"
+import { entryText, entryTime, logText, toLocalDatetimeInput } from "../components/teacher/courseLogFormatting"
+
+describe("course log timestamps", () => {
+    test.each([
+        { date: new Date(2026, 0, 2, 0, 3, 4), input: "2026-01-02T00:03", time: "2026-01-02 00:03:04" },
+        { date: new Date(2024, 1, 29, 23, 59, 58), input: "2024-02-29T23:59", time: "2024-02-29 23:59:58" },
+    ])("formats $time using local time and a 24-hour clock", ({ date, input, time }) => {
+        expect(toLocalDatetimeInput(date)).toBe(input)
+        expect(entryTime(create(CourseLogEntrySchema, { time: timestampFromDate(date) }))).toBe(time)
+    })
+
+    test("omits a missing timestamp", () => {
+        expect(entryTime(create(CourseLogEntrySchema))).toBe("")
+    })
+})
+
+describe("course log text", () => {
+    test("includes structured fields in key order without losing multiline output or colliding names", () => {
+        const entry = create(CourseLogEntrySchema, {
+            time: timestampFromDate(new Date(2026, 2, 10, 12, 0, 1)),
+            level: CourseLogEntry_Level.ERROR,
+            repository: "student-a",
+            message: "test run failed",
+            fields: { output: "--- FAIL: TestFoo\n    want 1, got 2", message: "details", assignment: "lab1" },
+            source: "ci/run_tests.go:120",
+        })
+        expect(entryText(entry)).toBe("2026-03-10 12:00:01 Error [student-a] test run failed assignment=lab1 message=details output=--- FAIL: TestFoo\n    want 1, got 2 ci/run_tests.go:120")
+        const reordered = create(CourseLogEntrySchema, {
+            ...entry,
+            fields: { assignment: "lab1", message: "details", output: "--- FAIL: TestFoo\n    want 1, got 2" },
+        })
+        expect(entryText(reordered)).toBe(entryText(entry))
+    })
+
+    test.each([
+        [CourseLogEntry_Level.DEBUG, "Debug"],
+        [CourseLogEntry_Level.INFO, "Info"],
+        [CourseLogEntry_Level.WARN, "Warn"],
+        [CourseLogEntry_Level.ERROR, "Error"],
+    ] as const)("formats level %s and omits absent attributes", (level, name) => {
+        expect(entryText(create(CourseLogEntrySchema, { level, message: "event" }))).toBe(`${name} event`)
+    })
+
+    test("exports only the supplied entries in their existing order", () => {
+        const entries = [
+            create(CourseLogEntrySchema, { level: CourseLogEntry_Level.WARN, message: "second" }),
+            create(CourseLogEntrySchema, { level: CourseLogEntry_Level.INFO, message: "first" }),
+        ]
+        expect(logText(entries)).toBe("Warn second\nInfo first")
+        expect(logText(entries.slice(1))).toBe("Info first")
+        expect(logText([])).toBe("")
+    })
+})

--- a/public/src/__tests__/courseLogFormatting.test.ts
+++ b/public/src/__tests__/courseLogFormatting.test.ts
@@ -23,11 +23,12 @@ describe("course log text", () => {
             time: timestampFromDate(new Date(2026, 2, 10, 12, 0, 1)),
             level: CourseLogEntry_Level.ERROR,
             repository: "student-a",
+            repositoryType: "USER",
             message: "test run failed",
             fields: { output: "--- FAIL: TestFoo\n    want 1, got 2", message: "details", assignment: "lab1" },
             source: "ci/run_tests.go:120",
         })
-        expect(entryText(entry)).toBe("2026-03-10 12:00:01 Error [student-a] test run failed assignment=lab1 message=details output=--- FAIL: TestFoo\n    want 1, got 2 ci/run_tests.go:120")
+        expect(entryText(entry)).toBe("2026-03-10 12:00:01 Error [student-a USER] test run failed assignment=lab1 message=details output=--- FAIL: TestFoo\n    want 1, got 2 ci/run_tests.go:120")
         const reordered = create(CourseLogEntrySchema, {
             ...entry,
             fields: { assignment: "lab1", message: "details", output: "--- FAIL: TestFoo\n    want 1, got 2" },

--- a/public/src/__tests__/courseLogTable.test.tsx
+++ b/public/src/__tests__/courseLogTable.test.tsx
@@ -26,6 +26,23 @@ describe("CourseLogTable", () => {
         expect(screen.getByText("log message")).toBeTruthy()
     })
 
+    test("toggles columns inline, with no menu to open first", () => {
+        const entries = [create(CourseLogEntrySchema, { message: "log message", fields: { commit: "abc123" } })]
+        render(<CourseLogTable entries={entries} rows={entries} />)
+
+        // Every chip is reachable without opening anything, and a hidden column
+        // keeps its chip, so showing it again is a single click.
+        const group = screen.getByRole("group", { name: "Columns" })
+        expect(screen.queryByRole("button", { name: "Columns" })).toBeNull()
+        const commit = screen.getByLabelText("Show commit") as HTMLInputElement
+        expect(group.contains(commit)).toBe(true)
+        expect(commit.checked).toBe(true)
+        fireEvent.click(commit)
+        expect(screen.queryByRole("columnheader", { name: "commit" })).toBeNull()
+        expect((screen.getByLabelText("Show commit") as HTMLInputElement).checked).toBe(false)
+        expect(group.contains(screen.getByLabelText("Show commit"))).toBe(true)
+    })
+
     test("keeps columns from entries excluded by search", () => {
         const entries = [
             create(CourseLogEntrySchema, { message: "first", fields: { assignment: "lab1" } }),

--- a/public/src/__tests__/courseLogTable.test.tsx
+++ b/public/src/__tests__/courseLogTable.test.tsx
@@ -1,0 +1,55 @@
+import { create } from "@bufbuild/protobuf"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { CourseLogEntrySchema } from "../../proto/qf/requests_pb"
+import CourseLogTable from "../components/teacher/CourseLogTable"
+
+describe("CourseLogTable", () => {
+    test("renders and toggles fixed and structured columns independently", () => {
+        const entries = [create(CourseLogEntrySchema, {
+            message: "log message",
+            source: "ci/tests.go:12",
+            fields: { message: "structured message", source: "structured source", "field:message": "nested name" },
+        })]
+        render(<CourseLogTable entries={entries} rows={entries} />)
+
+        expect(screen.getByText("log message")).toBeTruthy()
+        expect(screen.getByText("structured message")).toBeTruthy()
+        expect(screen.getByText("structured source")).toBeTruthy()
+        expect(screen.getByText("nested name")).toBeTruthy()
+        fireEvent.click(screen.getByLabelText("Show Message"))
+        expect(screen.queryByText("log message")).toBeNull()
+        expect(screen.getByText("structured message")).toBeTruthy()
+        fireEvent.click(screen.getByLabelText("Show source (field)"))
+        expect(screen.queryByText("structured source")).toBeNull()
+        expect(screen.getByText("ci/tests.go:12")).toBeTruthy()
+        fireEvent.click(screen.getByLabelText("Show Message"))
+        expect(screen.getByText("log message")).toBeTruthy()
+    })
+
+    test("keeps columns from entries excluded by search", () => {
+        const entries = [
+            create(CourseLogEntrySchema, { message: "first", fields: { assignment: "lab1" } }),
+            create(CourseLogEntrySchema, { message: "second", fields: { output: "test output" } }),
+        ]
+        render(<CourseLogTable entries={entries} rows={[entries[0]]} />)
+        expect(screen.getByRole("columnheader", { name: "output" })).toBeTruthy()
+        expect(screen.getByLabelText("Show output")).toBeTruthy()
+        expect(screen.queryByText("test output")).toBeNull()
+    })
+
+    test("remembers hidden columns through empty results and changing fields", () => {
+        const entries = [create(CourseLogEntrySchema, { fields: { commit: "abc123" } })]
+        const { rerender } = render(<CourseLogTable entries={entries} rows={entries} />)
+        fireEvent.click(screen.getByLabelText("Show commit"))
+        rerender(<CourseLogTable entries={[]} rows={[]} />)
+        expect(screen.queryByRole("table")).toBeNull()
+        const withoutCommit = [create(CourseLogEntrySchema, { message: "no commit" })]
+        rerender(<CourseLogTable entries={withoutCommit} rows={withoutCommit} />)
+        expect(screen.queryByLabelText("Show commit")).toBeNull()
+        rerender(<CourseLogTable entries={entries} rows={entries} />)
+        expect(screen.queryByRole("columnheader", { name: "commit" })).toBeNull()
+        expect((screen.getByLabelText("Show commit") as HTMLInputElement).checked).toBe(false)
+        fireEvent.click(screen.getByLabelText("Show commit"))
+        expect(screen.getByText("abc123")).toBeTruthy()
+    })
+})

--- a/public/src/__tests__/courseLogs.test.tsx
+++ b/public/src/__tests__/courseLogs.test.tsx
@@ -88,7 +88,72 @@ describe("CourseLogs", () => {
         // The CI output a teacher needs lives in fields; it must be on screen,
         // not only in the copied and downloaded text.
         expect(await screen.findByText(/--- FAIL: TestFoo/)).toBeTruthy()
-        expect(screen.getByText(/assignment=lab1/)).toBeTruthy()
+        // Fields render as their own column, headed by the key, with only the
+        // value in each row.
+        expect(screen.getByRole("columnheader", { name: "assignment" })).toBeTruthy()
+        expect(screen.getByText("lab1")).toBeTruthy()
+        expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
+    })
+
+    test("renders entry timestamps in 24-hour, yyyy-mm-dd order rather than the locale's", async () => {
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async () => ({ // skipcq: JS-0116
+                message: create(CourseLogSchema, {
+                    entries: [entry({ message: "resolved push repository" })],
+                    repositories: ["student-a"],
+                }),
+                error: null,
+            })),
+        }
+        renderCourseLogs(api)
+
+        // entry() fixes the time at 2026-03-10 12:00:00 local, so the rendered
+        // text is deterministic regardless of the machine's own time zone.
+        expect(await screen.findByText("2026-03-10 12:00:00")).toBeTruthy()
+    })
+
+    test("shows the Debug badge for a Debug-level entry", async () => {
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async () => ({ // skipcq: JS-0116
+                message: create(CourseLogSchema, {
+                    entries: [entry({ message: "verbose detail", level: CourseLogEntry_Level.DEBUG })],
+                    repositories: ["student-a"],
+                }),
+                error: null,
+            })),
+        }
+        renderCourseLogs(api)
+
+        expect(await screen.findByText("verbose detail")).toBeTruthy()
+        // "Debug" also names an option in the "Minimum level" select; scope to the badge.
+        expect(screen.getByText("Debug", { selector: "span.badge" })).toBeTruthy()
+    })
+
+    test("hides and reshows a column from the Columns menu", async () => {
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async () => ({ // skipcq: JS-0116
+                message: create(CourseLogSchema, {
+                    entries: [entry({ message: "resolved push repository", source: "ci/run_tests.go:120" })],
+                    repositories: ["student-a"],
+                }),
+                error: null,
+            })),
+        }
+        renderCourseLogs(api)
+        await screen.findByText("resolved push repository")
+        expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
+
+        fireEvent.click(screen.getByLabelText("Show Source"))
+        expect(screen.queryByText("ci/run_tests.go:120")).toBeFalsy()
+        expect(screen.queryByRole("columnheader", { name: "Source" })).toBeFalsy()
+
+        fireEvent.click(screen.getByLabelText("Show Source"))
         expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
     })
 

--- a/public/src/__tests__/courseLogs.test.tsx
+++ b/public/src/__tests__/courseLogs.test.tsx
@@ -157,6 +157,31 @@ describe("CourseLogs", () => {
         expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
     })
 
+    test("keeps column choices through Refresh and an empty search", async () => {
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async () => ({
+                message: create(CourseLogSchema, { entries: [entry({ fields: { message: "structured detail" } })] }),
+                error: null,
+            })),
+        }
+        renderCourseLogs(api)
+        await screen.findByText("resolved push repository")
+        fireEvent.click(screen.getByLabelText("Show Message"))
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
+        await screen.findByText("structured detail")
+        expect(screen.queryByRole("columnheader", { name: "Message" })).toBeNull()
+        const search = screen.getByPlaceholderText("Filter loaded entries")
+        fireEvent.keyUp(search, { target: { value: "no match" } })
+        expect(screen.queryByRole("table")).toBeNull()
+        fireEvent.keyUp(search, { target: { value: "resolved push" } })
+        expect(screen.getByText("structured detail")).toBeTruthy()
+        expect(screen.queryByRole("columnheader", { name: "Message" })).toBeNull()
+        fireEvent.click(screen.getByLabelText("Show Message"))
+        expect(screen.getByText("resolved push repository")).toBeTruthy()
+    })
+
     test("applies draft filters only on Refresh, including repeated refreshes", async () => {
         const requests: Parameters<ApiClient["client"]["getCourseLog"]>[0][] = []
         const api = new ApiClient()

--- a/public/src/__tests__/courseLogs.test.tsx
+++ b/public/src/__tests__/courseLogs.test.tsx
@@ -95,6 +95,39 @@ describe("CourseLogs", () => {
         expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
     })
 
+    test("gives repositoryType its own column, and a colliding field key its own", async () => {
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async () => ({ // skipcq: JS-0116
+                message: create(CourseLogSchema, {
+                    entries: [entry({
+                        message: "resolved push repository",
+                        // "message" collides with a fixed column: the server keys the
+                        // log message as "msg", so an attribute named "message" does
+                        // reach the fields map.
+                        fields: { commit: "abc123", message: "shadowed" },
+                    })],
+                    repositories: ["student-a"],
+                }),
+                error: null,
+            })),
+        }
+        renderCourseLogs(api)
+        await screen.findByText("resolved push repository")
+
+        // repositoryType is promoted out of fields by the server, so it needs a
+        // column of its own or it is not on screen at all.
+        expect(screen.getByRole("columnheader", { name: "Repository type" })).toBeTruthy()
+        expect(screen.getByText("USER")).toBeTruthy()
+        expect(screen.getByRole("columnheader", { name: "commit" })).toBeTruthy()
+        // The colliding key gets a column of its own, suffixed so it reads apart
+        // from the fixed Message column, which it neither claims nor displaces.
+        expect(screen.getAllByRole("columnheader", { name: "Message" })).toHaveLength(1)
+        expect(screen.getByRole("columnheader", { name: "message (field)" })).toBeTruthy()
+        expect(screen.getByText("shadowed")).toBeTruthy()
+    })
+
     test("renders entry timestamps in 24-hour, yyyy-mm-dd order rather than the locale's", async () => {
         const api = new ApiClient()
         api.client = {

--- a/public/src/__tests__/courseLogs.test.tsx
+++ b/public/src/__tests__/courseLogs.test.tsx
@@ -157,6 +157,38 @@ describe("CourseLogs", () => {
         expect(screen.getByText("ci/run_tests.go:120")).toBeTruthy()
     })
 
+    test("applies draft filters only on Refresh, including repeated refreshes", async () => {
+        const requests: Parameters<ApiClient["client"]["getCourseLog"]>[0][] = []
+        const api = new ApiClient()
+        api.client = {
+            ...api.client,
+            getCourseLog: mock("getCourseLog", async request => {
+                requests.push(request)
+                return { message: create(CourseLogSchema, { entries: [entry()], repositories: ["student-a"] }), error: null }
+            }),
+        }
+        renderCourseLogs(api)
+        await screen.findByText("resolved push repository")
+        fireEvent.change(screen.getByLabelText("From"), { target: { value: "2026-03-09T12:00" } })
+        fireEvent.change(screen.getByLabelText("To"), { target: { value: "2026-03-10T12:00" } })
+        fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "student-a" } })
+        fireEvent.change(screen.getByLabelText("Minimum level"), { target: { value: CourseLogEntry_Level.ERROR } })
+        expect(requests).toHaveLength(1)
+
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
+        await screen.findByText("resolved push repository")
+        expect(requests).toHaveLength(2)
+        expect(requests[1]).toMatchObject({
+            from: timestampFromDate(new Date(2026, 2, 9, 12)),
+            to: timestampFromDate(new Date(2026, 2, 10, 12)),
+            repository: "student-a",
+            level: CourseLogEntry_Level.ERROR,
+        })
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
+        await waitFor(() => expect(requests).toHaveLength(3))
+        expect(requests[2]).toEqual(requests[1])
+    })
+
     test("shows an error state when the request fails", async () => {
         const api = new ApiClient()
         api.client = {
@@ -317,7 +349,7 @@ describe("CourseLogs", () => {
     })
 
     test("clears the repository selection when the route names another course", async () => {
-        const requests: { courseID?: unknown; repository?: unknown }[] = []
+        const requests: Parameters<ApiClient["client"]["getCourseLog"]>[0][] = []
         const api = new ApiClient()
         api.client = {
             ...api.client,
@@ -346,12 +378,16 @@ describe("CourseLogs", () => {
         await screen.findByText("resolved push repository")
         fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "student-a" } })
 
+        fireEvent.change(screen.getByLabelText("From"), { target: { value: "2999-01-01T12:00" } })
+        expect(screen.getByText(/From is after To/)).toBeTruthy()
         screen.getByRole("button", { name: "Course 2" }).click()
 
         // A repository belongs to one course; it must not filter another's log.
         await waitFor(() => expect(requests).toHaveLength(2))
         expect(requests[1].courseID).toBe(BigInt(2))
         expect(requests[1].repository).toBe("")
+        expect(requests[1].from).toEqual(requests[0].from)
+        expect((screen.getByLabelText("From") as HTMLInputElement).value).toBe("2999-01-01T12:00")
         expect((screen.getByLabelText("Repository") as HTMLSelectElement).value).toBe("")
     })
 

--- a/public/src/__tests__/useCourseLogs.test.tsx
+++ b/public/src/__tests__/useCourseLogs.test.tsx
@@ -1,0 +1,82 @@
+import { create } from "@bufbuild/protobuf"
+import { ConnectError } from "@connectrpc/connect"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { Provider } from "overmind-react"
+import type { ReactNode } from "react"
+import { CourseLogEntry_Level, CourseLogSchema } from "../../proto/qf/requests_pb"
+import { useCourseLogs } from "../hooks/useCourseLogs"
+import { ApiClient } from "../overmind/namespaces/global/effects"
+import { initializeOvermind, mock } from "./TestHelpers"
+
+type LogResponse = Awaited<ReturnType<ApiClient["client"]["getCourseLog"]>>
+const filters = { from: "2026-03-09T12:00", to: "", repository: "", level: CourseLogEntry_Level.DEBUG }
+const response = (message: string): LogResponse => ({
+    message: create(CourseLogSchema, { entries: [{ message }] }),
+    error: null,
+})
+
+const setup = () => {
+    const requests: { request: Parameters<ApiClient["client"]["getCourseLog"]>[0]; resolve: (response: LogResponse) => void }[] = []
+    const api = new ApiClient()
+    api.client = {
+        ...api.client,
+        getCourseLog: mock("getCourseLog", request => new Promise(resolve => { requests.push({ request, resolve }) })),
+    }
+    const state = initializeOvermind({}, api)
+    const wrapper = ({ children }: { children: ReactNode }) => <Provider value={state}>{children}</Provider>
+    return {
+        ...renderHook(({ courseID }) => useCourseLogs(courseID, filters), { wrapper, initialProps: { courseID: 1n } }),
+        requests,
+    }
+}
+
+describe("useCourseLogs", () => {
+    test("reuses applied filters on course changes and clears the repository", async () => {
+        const { result, rerender, requests } = setup()
+        const applied = { ...filters, repository: "student-a", level: CourseLogEntry_Level.ERROR }
+        act(() => result.current.refresh(applied))
+        await act(async () => requests[1].resolve(response("course one")))
+        rerender({ courseID: 2n })
+        expect(requests[2].request).toMatchObject({ courseID: 2n, repository: "", level: CourseLogEntry_Level.ERROR })
+        expect(requests[2].request.from).toEqual(requests[1].request.from)
+        expect(requests[2].request.to).toBeUndefined()
+        expect(result.current).toMatchObject({ loading: true, result: null, error: null })
+        await act(async () => requests[2].resolve(response("course two")))
+        expect(result.current.result?.entries[0].message).toBe("course two")
+    })
+
+    test.each([false, true])("ignores stale success and error responses (new request completed: %s)", async completed => {
+        const { result, rerender, requests } = setup()
+        rerender({ courseID: 2n })
+        rerender({ courseID: 1n })
+        if (completed) {
+            await act(async () => requests[2].resolve(response("current course")))
+        }
+        await act(async () => {
+            requests[0].resolve(response("stale course"))
+            requests[1].resolve({ ...response(""), error: new ConnectError("stale error") })
+        })
+        expect(result.current.error).toBeNull()
+        expect(result.current.loading).toBe(!completed)
+        expect(result.current.result?.entries[0].message ?? null).toBe(completed ? "current course" : null)
+    })
+
+    test("ignores an earlier refresh within the same course", async () => {
+        const { result, requests } = setup()
+        act(() => result.current.refresh({ ...filters, level: CourseLogEntry_Level.ERROR }))
+        await act(async () => requests[1].resolve(response("new filter")))
+        await act(async () => requests[0].resolve(response("old filter")))
+        expect(result.current.result?.entries[0].message).toBe("new filter")
+    })
+
+    test("clears a current error when retrying", async () => {
+        const { result, requests } = setup()
+        await act(async () => requests[0].resolve({ ...response(""), error: new ConnectError("unavailable") }))
+        expect(result.current.error).toContain("unavailable")
+        act(() => result.current.refresh(filters))
+        expect(result.current).toMatchObject({ loading: true, result: null, error: null })
+        await act(async () => requests[1].resolve(response("retried")))
+        await waitFor(() => expect(result.current.loading).toBe(false))
+        expect(result.current.result?.entries[0].message).toBe("retried")
+    })
+})

--- a/public/src/components/LogCard.tsx
+++ b/public/src/components/LogCard.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react"
+
+interface LogCardProps {
+    title: string
+    controls?: ReactNode
+    className?: string
+    children: ReactNode
+}
+
+const LogCard = ({ title, controls, className = "", children }: LogCardProps) => (
+    <div className={`card bg-base-200 shadow-xl rounded-2xl ${className}`}>
+        <div className="relative z-20 flex flex-wrap shrink-0 items-center justify-between gap-2 bg-base-300 px-4 py-3 rounded-t-2xl border-b border-base-content/10">
+            <h3 className="text-sm font-semibold flex items-center gap-2">
+                <i className="fas fa-terminal" />
+                <span>{title}</span>
+            </h3>
+            {controls}
+        </div>
+        {children}
+    </div>
+)
+
+export default LogCard

--- a/public/src/components/LogOutput.tsx
+++ b/public/src/components/LogOutput.tsx
@@ -1,9 +1,17 @@
-import type { ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 
 type LogOutputProps = {
     title?: string
     controls?: ReactNode
     codeClassName?: string
+    /** fill grows the scrollable body down to the bottom of the viewport instead
+     *  of capping it at a fixed 70vh, for a page (like the course log) whose card
+     *  is the last thing on the page and has nothing below it competing for space. */
+    fill?: boolean
+    /** variant selects how children are wrapped: "code" (default) renders them inside
+     *  a monospaced <pre><code> block, for a plain-text log; "table" renders them as-is
+     *  inside a horizontally scrollable container, for a column-oriented view. */
+    variant?: "code" | "table"
     children: ReactNode
 }
 
@@ -11,7 +19,37 @@ type LogOutputProps = {
  *  a header with a terminal icon, a title, and an optional right-hand slot for controls,
  *  followed by a monospaced body. The body scrolls within the card rather than growing
  *  the page, so that a long log leaves the caller's own controls reachable. */
-const LogOutput = ({ title = "Build Log", controls, codeClassName = "text-error", children }: LogOutputProps) => {
+const LogOutput = ({ title = "Build Log", controls, codeClassName = "text-error", fill = false, variant = "code", children }: LogOutputProps) => {
+    const bodyRef = useRef<HTMLDivElement>(null)
+    const [fillHeight, setFillHeight] = useState<number>()
+
+    useEffect(() => {
+        if (!fill) {
+            return
+        }
+        const el = bodyRef.current
+        if (!el) {
+            return
+        }
+        // Recomputed on window resize and on any layout change above this card
+        // (filters wrapping to another row, an alert appearing), since either
+        // moves the body's own top and would otherwise leave a stale height.
+        const update = () => {
+            const available = window.innerHeight - el.getBoundingClientRect().top - 16
+            setFillHeight(Math.max(available, 200))
+        }
+        update()
+        // ResizeObserver is unavailable in some test environments (e.g. jsdom);
+        // window resize alone still keeps the height reasonably in sync there.
+        const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(update)
+        observer?.observe(document.body)
+        window.addEventListener("resize", update)
+        return () => {
+            observer?.disconnect()
+            window.removeEventListener("resize", update)
+        }
+    }, [fill])
+
     return (
         <div className="card bg-base-200 shadow-xl rounded-2xl overflow-hidden">
             <div className="card-body p-0">
@@ -22,12 +60,20 @@ const LogOutput = ({ title = "Build Log", controls, codeClassName = "text-error"
                     </h3>
                     {controls}
                 </div>
-                <div className="max-h-[70vh] overflow-auto">
-                    <pre className="p-4 text-sm leading-relaxed font-mono bg-base-200 m-0">
-                        <code className={codeClassName} style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
-                            {children}
-                        </code>
-                    </pre>
+                <div
+                    ref={bodyRef}
+                    className={fill ? "overflow-auto" : "max-h-[70vh] overflow-auto"}
+                    style={fill ? { maxHeight: fillHeight } : undefined}
+                >
+                    {variant === "table" ? (
+                        <div className="overflow-x-auto">{children}</div>
+                    ) : (
+                        <pre className="p-4 text-sm leading-relaxed font-mono bg-base-200 m-0">
+                            <code className={codeClassName} style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                                {children}
+                            </code>
+                        </pre>
+                    )}
                 </div>
             </div>
         </div>

--- a/public/src/components/LogOutput.tsx
+++ b/public/src/components/LogOutput.tsx
@@ -1,83 +1,14 @@
-import { useEffect, useRef, useState, type ReactNode } from "react"
+import type { ReactNode } from "react"
+import LogCard from "./LogCard"
 
-type LogOutputProps = {
-    title?: string
-    controls?: ReactNode
-    codeClassName?: string
-    /** fill grows the scrollable body down to the bottom of the viewport instead
-     *  of capping it at a fixed 70vh, for a page (like the course log) whose card
-     *  is the last thing on the page and has nothing below it competing for space. */
-    fill?: boolean
-    /** variant selects how children are wrapped: "code" (default) renders them inside
-     *  a monospaced <pre><code> block, for a plain-text log; "table" renders them as-is
-     *  inside a horizontally scrollable container, for a column-oriented view. */
-    variant?: "code" | "table"
-    children: ReactNode
-}
-
-/** LogOutput is the card shell shared by the submission build log and the course log:
- *  a header with a terminal icon, a title, and an optional right-hand slot for controls,
- *  followed by a monospaced body. The body scrolls within the card rather than growing
- *  the page, so that a long log leaves the caller's own controls reachable. */
-const LogOutput = ({ title = "Build Log", controls, codeClassName = "text-error", fill = false, variant = "code", children }: LogOutputProps) => {
-    const bodyRef = useRef<HTMLDivElement>(null)
-    const [fillHeight, setFillHeight] = useState<number>()
-
-    useEffect(() => {
-        if (!fill) {
-            return
-        }
-        const el = bodyRef.current
-        if (!el) {
-            return
-        }
-        // Recomputed on window resize and on any layout change above this card
-        // (filters wrapping to another row, an alert appearing), since either
-        // moves the body's own top and would otherwise leave a stale height.
-        const update = () => {
-            const available = window.innerHeight - el.getBoundingClientRect().top - 16
-            setFillHeight(Math.max(available, 200))
-        }
-        update()
-        // ResizeObserver is unavailable in some test environments (e.g. jsdom);
-        // window resize alone still keeps the height reasonably in sync there.
-        const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(update)
-        observer?.observe(document.body)
-        window.addEventListener("resize", update)
-        return () => {
-            observer?.disconnect()
-            window.removeEventListener("resize", update)
-        }
-    }, [fill])
-
-    return (
-        <div className="card bg-base-200 shadow-xl rounded-2xl overflow-hidden">
-            <div className="card-body p-0">
-                <div className="flex items-center justify-between bg-base-300 px-4 py-3 border-b border-base-content/10">
-                    <h3 className="text-sm font-semibold flex items-center gap-2">
-                        <i className="fas fa-terminal" />
-                        <span>{title}</span>
-                    </h3>
-                    {controls}
-                </div>
-                <div
-                    ref={bodyRef}
-                    className={fill ? "overflow-auto" : "max-h-[70vh] overflow-auto"}
-                    style={fill ? { maxHeight: fillHeight } : undefined}
-                >
-                    {variant === "table" ? (
-                        <div className="overflow-x-auto">{children}</div>
-                    ) : (
-                        <pre className="p-4 text-sm leading-relaxed font-mono bg-base-200 m-0">
-                            <code className={codeClassName} style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
-                                {children}
-                            </code>
-                        </pre>
-                    )}
-                </div>
-            </div>
+const LogOutput = ({ children }: { children: ReactNode }) => (
+    <LogCard title="Build Log">
+        <div className="max-h-[70vh] overflow-auto rounded-b-2xl">
+            <pre className="p-4 text-sm leading-relaxed font-mono bg-base-200 m-0">
+                <code className="text-error whitespace-pre-wrap break-words">{children}</code>
+            </pre>
         </div>
-    )
-}
+    </LogCard>
+)
 
 export default LogOutput

--- a/public/src/components/teacher/CourseLogTable.tsx
+++ b/public/src/components/teacher/CourseLogTable.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState, type ReactNode } from "react"
+import type { CourseLogEntry } from "../../../proto/qf/requests_pb"
+import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
+import LogOutput from "../LogOutput"
+import { entryTime, LEVEL_NAMES } from "./courseLogFormatting"
+
+interface Column {
+    id: string
+    label: string
+    render: (entry: CourseLogEntry) => ReactNode
+}
+
+const LEVEL_BADGE_COLOR: Record<CourseLogEntry_Level, string> = {
+    [CourseLogEntry_Level.DEBUG]: "badge-ghost",
+    [CourseLogEntry_Level.INFO]: "badge-info",
+    [CourseLogEntry_Level.WARN]: "badge-warning",
+    [CourseLogEntry_Level.ERROR]: "badge-error",
+}
+
+const columns: Column[] = [
+    { id: "time", label: "Time", render: entry => entryTime(entry) || "N/A" },
+    {
+        id: "level", label: "Level", render: entry => (
+            <span className={`badge badge-xs ${LEVEL_BADGE_COLOR[entry.level]}`}>
+                {LEVEL_NAMES[entry.level]}
+            </span>
+        ),
+    },
+    { id: "repository", label: "Repository", render: entry => entry.repository },
+    {
+        id: "message", label: "Message", render: entry => (
+            <span className="flex flex-wrap items-center gap-2">
+                <span>{entry.message}</span>
+                {entry.truncated && <span className="badge badge-xs badge-warning">truncated</span>}
+            </span>
+        ),
+    },
+    { id: "source", label: "Source", render: entry => entry.source },
+]
+
+interface CourseLogTableProps {
+    entries: CourseLogEntry[]
+    rows: CourseLogEntry[]
+    controls?: ReactNode
+}
+
+const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
+    const [hidden, setHidden] = useState<Set<string>>(new Set())
+    // Derive columns from all loaded entries so searching doesn't change the menu.
+    const available = useMemo(() => [
+        ...columns,
+        ...Array.from(new Set(entries.flatMap(entry => Object.keys(entry.fields))))
+            .sort((a, b) => a.localeCompare(b))
+            .map((key): Column => ({
+                id: `field:${key}`,
+                label: columns.some(column => column.id === key) ? `${key} (field)` : key,
+                render: entry => entry.fields[key] ?? "",
+            })),
+    ], [entries])
+    const visible = available.filter(column => !hidden.has(column.id))
+    const toggleColumn = (id: string) => setHidden(previous => {
+        const next = new Set(previous)
+        if (next.has(id)) {
+            next.delete(id)
+        } else {
+            next.add(id)
+        }
+        return next
+    })
+
+    // Stay mounted through loading and empty results to preserve column choices.
+    if (rows.length === 0) {
+        return null
+    }
+
+    return (
+        <LogOutput
+            title="Course Logs"
+            variant="table"
+            fill
+            controls={
+                <div className="flex items-center gap-2">
+                    <div className="dropdown dropdown-end">
+                        <div tabIndex={0} role="button" className="btn btn-sm">
+                            <i className="fas fa-table-columns" />
+                            Columns
+                        </div>
+                        <ul tabIndex={0} className="dropdown-content menu z-10 mt-2 w-56 max-h-80 overflow-y-auto rounded-box bg-base-100 p-2 shadow">
+                            {available.map(column => (
+                                <li key={column.id}>
+                                    <label className="flex items-center gap-2">
+                                        <input
+                                            type="checkbox"
+                                            className="checkbox checkbox-xs"
+                                            checked={!hidden.has(column.id)}
+                                            onChange={() => toggleColumn(column.id)}
+                                        />
+                                        <span>Show {column.label}</span>
+                                    </label>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    {controls}
+                </div>
+            }
+        >
+            <table className="table table-zebra table-xs">
+                <thead className="sticky top-0 z-10 bg-base-300">
+                    <tr>
+                        {visible.map(column => (
+                            <th key={column.id} className="whitespace-nowrap">{column.label}</th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((entry, idx) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <tr key={idx}>
+                            {visible.map(column => (
+                                <td key={column.id} className="align-top whitespace-pre-wrap break-words">
+                                    {column.render(entry)}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </LogOutput>
+    )
+}
+
+export default CourseLogTable

--- a/public/src/components/teacher/CourseLogTable.tsx
+++ b/public/src/components/teacher/CourseLogTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react"
 import type { CourseLogEntry } from "../../../proto/qf/requests_pb"
 import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
-import LogOutput from "../LogOutput"
+import LogCard from "../LogCard"
 import { entryTime, LEVEL_NAMES } from "./courseLogFormatting"
 
 interface Column {
@@ -74,10 +74,9 @@ const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
     }
 
     return (
-        <LogOutput
+        <LogCard
             title="Course Logs"
-            variant="table"
-            fill
+            className="flex-1 min-h-48"
             controls={
                 <div className="flex items-center gap-2">
                     <div className="dropdown dropdown-end">
@@ -105,28 +104,30 @@ const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
                 </div>
             }
         >
-            <table className="table table-zebra table-xs">
-                <thead className="sticky top-0 z-10 bg-base-300">
-                    <tr>
-                        {visible.map(column => (
-                            <th key={column.id} className="whitespace-nowrap">{column.label}</th>
-                        ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows.map((entry, idx) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <tr key={idx}>
+            <div className="flex-1 min-h-0 overflow-auto rounded-b-2xl">
+                <table className="table table-zebra table-xs">
+                    <thead className="sticky top-0 z-10 bg-base-300">
+                        <tr>
                             {visible.map(column => (
-                                <td key={column.id} className="align-top whitespace-pre-wrap break-words">
-                                    {column.render(entry)}
-                                </td>
+                                <th key={column.id} className="whitespace-nowrap">{column.label}</th>
                             ))}
                         </tr>
-                    ))}
-                </tbody>
-            </table>
-        </LogOutput>
+                    </thead>
+                    <tbody>
+                        {rows.map((entry, idx) => (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <tr key={idx}>
+                                {visible.map(column => (
+                                    <td key={column.id} className="align-top whitespace-pre-wrap break-words">
+                                        {column.render(entry)}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </LogCard>
     )
 }
 

--- a/public/src/components/teacher/CourseLogTable.tsx
+++ b/public/src/components/teacher/CourseLogTable.tsx
@@ -47,7 +47,7 @@ interface CourseLogTableProps {
 
 const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
     const [hidden, setHidden] = useState<Set<string>>(new Set())
-    // Derive columns from all loaded entries so searching doesn't change the menu.
+    // Derive columns from all loaded entries so searching doesn't change the chips.
     const available = useMemo(() => [
         ...columns,
         ...Array.from(new Set(entries.flatMap(entry => Object.keys(entry.fields))))
@@ -78,33 +78,35 @@ const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
         <LogCard
             title="Course Logs"
             className="flex-1 min-h-48"
-            controls={
-                <div className="flex items-center gap-2">
-                    <div className="dropdown dropdown-end">
-                        <div tabIndex={0} role="button" className="btn btn-sm">
-                            <i className="fas fa-table-columns" />
-                            Columns
-                        </div>
-                        <ul tabIndex={0} className="dropdown-content menu z-10 mt-2 w-56 max-h-80 overflow-y-auto rounded-box bg-base-100 p-2 shadow">
-                            {available.map(column => (
-                                <li key={column.id}>
-                                    <label className="flex items-center gap-2">
-                                        <input
-                                            type="checkbox"
-                                            className="checkbox checkbox-xs"
-                                            checked={!hidden.has(column.id)}
-                                            onChange={() => toggleColumn(column.id)}
-                                        />
-                                        <span>Show {column.label}</span>
-                                    </label>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                    {controls}
-                </div>
-            }
+            controls={<div className="flex items-center gap-2">{controls}</div>}
         >
+            <div
+                role="group"
+                aria-label="Columns"
+                className="flex flex-wrap items-center gap-1.5 shrink-0 max-h-24 overflow-y-auto border-b border-base-content/10 px-4 py-2"
+            >
+                <span aria-hidden="true" className="text-xs font-semibold opacity-60 mr-1">
+                    <i className="fas fa-table-columns mr-1.5" />
+                    Columns
+                </span>
+                {available.map(column => (
+                    <label
+                        key={column.id}
+                        // chips have a tint when selected, gray with an outline when not
+                        className={`btn btn-xs font-normal has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 ${hidden.has(column.id) ? "btn-outline opacity-50" : "btn-soft btn-primary"}`}
+                    >
+                        <input
+                            type="checkbox"
+                            className="sr-only"
+                            checked={!hidden.has(column.id)}
+                            onChange={() => toggleColumn(column.id)}
+                        />
+                        {/* The accessible name reads "Show <column>" rather than the bare column name. */}
+                        <span className="sr-only">Show </span>
+                        {column.label}
+                    </label>
+                ))}
+            </div>
             <div className="flex-1 min-h-0 overflow-auto rounded-b-2xl">
                 <table className="table table-zebra table-xs">
                     <thead className="sticky top-0 z-10 bg-base-300">

--- a/public/src/components/teacher/CourseLogTable.tsx
+++ b/public/src/components/teacher/CourseLogTable.tsx
@@ -93,7 +93,7 @@ const CourseLogTable = ({ entries, rows, controls }: CourseLogTableProps) => {
                     <label
                         key={column.id}
                         // chips have a tint when selected, gray with an outline when not
-                        className={`btn btn-xs font-normal has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 ${hidden.has(column.id) ? "btn-outline opacity-50" : "btn-soft btn-primary"}`}
+                        className={`btn btn-xs h-auto py-1 leading-none font-normal has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 ${hidden.has(column.id) ? "btn-outline opacity-50" : "btn-soft btn-primary"}`}
                     >
                         <input
                             type="checkbox"

--- a/public/src/components/teacher/CourseLogTable.tsx
+++ b/public/src/components/teacher/CourseLogTable.tsx
@@ -27,6 +27,7 @@ const columns: Column[] = [
         ),
     },
     { id: "repository", label: "Repository", render: entry => entry.repository },
+    { id: "repositoryType", label: "Repository type", render: entry => entry.repositoryType },
     {
         id: "message", label: "Message", render: entry => (
             <span className="flex flex-wrap items-center gap-2">

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -4,9 +4,9 @@ import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
 import { useCourseID } from "../../hooks/useCourseID"
 import { useCourseLogs } from "../../hooks/useCourseLogs"
 import { CenteredMessage } from "../CenteredMessage"
+import Search from "../Search"
 import CourseLogTable from "./CourseLogTable"
 import { entryText, LEVEL_NAMES, logText, toLocalDatetimeInput } from "./courseLogFormatting"
-import Search from "../Search"
 
 const EMPTY_ENTRIES: CourseLogEntry[] = []
 
@@ -91,12 +91,13 @@ const CourseLogs = () => {
                             <span className="label-text font-semibold">From</span>
                             <input
                                 type="datetime-local"
-                                // A locale like en-US would otherwise render this in
-                                // 12-hour AM/PM time with a mm/dd/yyyy field order; sv-SE
-                                // renders 24-hour time in yyyy-mm-dd order in Chromium-based
-                                // browsers regardless of the browser's own locale. Firefox
-                                // does not honor lang here and keeps its own OS-locale format.
-                                lang="sv-SE"
+                                // The native picker follows a locale, and en-US would render
+                                // it in 12-hour AM/PM time with a mm/dd/yyyy field order.
+                                // nb-NO gives 24-hour time and day-month-year in Chromium-based
+                                // browsers whatever the browser's own locale; the rendered log
+                                // timestamps are ours to format, and stay yyyy-mm-dd. Firefox
+                                // does not honor lang here and keeps its OS-locale format.
+                                lang="nb-NO"
                                 className="input input-bordered w-full"
                                 value={from}
                                 onChange={e => setDraft({ ...draft, from: e.target.value })}
@@ -106,7 +107,7 @@ const CourseLogs = () => {
                             <span className="label-text font-semibold">To</span>
                             <input
                                 type="datetime-local"
-                                lang="sv-SE"
+                                lang="nb-NO"
                                 className="input input-bordered w-full"
                                 value={to}
                                 onChange={e => setDraft({ ...draft, toEdited: true, to: e.target.value })}

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -1,58 +1,14 @@
-import { timestampDate } from "@bufbuild/protobuf/wkt"
-import { useMemo, useState, type ReactNode } from "react"
+import { useState } from "react"
 import type { CourseLogEntry } from "../../../proto/qf/requests_pb"
 import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
 import { useCourseID } from "../../hooks/useCourseID"
 import { useCourseLogs } from "../../hooks/useCourseLogs"
 import { CenteredMessage } from "../CenteredMessage"
-import LogOutput from "../LogOutput"
+import CourseLogTable from "./CourseLogTable"
+import { entryTime, LEVEL_NAMES, toLocalDatetimeInput } from "./courseLogFormatting"
 import Search from "../Search"
 
-const LEVEL_NAMES: Record<CourseLogEntry_Level, string> = {
-    [CourseLogEntry_Level.DEBUG]: "Debug",
-    [CourseLogEntry_Level.INFO]: "Info",
-    [CourseLogEntry_Level.WARN]: "Warn",
-    [CourseLogEntry_Level.ERROR]: "Error",
-}
-
-const LEVEL_BADGE_COLOR: Record<CourseLogEntry_Level, string> = {
-    [CourseLogEntry_Level.DEBUG]: "badge-ghost",
-    [CourseLogEntry_Level.INFO]: "badge-info",
-    [CourseLogEntry_Level.WARN]: "badge-warning",
-    [CourseLogEntry_Level.ERROR]: "badge-error",
-}
-
-// The fixed columns shown for every entry, in display order; a column per
-// distinct key found across the loaded entries' fields is appended after
-// these. Order here also drives the order of the toggle menu.
-const FIXED_COLUMNS = ["time", "level", "repository", "message", "source"] as const
-type FixedColumn = typeof FIXED_COLUMNS[number]
-
-const COLUMN_LABELS: Record<FixedColumn, string> = {
-    time: "Time",
-    level: "Level",
-    repository: "Repository",
-    message: "Message",
-    source: "Source",
-}
-
-const pad = (n: number): string => n.toString().padStart(2, "0")
-
-// toLocalDatetimeInput formats date for a <input type="datetime-local"> value, in the
-// browser's local time zone; Date#toISOString is always UTC, so it cannot be reused here.
-const toLocalDatetimeInput = (date: Date): string =>
-    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
-
-// entryTime renders an entry's timestamp in a fixed 24-hour, year-month-day
-// order (e.g. "2024-02-08 23:59:00"), rather than the browser locale's, which
-// could show AM/PM and a locale-dependent date order such as mm/dd/yyyy.
-const entryTime = (entry: CourseLogEntry): string => {
-    if (!entry.time) {
-        return ""
-    }
-    const d = timestampDate(entry.time)
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
-}
+const EMPTY_ENTRIES: CourseLogEntry[] = []
 
 // entryFields renders an entry's remaining structured attributes, sorted by
 // key because a protobuf map has no order of its own and an entry's fields
@@ -72,71 +28,6 @@ const entryText = (entry: CourseLogEntry): string => {
     const parts = [entryTime(entry), LEVEL_NAMES[entry.level], repository, entry.message, entryFields(entry), entry.source]
     return parts.filter(Boolean).join(" ")
 }
-
-// renderCell renders one entry's value for a given column: the fixed columns
-// read their own field, and anything else is looked up in the entry's fields
-// map, where a value not present in this particular entry renders as nothing.
-const renderCell = (entry: CourseLogEntry, column: string): ReactNode => {
-    switch (column) {
-        case "time":
-            return entryTime(entry) || "N/A"
-        case "level":
-            return (
-                <span className={`badge badge-xs ${LEVEL_BADGE_COLOR[entry.level]}`}>
-                    {LEVEL_NAMES[entry.level]}
-                </span>
-            )
-        case "repository":
-            return entry.repository
-        case "message":
-            return (
-                <span className="flex flex-wrap items-center gap-2">
-                    <span>{entry.message}</span>
-                    {entry.truncated && <span className="badge badge-xs badge-warning">truncated</span>}
-                </span>
-            )
-        case "source":
-            return entry.source
-        default:
-            return entry.fields[column] ?? ""
-    }
-}
-
-/** ColumnsMenu is a checklist dropdown for showing or hiding individual columns
- *  of the log table, e.g. to deactivate a field like branch_ref that is not
- *  relevant right now. Hidden columns are keyed by name, so a column keeps
- *  its shown/hidden state across a Refresh even if it briefly disappears
- *  because no loaded entry currently carries it. */
-const ColumnsMenu = ({ columns, hidden, onToggle }: { columns: string[]; hidden: Set<string>; onToggle: (column: string) => void }) => (
-    <div className="dropdown dropdown-end">
-        <div tabIndex={0} role="button" className="btn btn-sm">
-            <i className="fas fa-table-columns" />
-            Columns
-        </div>
-        <ul tabIndex={0} className="dropdown-content menu z-10 mt-2 w-56 max-h-80 overflow-y-auto rounded-box bg-base-100 p-2 shadow">
-            {columns.map(column => {
-                const label = COLUMN_LABELS[column as FixedColumn] ?? column
-                return (
-                    <li key={column}>
-                        {/* The visible (and so implicit-label) text reads "Show <column>"
-                            rather than the bare column name, so it never collides with an
-                            identically-named filter above (e.g. the "Repository" select)
-                            for anyone finding controls by label text, sighted or not. */}
-                        <label className="flex items-center gap-2">
-                            <input
-                                type="checkbox"
-                                className="checkbox checkbox-xs"
-                                checked={!hidden.has(column)}
-                                onChange={() => onToggle(column)}
-                            />
-                            <span>Show {label}</span>
-                        </label>
-                    </li>
-                )
-            })}
-        </ul>
-    </div>
-)
 
 /** CourseLogs is the teacher-only "Course Logs" page at /course/:id/logs.
  *  It queries GetCourseLog for the current course and lets a teacher narrow
@@ -161,7 +52,6 @@ const CourseLogs = () => {
     const { from, to, toEdited, repository, level } = draft
     const { result, loading, error, refresh } = useCourseLogs(courseID, { from, to: "", repository, level })
     const [search, setSearch] = useState("")
-    const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set())
 
     const invalidInterval = Boolean(from) && new Date(from) > (toEdited && to ? new Date(to) : new Date())
     const handleRefresh = () => {
@@ -184,34 +74,10 @@ const CourseLogs = () => {
         ? [...repositories, repository].sort((a, b) => a.localeCompare(b))
         : repositories
 
-    // Memoized because it feeds the fieldColumns memo below; without this, a
-    // fresh array each render would defeat that memo and recompute the column
-    // set on every keystroke in the free-text filter.
-    const entries = useMemo(() => result?.entries ?? [], [result])
+    const entries = result?.entries ?? EMPTY_ENTRIES
     const filtered = search
         ? entries.filter(entry => entryText(entry).toLowerCase().includes(search))
         : entries
-
-    // The field columns are derived from every loaded entry, not just the
-    // filtered ones, so typing into the free-text filter never makes a column
-    // appear or disappear on its own.
-    const fieldColumns = useMemo(
-        () => Array.from(new Set(entries.flatMap(entry => Object.keys(entry.fields)))).sort((a, b) => a.localeCompare(b)),
-        [entries]
-    )
-    const columns = useMemo(() => [...FIXED_COLUMNS, ...fieldColumns], [fieldColumns])
-    const visibleColumns = columns.filter(column => !hiddenColumns.has(column))
-    const toggleColumn = (column: string) => {
-        setHiddenColumns(prev => {
-            const next = new Set(prev)
-            if (next.has(column)) {
-                next.delete(column)
-            } else {
-                next.add(column)
-            }
-            return next
-        })
-    }
 
     const logText = () => filtered.map(entryText).join("\n")
 
@@ -323,44 +189,16 @@ const CourseLogs = () => {
             {!error && !loading && result && filtered.length === 0 && (
                 <CenteredMessage message="No log entries match the current filters" />
             )}
-            {!error && !loading && result && filtered.length > 0 && (
-                <LogOutput
-                    title="Course Logs"
-                    variant="table"
-                    fill
-                    controls={
-                        <div className="flex items-center gap-2">
-                            <ColumnsMenu columns={columns} hidden={hiddenColumns} onToggle={toggleColumn} />
-                            <button type="button" className="btn btn-sm" onClick={() => void handleCopy()}>Copy</button>
-                            <button type="button" className="btn btn-sm" onClick={handleDownload}>Download</button>
-                        </div>
-                    }
-                >
-                    <table className="table table-zebra table-xs">
-                        <thead className="sticky top-0 z-10 bg-base-300">
-                            <tr>
-                                {visibleColumns.map(column => (
-                                    <th key={column} className="whitespace-nowrap">
-                                        {COLUMN_LABELS[column as FixedColumn] ?? column}
-                                    </th>
-                                ))}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {filtered.map((entry, idx) => (
-                                // eslint-disable-next-line react/no-array-index-key
-                                <tr key={idx}>
-                                    {visibleColumns.map(column => (
-                                        <td key={column} className="align-top whitespace-pre-wrap break-words">
-                                            {renderCell(entry, column)}
-                                        </td>
-                                    ))}
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </LogOutput>
-            )}
+            <CourseLogTable
+                entries={entries}
+                rows={filtered}
+                controls={
+                    <>
+                        <button type="button" className="btn btn-sm" onClick={() => void handleCopy()}>Copy</button>
+                        <button type="button" className="btn btn-sm" onClick={handleDownload}>Download</button>
+                    </>
+                }
+            />
         </div>
     )
 }

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -83,8 +83,8 @@ const CourseLogs = () => {
     }
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="card bg-base-200 shadow-sm">
+        <div className="flex flex-col gap-4 h-[calc(100dvh_-_var(--navbar-height)_-_3rem)]">
+            <div className="card bg-base-200 shadow-sm shrink-0">
                 <div className="card-body gap-3">
                     <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
                         <label className="form-control w-full">
@@ -137,7 +137,7 @@ const CourseLogs = () => {
                         </label>
                     </div>
                     {invalidInterval && (
-                        <div className="alert alert-error">
+                        <div className="alert alert-error shrink-0">
                             <span>From is after To; pick a From that precedes the end of the interval.</span>
                         </div>
                     )}
@@ -150,7 +150,7 @@ const CourseLogs = () => {
                 </div>
             </div>
 
-            {notice && <div className="alert alert-error"><span>{notice}</span></div>}
+            {notice && <div className="alert alert-error shrink-0"><span>{notice}</span></div>}
             {error && <CenteredMessage message={`Failed to load course logs: ${error}`} />}
             {!error && loading && <CenteredMessage message="Loading course logs…" />}
             {/* truncated reports that the server cut its own result at the limit,
@@ -158,7 +158,7 @@ const CourseLogs = () => {
                 therefore the server's, and the warning stands even when the filter
                 leaves nothing on screen. */}
             {!error && !loading && result?.truncated && (
-                <div className="alert alert-warning">
+                <div className="alert alert-warning shrink-0">
                     <span>
                         Result limited to the newest {entries.length} entries.
                         Narrow the interval or the filters and click Refresh to see the rest.

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -1,9 +1,9 @@
-import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt"
-import { useEffect, useMemo, useState, type ReactNode } from "react"
-import type { CourseLog, CourseLogEntry } from "../../../proto/qf/requests_pb"
+import { timestampDate } from "@bufbuild/protobuf/wkt"
+import { useMemo, useState, type ReactNode } from "react"
+import type { CourseLogEntry } from "../../../proto/qf/requests_pb"
 import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
 import { useCourseID } from "../../hooks/useCourseID"
-import { useGrpc } from "../../overmind"
+import { useCourseLogs } from "../../hooks/useCourseLogs"
 import { CenteredMessage } from "../CenteredMessage"
 import LogOutput from "../LogOutput"
 import Search from "../Search"
@@ -145,74 +145,35 @@ const ColumnsMenu = ({ columns, hidden, onToggle }: { columns: string[]; hidden:
  *  free-text one take effect only on Refresh. */
 const CourseLogs = () => {
     const courseID = useCourseID()
-    const { api } = useGrpc().global
-
-    const [from, setFrom] = useState(() => toLocalDatetimeInput(new Date(Date.now() - 24 * 60 * 60 * 1000)))
-    const [to, setTo] = useState(() => toLocalDatetimeInput(new Date()))
-    const [toEdited, setToEdited] = useState(false)
-    const [repository, setRepository] = useState("")
-    const [level, setLevel] = useState(CourseLogEntry_Level.DEBUG)
+    const [notice, setNotice] = useState<string | null>(null)
+    const [draft, setDraft] = useState(() => ({
+        courseID,
+        from: toLocalDatetimeInput(new Date(Date.now() - 24 * 60 * 60 * 1000)),
+        to: toLocalDatetimeInput(new Date()),
+        toEdited: false,
+        repository: "",
+        level: CourseLogEntry_Level.DEBUG,
+    }))
+    if (draft.courseID !== courseID) {
+        setDraft({ ...draft, courseID, repository: "", to: draft.toEdited ? draft.to : toLocalDatetimeInput(new Date()) })
+        setNotice(null)
+    }
+    const { from, to, toEdited, repository, level } = draft
+    const { result, loading, error, refresh } = useCourseLogs(courseID, { from, to: "", repository, level })
     const [search, setSearch] = useState("")
     const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set())
 
-    const [result, setResult] = useState<CourseLog | null>(null)
-    const [loading, setLoading] = useState(false)
-    const [error, setError] = useState<string | null>(null)
-    const [notice, setNotice] = useState<string | null>(null)
-
-    // From must not run past the end of the interval. An unedited To means "now",
-    // which keeps moving, so compare against the clock rather than against the
-    // value still shown in the field, which only advances on Refresh.
     const invalidInterval = Boolean(from) && new Date(from) > (toEdited && to ? new Date(to) : new Date())
-
-    // repo is passed explicitly so that a course change can clear the selection
-    // and query without it in the same pass, before the state update lands.
-    const fetchLogs = async (repo = repository) => {
+    const handleRefresh = () => {
         if (invalidInterval) {
             return
         }
-        setLoading(true)
-        setError(null)
         setNotice(null)
-        // A To the teacher has not set means "up to now", so leave it out and let
-        // the server bound the interval by its own clock; a page left open would
-        // otherwise keep querying the interval that ended when it mounted, and
-        // Refresh could never show anything logged since. The field is advanced
-        // to match, since it stays pre-filled on screen.
         if (!toEdited) {
-            setTo(toLocalDatetimeInput(new Date()))
+            setDraft({ ...draft, to: toLocalDatetimeInput(new Date()) })
         }
-        const response = await api.client.getCourseLog({
-            courseID,
-            from: from ? timestampFromDate(new Date(from)) : undefined,
-            to: toEdited && to ? timestampFromDate(new Date(to)) : undefined,
-            repository: repo,
-            level,
-        })
-        setLoading(false)
-        if (response.error) {
-            setError(response.error.message)
-            return
-        }
-        setResult(response.message)
+        refresh({ from, to: toEdited ? to : "", repository, level })
     }
-
-    useEffect(() => {
-        // set-state-in-effect guards against effects that mirror derived state.
-        // This one starts a request instead, which is what an effect is for, and
-        // reporting that it is in flight is unavoidably a state update. Escaping
-        // the rule would take a data-fetching layer this page does not have.
-        /* eslint-disable react-hooks/set-state-in-effect */
-        // A repository belongs to a single course, so the selection cannot carry
-        // over to another one.
-        setRepository("")
-        void fetchLogs("")
-        /* eslint-enable react-hooks/set-state-in-effect */
-        // Fetch on mount and whenever the route names another course, since the
-        // router keeps this page mounted across that change. The remaining
-        // filters are deliberately left out, so that they apply only on Refresh.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [courseID])
 
     // The response lists every repository with an entry in the interval, whatever
     // the repository filter, but a selection whose repository fell silent must
@@ -293,7 +254,7 @@ const CourseLogs = () => {
                                 lang="sv-SE"
                                 className="input input-bordered w-full"
                                 value={from}
-                                onChange={e => setFrom(e.target.value)}
+                                onChange={e => setDraft({ ...draft, from: e.target.value })}
                             />
                         </label>
                         <label className="form-control w-full">
@@ -303,7 +264,7 @@ const CourseLogs = () => {
                                 lang="sv-SE"
                                 className="input input-bordered w-full"
                                 value={to}
-                                onChange={e => { setToEdited(true); setTo(e.target.value) }}
+                                onChange={e => setDraft({ ...draft, toEdited: true, to: e.target.value })}
                             />
                         </label>
                         <label className="form-control w-full">
@@ -311,7 +272,7 @@ const CourseLogs = () => {
                             <select
                                 className="select select-bordered w-full"
                                 value={repository}
-                                onChange={e => setRepository(e.target.value)}
+                                onChange={e => setDraft({ ...draft, repository: e.target.value })}
                             >
                                 <option value="">All repositories</option>
                                 {repositoryOptions.map(repo => <option key={repo} value={repo}>{repo}</option>)}
@@ -322,7 +283,7 @@ const CourseLogs = () => {
                             <select
                                 className="select select-bordered w-full"
                                 value={level}
-                                onChange={e => setLevel(Number(e.target.value))}
+                                onChange={e => setDraft({ ...draft, level: Number(e.target.value) })}
                             >
                                 {Object.values(CourseLogEntry_Level).filter((v): v is CourseLogEntry_Level => typeof v === "number").map(value => (
                                     <option key={value} value={value}>{LEVEL_NAMES[value]}</option>
@@ -336,7 +297,7 @@ const CourseLogs = () => {
                         </div>
                     )}
                     <div className="flex items-center gap-2">
-                        <button type="button" className="btn btn-primary" onClick={() => void fetchLogs()} disabled={loading || invalidInterval}>
+                        <button type="button" className="btn btn-primary" onClick={handleRefresh} disabled={loading || invalidInterval}>
                             {loading ? "Refreshing…" : "Refresh"}
                         </button>
                         <Search placeholder="Filter loaded entries" setQuery={setSearch} className="flex-1" />

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -5,29 +5,10 @@ import { useCourseID } from "../../hooks/useCourseID"
 import { useCourseLogs } from "../../hooks/useCourseLogs"
 import { CenteredMessage } from "../CenteredMessage"
 import CourseLogTable from "./CourseLogTable"
-import { entryTime, LEVEL_NAMES, toLocalDatetimeInput } from "./courseLogFormatting"
+import { entryText, LEVEL_NAMES, logText, toLocalDatetimeInput } from "./courseLogFormatting"
 import Search from "../Search"
 
 const EMPTY_ENTRIES: CourseLogEntry[] = []
-
-// entryFields renders an entry's remaining structured attributes, sorted by
-// key because a protobuf map has no order of its own and an entry's fields
-// would otherwise move around between requests.
-const entryFields = (entry: CourseLogEntry): string =>
-    Object.entries(entry.fields)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, value]) => `${key}=${value}`)
-        .join(" ")
-
-// entryText renders one entry as plain text for the copy and download actions,
-// and for the free-text filter; it lists every part regardless of which
-// columns are currently hidden, so hiding a column never hides what it filters,
-// copies, or downloads.
-const entryText = (entry: CourseLogEntry): string => {
-    const repository = entry.repository ? `[${entry.repository}]` : ""
-    const parts = [entryTime(entry), LEVEL_NAMES[entry.level], repository, entry.message, entryFields(entry), entry.source]
-    return parts.filter(Boolean).join(" ")
-}
 
 /** CourseLogs is the teacher-only "Course Logs" page at /course/:id/logs.
  *  It queries GetCourseLog for the current course and lets a teacher narrow
@@ -79,13 +60,11 @@ const CourseLogs = () => {
         ? entries.filter(entry => entryText(entry).toLowerCase().includes(search))
         : entries
 
-    const logText = () => filtered.map(entryText).join("\n")
-
     const handleCopy = async () => {
         try {
             // navigator.clipboard is undefined outside a secure context, and
             // writeText rejects when the browser denies clipboard access.
-            await navigator.clipboard.writeText(logText())
+            await navigator.clipboard.writeText(logText(filtered))
             setNotice(null)
         } catch {
             setNotice("Could not copy the log; the browser denied access to the clipboard")
@@ -93,7 +72,7 @@ const CourseLogs = () => {
     }
 
     const handleDownload = () => {
-        const url = URL.createObjectURL(new Blob([logText()], { type: "text/plain" }))
+        const url = URL.createObjectURL(new Blob([logText(filtered)], { type: "text/plain" }))
         const link = document.createElement("a")
         link.href = url
         link.download = `course-${courseID}-log.txt`

--- a/public/src/components/teacher/CourseLogs.tsx
+++ b/public/src/components/teacher/CourseLogs.tsx
@@ -1,5 +1,5 @@
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState, type ReactNode } from "react"
 import type { CourseLog, CourseLogEntry } from "../../../proto/qf/requests_pb"
 import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
 import { useCourseID } from "../../hooks/useCourseID"
@@ -22,15 +22,37 @@ const LEVEL_BADGE_COLOR: Record<CourseLogEntry_Level, string> = {
     [CourseLogEntry_Level.ERROR]: "badge-error",
 }
 
-// toLocalDatetimeInput formats date for a <input type="datetime-local"> value, in the
-// browser's local time zone; Date#toISOString is always UTC, so it cannot be reused here.
-const toLocalDatetimeInput = (date: Date): string => {
-    const pad = (n: number) => n.toString().padStart(2, "0")
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+// The fixed columns shown for every entry, in display order; a column per
+// distinct key found across the loaded entries' fields is appended after
+// these. Order here also drives the order of the toggle menu.
+const FIXED_COLUMNS = ["time", "level", "repository", "message", "source"] as const
+type FixedColumn = typeof FIXED_COLUMNS[number]
+
+const COLUMN_LABELS: Record<FixedColumn, string> = {
+    time: "Time",
+    level: "Level",
+    repository: "Repository",
+    message: "Message",
+    source: "Source",
 }
 
-const entryTime = (entry: CourseLogEntry): string =>
-    entry.time ? timestampDate(entry.time).toLocaleString() : ""
+const pad = (n: number): string => n.toString().padStart(2, "0")
+
+// toLocalDatetimeInput formats date for a <input type="datetime-local"> value, in the
+// browser's local time zone; Date#toISOString is always UTC, so it cannot be reused here.
+const toLocalDatetimeInput = (date: Date): string =>
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+// entryTime renders an entry's timestamp in a fixed 24-hour, year-month-day
+// order (e.g. "2024-02-08 23:59:00"), rather than the browser locale's, which
+// could show AM/PM and a locale-dependent date order such as mm/dd/yyyy.
+const entryTime = (entry: CourseLogEntry): string => {
+    if (!entry.time) {
+        return ""
+    }
+    const d = timestampDate(entry.time)
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
 
 // entryFields renders an entry's remaining structured attributes, sorted by
 // key because a protobuf map has no order of its own and an entry's fields
@@ -41,15 +63,80 @@ const entryFields = (entry: CourseLogEntry): string =>
         .map(([key, value]) => `${key}=${value}`)
         .join(" ")
 
-// entryText renders one entry as plain text for the copy and download actions;
-// it must list the same parts, in the same order, as the rendered row, so that
-// the screen, the clipboard, the downloaded file, and the free-text filter all
-// agree on what an entry says.
+// entryText renders one entry as plain text for the copy and download actions,
+// and for the free-text filter; it lists every part regardless of which
+// columns are currently hidden, so hiding a column never hides what it filters,
+// copies, or downloads.
 const entryText = (entry: CourseLogEntry): string => {
     const repository = entry.repository ? `[${entry.repository}]` : ""
     const parts = [entryTime(entry), LEVEL_NAMES[entry.level], repository, entry.message, entryFields(entry), entry.source]
     return parts.filter(Boolean).join(" ")
 }
+
+// renderCell renders one entry's value for a given column: the fixed columns
+// read their own field, and anything else is looked up in the entry's fields
+// map, where a value not present in this particular entry renders as nothing.
+const renderCell = (entry: CourseLogEntry, column: string): ReactNode => {
+    switch (column) {
+        case "time":
+            return entryTime(entry) || "N/A"
+        case "level":
+            return (
+                <span className={`badge badge-xs ${LEVEL_BADGE_COLOR[entry.level]}`}>
+                    {LEVEL_NAMES[entry.level]}
+                </span>
+            )
+        case "repository":
+            return entry.repository
+        case "message":
+            return (
+                <span className="flex flex-wrap items-center gap-2">
+                    <span>{entry.message}</span>
+                    {entry.truncated && <span className="badge badge-xs badge-warning">truncated</span>}
+                </span>
+            )
+        case "source":
+            return entry.source
+        default:
+            return entry.fields[column] ?? ""
+    }
+}
+
+/** ColumnsMenu is a checklist dropdown for showing or hiding individual columns
+ *  of the log table, e.g. to deactivate a field like branch_ref that is not
+ *  relevant right now. Hidden columns are keyed by name, so a column keeps
+ *  its shown/hidden state across a Refresh even if it briefly disappears
+ *  because no loaded entry currently carries it. */
+const ColumnsMenu = ({ columns, hidden, onToggle }: { columns: string[]; hidden: Set<string>; onToggle: (column: string) => void }) => (
+    <div className="dropdown dropdown-end">
+        <div tabIndex={0} role="button" className="btn btn-sm">
+            <i className="fas fa-table-columns" />
+            Columns
+        </div>
+        <ul tabIndex={0} className="dropdown-content menu z-10 mt-2 w-56 max-h-80 overflow-y-auto rounded-box bg-base-100 p-2 shadow">
+            {columns.map(column => {
+                const label = COLUMN_LABELS[column as FixedColumn] ?? column
+                return (
+                    <li key={column}>
+                        {/* The visible (and so implicit-label) text reads "Show <column>"
+                            rather than the bare column name, so it never collides with an
+                            identically-named filter above (e.g. the "Repository" select)
+                            for anyone finding controls by label text, sighted or not. */}
+                        <label className="flex items-center gap-2">
+                            <input
+                                type="checkbox"
+                                className="checkbox checkbox-xs"
+                                checked={!hidden.has(column)}
+                                onChange={() => onToggle(column)}
+                            />
+                            <span>Show {label}</span>
+                        </label>
+                    </li>
+                )
+            })}
+        </ul>
+    </div>
+)
 
 /** CourseLogs is the teacher-only "Course Logs" page at /course/:id/logs.
  *  It queries GetCourseLog for the current course and lets a teacher narrow
@@ -66,6 +153,7 @@ const CourseLogs = () => {
     const [repository, setRepository] = useState("")
     const [level, setLevel] = useState(CourseLogEntry_Level.DEBUG)
     const [search, setSearch] = useState("")
+    const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set())
 
     const [result, setResult] = useState<CourseLog | null>(null)
     const [loading, setLoading] = useState(false)
@@ -135,10 +223,34 @@ const CourseLogs = () => {
         ? [...repositories, repository].sort((a, b) => a.localeCompare(b))
         : repositories
 
-    const entries = result?.entries ?? []
+    // Memoized because it feeds the fieldColumns memo below; without this, a
+    // fresh array each render would defeat that memo and recompute the column
+    // set on every keystroke in the free-text filter.
+    const entries = useMemo(() => result?.entries ?? [], [result])
     const filtered = search
         ? entries.filter(entry => entryText(entry).toLowerCase().includes(search))
         : entries
+
+    // The field columns are derived from every loaded entry, not just the
+    // filtered ones, so typing into the free-text filter never makes a column
+    // appear or disappear on its own.
+    const fieldColumns = useMemo(
+        () => Array.from(new Set(entries.flatMap(entry => Object.keys(entry.fields)))).sort((a, b) => a.localeCompare(b)),
+        [entries]
+    )
+    const columns = useMemo(() => [...FIXED_COLUMNS, ...fieldColumns], [fieldColumns])
+    const visibleColumns = columns.filter(column => !hiddenColumns.has(column))
+    const toggleColumn = (column: string) => {
+        setHiddenColumns(prev => {
+            const next = new Set(prev)
+            if (next.has(column)) {
+                next.delete(column)
+            } else {
+                next.add(column)
+            }
+            return next
+        })
+    }
 
     const logText = () => filtered.map(entryText).join("\n")
 
@@ -173,6 +285,12 @@ const CourseLogs = () => {
                             <span className="label-text font-semibold">From</span>
                             <input
                                 type="datetime-local"
+                                // A locale like en-US would otherwise render this in
+                                // 12-hour AM/PM time with a mm/dd/yyyy field order; sv-SE
+                                // renders 24-hour time in yyyy-mm-dd order in Chromium-based
+                                // browsers regardless of the browser's own locale. Firefox
+                                // does not honor lang here and keeps its own OS-locale format.
+                                lang="sv-SE"
                                 className="input input-bordered w-full"
                                 value={from}
                                 onChange={e => setFrom(e.target.value)}
@@ -182,6 +300,7 @@ const CourseLogs = () => {
                             <span className="label-text font-semibold">To</span>
                             <input
                                 type="datetime-local"
+                                lang="sv-SE"
                                 className="input input-bordered w-full"
                                 value={to}
                                 onChange={e => { setToEdited(true); setTo(e.target.value) }}
@@ -246,37 +365,39 @@ const CourseLogs = () => {
             {!error && !loading && result && filtered.length > 0 && (
                 <LogOutput
                     title="Course Logs"
-                    codeClassName="text-base-content"
+                    variant="table"
+                    fill
                     controls={
                         <div className="flex items-center gap-2">
+                            <ColumnsMenu columns={columns} hidden={hiddenColumns} onToggle={toggleColumn} />
                             <button type="button" className="btn btn-sm" onClick={() => void handleCopy()}>Copy</button>
                             <button type="button" className="btn btn-sm" onClick={handleDownload}>Download</button>
                         </div>
                     }
                 >
-                    {filtered.map((entry, idx) => {
-                        const fields = entryFields(entry)
-                        return (
-                            // A row is a <span> because it renders inside the <code> element
-                            // of LogOutput, which only admits phrasing content.
-                            // eslint-disable-next-line react/no-array-index-key
-                            <span key={idx} className="flex flex-wrap items-baseline gap-2 py-0.5">
-                                <span className="text-base-content/60 shrink-0">{entryTime(entry) || "N/A"}</span>
-                                <span className={`badge badge-xs ${LEVEL_BADGE_COLOR[entry.level]} shrink-0`}>
-                                    {LEVEL_NAMES[entry.level]}
-                                </span>
-                                {entry.repository && (
-                                    <span className="text-base-content/60 shrink-0">[{entry.repository}]</span>
-                                )}
-                                <span className="break-words">{entry.message}</span>
-                                {fields && (
-                                    <span className="text-base-content/70 break-words whitespace-pre-wrap">{fields}</span>
-                                )}
-                                {entry.source && <span className="text-base-content/40 shrink-0">{entry.source}</span>}
-                                {entry.truncated && <span className="badge badge-xs badge-warning shrink-0">truncated</span>}
-                            </span>
-                        )
-                    })}
+                    <table className="table table-zebra table-xs">
+                        <thead className="sticky top-0 z-10 bg-base-300">
+                            <tr>
+                                {visibleColumns.map(column => (
+                                    <th key={column} className="whitespace-nowrap">
+                                        {COLUMN_LABELS[column as FixedColumn] ?? column}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map((entry, idx) => (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <tr key={idx}>
+                                    {visibleColumns.map(column => (
+                                        <td key={column} className="align-top whitespace-pre-wrap break-words">
+                                            {renderCell(entry, column)}
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </LogOutput>
             )}
         </div>

--- a/public/src/components/teacher/courseLogFormatting.ts
+++ b/public/src/components/teacher/courseLogFormatting.ts
@@ -26,3 +26,24 @@ export const entryTime = (entry: CourseLogEntry): string => {
     const d = timestampDate(entry.time)
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
+
+// entryFields renders an entry's remaining structured attributes, sorted by
+// key because a protobuf map has no order of its own and an entry's fields
+// would otherwise move around between requests.
+const entryFields = (entry: CourseLogEntry): string =>
+    Object.entries(entry.fields)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => `${key}=${value}`)
+        .join(" ")
+
+// entryText renders one entry as plain text for the copy and download actions,
+// and for the free-text filter; it lists every part regardless of which
+// columns are currently hidden, so hiding a column never hides what it filters,
+// copies, or downloads.
+export const entryText = (entry: CourseLogEntry): string => {
+    const repository = entry.repository ? `[${entry.repository}]` : ""
+    const parts = [entryTime(entry), LEVEL_NAMES[entry.level], repository, entry.message, entryFields(entry), entry.source]
+    return parts.filter(Boolean).join(" ")
+}
+
+export const logText = (entries: readonly CourseLogEntry[]): string => entries.map(entryText).join("\n")

--- a/public/src/components/teacher/courseLogFormatting.ts
+++ b/public/src/components/teacher/courseLogFormatting.ts
@@ -41,7 +41,10 @@ const entryFields = (entry: CourseLogEntry): string =>
 // columns are currently hidden, so hiding a column never hides what it filters,
 // copies, or downloads.
 export const entryText = (entry: CourseLogEntry): string => {
-    const repository = entry.repository ? `[${entry.repository}]` : ""
+    // A repository and its type share one bracketed token, so that the type does
+    // not read as a word of the message when the line is copied or downloaded.
+    const repo = [entry.repository, entry.repositoryType].filter(Boolean).join(" ")
+    const repository = repo ? `[${repo}]` : ""
     const parts = [entryTime(entry), LEVEL_NAMES[entry.level], repository, entry.message, entryFields(entry), entry.source]
     return parts.filter(Boolean).join(" ")
 }

--- a/public/src/components/teacher/courseLogFormatting.ts
+++ b/public/src/components/teacher/courseLogFormatting.ts
@@ -1,0 +1,28 @@
+import { timestampDate } from "@bufbuild/protobuf/wkt"
+import type { CourseLogEntry } from "../../../proto/qf/requests_pb"
+import { CourseLogEntry_Level } from "../../../proto/qf/requests_pb"
+
+export const LEVEL_NAMES: Record<CourseLogEntry_Level, string> = {
+    [CourseLogEntry_Level.DEBUG]: "Debug",
+    [CourseLogEntry_Level.INFO]: "Info",
+    [CourseLogEntry_Level.WARN]: "Warn",
+    [CourseLogEntry_Level.ERROR]: "Error",
+}
+
+const pad = (n: number): string => n.toString().padStart(2, "0")
+
+// toLocalDatetimeInput formats date for a <input type="datetime-local"> value, in the
+// browser's local time zone; Date#toISOString is always UTC, so it cannot be reused here.
+export const toLocalDatetimeInput = (date: Date): string =>
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+// entryTime renders an entry's timestamp in a fixed 24-hour, year-month-day
+// order (e.g. "2024-02-08 23:59:00"), rather than the browser locale's, which
+// could show AM/PM and a locale-dependent date order such as mm/dd/yyyy.
+export const entryTime = (entry: CourseLogEntry): string => {
+    if (!entry.time) {
+        return ""
+    }
+    const d = timestampDate(entry.time)
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}

--- a/public/src/hooks/useCourseLogs.ts
+++ b/public/src/hooks/useCourseLogs.ts
@@ -1,0 +1,55 @@
+import { timestampFromDate } from "@bufbuild/protobuf/wkt"
+import { useEffect, useState } from "react"
+import type { CourseLog, CourseLogEntry_Level } from "../../proto/qf/requests_pb"
+import { useGrpc } from "../overmind"
+
+export interface CourseLogFilters {
+    from: string
+    // An empty To lets the server bound each request by its current time.
+    to: string
+    repository: string
+    level: CourseLogEntry_Level
+}
+
+interface CourseLogQuery {
+    courseID: bigint
+    filters: CourseLogFilters
+}
+
+interface CourseLogResponse {
+    query: CourseLogQuery
+    result: CourseLog | null
+    error: string | null
+}
+
+export const useCourseLogs = (courseID: bigint, initialFilters: CourseLogFilters) => {
+    const { api } = useGrpc().global
+    const [query, setQuery] = useState<CourseLogQuery>(() => ({ courseID, filters: initialFilters }))
+    const [response, setResponse] = useState<CourseLogResponse | null>(null)
+
+    if (query.courseID !== courseID) {
+        setQuery({ courseID, filters: { ...query.filters, repository: "" } })
+    }
+
+    useEffect(() => {
+        let active = true
+        const { from, to, repository, level } = query.filters
+        void api.client.getCourseLog({
+            courseID: query.courseID,
+            from: from ? timestampFromDate(new Date(from)) : undefined,
+            to: to ? timestampFromDate(new Date(to)) : undefined,
+            repository,
+            level,
+        }).then(({ message, error }) => {
+            if (active) {
+                setResponse({ query, result: error ? null : message, error: error?.message ?? null })
+            }
+        })
+        return () => { active = false }
+    }, [api, query])
+
+    // Query identity also hides old results immediately, before the effect runs.
+    const current = response?.query === query ? response : null
+    const refresh = (filters: CourseLogFilters) => setQuery({ courseID, filters: { ...filters } })
+    return { result: current?.result ?? null, error: current?.error ?? null, loading: !current, refresh }
+}


### PR DESCRIPTION
Closes #1591

## What changed

- **24-hour clock, `yyyy-mm-dd` dates** — Log entry timestamps now render as `yyyy-mm-dd HH:mm:ss` instead of `toLocaleString()`, which could show AM/PM and a locale-dependent date order. The `From`/`To` pickers are marked `lang="nb-NO"`, so Chromium-based browsers render them with a 24-hour clock whatever the browser's own locale (Firefox does not honor `lang` here and keeps its OS-locale format).
- **Debug badge** — Already rendered for every level, including Debug, so no change was needed; a test now pins that down.
- **The panel reaches the bottom of the screen** — The page's flex column is given a height, and the card, its body, and the scroll area grow into whatever the filters and any alerts above them leave. Sizing is pure CSS, so it follows every reflow — an alert appearing, filters wrapping to another row, a resized window — without measuring anything.
- **Column-oriented display** — The single-line rows are now a table: a column per fixed attribute (Time, Level, Repository, Repository type, Message, Source) plus one per distinct field key in the loaded entries (e.g. `commit`, `branch_ref`), each sized to its content, with the header pinned via `table-pin-rows`. A **Columns** menu shows or hides individual columns, e.g. to deactivate `branch_ref` when it isn't relevant; the choice survives a Refresh. Copy and Download still emit every attribute, whatever is hidden on screen.

`repositoryType` gained a column because the server promotes it out of the fields map, so nothing rendered it before. A field key that names a fixed column is left out of the dynamic columns: the server consumes slog's `time`, `level`, `source` and `repository` keys, but its message key is `msg`, so a `message` attribute would otherwise claim that column twice.

## Review follow-ups

Both Copilot findings on the first commit are fixed in 96206e3, by dropping the JS measurement rather than patching it: a `maxHeight` alone let a short log stop short of the bottom instead of filling it, and the measured height went stale on any reflow that moved the card without resizing the observed element. The table also no longer sits in an `overflow-x` wrapper of its own — that wrapper was a scroll container in both axes, so a sticky header would have stuck to it and been left behind when the body was the element actually scrolling.

## Testing

- `npm test` — 114 frontend tests pass, including new ones for the timestamp format, the Debug badge, the column toggle, the `repositoryType` column, and the colliding-field-key guard.
- `npm run tsc` — no new type errors (one pre-existing, unrelated failure in `updateAssignments.test.tsx`, also present on `master`).
- `npm run lint` — clean on the changed files.
- `npm run tailwind` — confirmed the new arbitrary utility compiles: `min-height: calc(100dvh - var(--navbar-height) - 3rem)`.

Layout was reasoned about rather than viewed in a browser, so the rendered page is worth a look before merging.