### PR TITLE
feat(frontend): add Edit Course tile to teacher page

### DIFF
--- a/public/src/__tests__/editCourse.test.tsx
+++ b/public/src/__tests__/editCourse.test.tsx
@@ -1,0 +1,68 @@
+import { create } from "@bufbuild/protobuf"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { Provider } from "overmind-react"
+import { MemoryRouter, Route, Routes } from "react-router"
+import { UserSchema } from "../../proto/qf/types_pb"
+import TeacherPage from "../pages/TeacherPage"
+import { MockData } from "./mock_data/mockData"
+import { initializeOvermind } from "./TestHelpers"
+
+// Course 1 of the mocked courses; the teacher below is enrolled in it as a teacher.
+const course = MockData.mockedCourses()[0]
+
+const teacherState = {
+    self: create(UserSchema, { ID: BigInt(1), Name: "Teacher", IsAdmin: false }),
+    activeCourse: course.ID,
+    courses: MockData.mockedCourses(),
+    enrollments: MockData.mockedEnrollments().enrollments.filter(e => e.userID === BigInt(1)),
+    assignments: MockData.mockedCourseAssignments(),
+    repositories: MockData.mockedRepositories(),
+}
+
+const renderTeacherPage = (path: string) => {
+    render(
+        <Provider value={initializeOvermind(teacherState)}>
+            <MemoryRouter initialEntries={[path]}>
+                <Routes>
+                    <Route path="/course/:id/*" element={<TeacherPage />} />
+                </Routes>
+            </MemoryRouter>
+        </Provider>
+    )
+}
+
+describe("EditCourse", () => {
+    test("offers the teacher an Edit Course tile on the course page", () => {
+        renderTeacherPage("/course/1")
+
+        expect(screen.getByRole("button", { name: "Edit Course" })).toBeTruthy()
+    })
+
+    test("renders the course form with the current course prefilled", () => {
+        renderTeacherPage("/course/1/edit")
+
+        expect(screen.getByDisplayValue(course.name)).toBeTruthy()
+        expect(screen.getByDisplayValue(course.code)).toBeTruthy()
+        expect(screen.getByDisplayValue(course.tag)).toBeTruthy()
+        expect(screen.getByDisplayValue(course.year.toString())).toBeTruthy()
+        expect(screen.getByRole("button", { name: /Save Changes/ })).toBeTruthy()
+    })
+
+    test("navigates from the tile to the course form", () => {
+        renderTeacherPage("/course/1")
+        // The form is only reachable through the tile; the teacher has no
+        // other route to it from the course page.
+        expect(screen.queryByDisplayValue(course.name)).toBeNull()
+
+        fireEvent.click(screen.getByRole("button", { name: "Edit Course" }))
+
+        expect(screen.getByDisplayValue(course.name)).toBeTruthy()
+    })
+
+    test("reports a course that is not in state", () => {
+        renderTeacherPage("/course/99/edit")
+
+        expect(screen.getByText("Course not found.")).toBeTruthy()
+        expect(screen.queryByDisplayValue(course.name)).toBeNull()
+    })
+})

--- a/public/src/components/teacher/EditCourse.tsx
+++ b/public/src/components/teacher/EditCourse.tsx
@@ -1,0 +1,19 @@
+import { useCourseID } from "../../hooks/useCourseID"
+import { useAppState } from "../../overmind"
+import CourseForm from "../forms/CourseForm"
+
+/** EditCourse lets a teacher edit the details of the course they are currently viewing.
+ *  It is reached from the teacher page at /course/:id/edit. */
+const EditCourse = () => {
+    const state = useAppState()
+    const courseID = useCourseID()
+    const course = state.courses.find(c => c.ID === courseID)
+
+    if (!course) {
+        return <p className="text-base-content/60">Course not found.</p>
+    }
+
+    return <CourseForm courseToEdit={course} />
+}
+
+export default EditCourse

--- a/public/src/pages/TeacherPage.tsx
+++ b/public/src/pages/TeacherPage.tsx
@@ -9,6 +9,7 @@ import StudentDetails from "../components/StudentDetails"
 import SubmissionGuide from "../components/student/SubmissionGuide"
 import Assignments from "../components/teacher/Assignments"
 import CourseLogs from "../components/teacher/CourseLogs"
+import EditCourse from "../components/teacher/EditCourse"
 import { Color, isManuallyGraded } from "../Helpers"
 import { useBackspaceNavigation } from "../hooks/useBackspaceNavigation"
 import { useCourseID } from "../hooks/useCourseID"
@@ -51,6 +52,12 @@ const TeacherPage = () => {
         buttonText: "Update Assignments",
         onclick: handleUpdateAssignments
     }
+    const editCourse = {
+        title: "Edit Course",
+        text: "Edit the course name, code, term, year, and slip days.",
+        buttonText: "Edit Course",
+        to: `${root}/edit`
+    }
     const review = { title: "Review Assignments", text: "Review assignments for students.", buttonText: "Review", to: `${root}/review` }
     const feedback = { title: "View Assignment Feedback", text: "View feedback provided by students on assignments.", buttonText: "Feedback", to: `${root}/feedback` }
     const logs = { title: "Course Logs", text: "View webhook, CI, and rebuild activity for this course.", buttonText: "Logs", to: `${root}/logs` }
@@ -65,6 +72,7 @@ const TeacherPage = () => {
                 <Card {...members} />
                 <Card {...assignments} />
                 <Card {...updateAssignments} />
+                <Card {...editCourse} />
                 <Card {...feedback} />
                 <Card {...logs} />
             </div>
@@ -78,6 +86,7 @@ const TeacherPage = () => {
                 <Route path="/feedback" element={<AssignmentFeedbackView />} />
                 <Route path="/feedback/:assignmentID" element={<AssignmentFeedbackView />} />
                 <Route path="/logs" element={<CourseLogs />} />
+                <Route path="/edit" element={<EditCourse />} />
                 <Route path="/submission-guide" element={<SubmissionGuide />} />
             </Routes>
         </>


### PR DESCRIPTION
Closes #1579

## What changed

- **Edit Course tile on the teacher page** — `TeacherPage` gets an "Edit Course" card next to "Update Course Assignments", routed to `/course/:id/edit`. Editing the course name, code, tag, year, and slip days no longer requires going through the profile menu to Admin → Edit Course, which non-admin teachers could not reach at all.
- **Teacher-side `EditCourse` component** — `components/teacher/EditCourse.tsx` resolves the active course from the route and hands it to the existing `CourseForm`, which already navigates back to the course page after saving. A course missing from state renders a short "Course not found." notice.
- **No backend change** — `UpdateCourse` was already permitted for teachers (`web/interceptor/access_control.go`). The admin page is untouched, since it still serves editing any course in the system.

## Testing

New `editCourse.test.tsx` mounts `TeacherPage` under `/course/:id/*` and checks that the tile is present, that clicking it opens the form, that the form is prefilled with the course's values, and that an unknown course id reports "Course not found.".

`npm run lint` and `npm run test` pass (21 files, 142 tests). `npx tsc --noEmit` reports one pre-existing error in `updateAssignments.test.tsx` that is unrelated to this change and also present on master.
